### PR TITLE
Fix shebangs and x bits on all scripts.

### DIFF
--- a/build-clang.sh
+++ b/build-clang.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 # Copyright (c) 2020, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
@@ -14,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-#!/bin/bash
 
 build_clang () {
   mkdir -p $BUILD_DIR/llvm

--- a/build-common.sh
+++ b/build-common.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 # Copyright (c) 2020, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0

--- a/build-compiler-rt.sh
+++ b/build-compiler-rt.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 # Copyright (c) 2020, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
@@ -14,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-#!/bin/bash
 
 build_compilerrt () {
   pushToCleanDir $BUILD_DIR/compiler-rt

--- a/build-misc.sh
+++ b/build-misc.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 # Copyright (c) 2020, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
@@ -14,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-#!/bin/bash
 
 build_misc () {
   [ "$#" -ne 0 ] && error "misc does not support variants."

--- a/build-newlib.sh
+++ b/build-newlib.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 # Copyright (c) 2020, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
@@ -14,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-#!/bin/bash
 
 build_newlib () {
   pushToCleanDir $BUILD_DIR/newlib

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 # Copyright (c) 2020, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
@@ -14,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-#!/bin/bash
 
 . $(dirname $BASH_SOURCE[0])/config.sh
 . $(dirname $BASH_SOURCE[0])/prepare-source.sh

--- a/config.sh
+++ b/config.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 # Copyright (c) 2020, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0

--- a/configure-toolchain.sh
+++ b/configure-toolchain.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 # Copyright (c) 2020, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
@@ -14,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-#!/bin/bash
 
 configure_toolchain() {
   # LLD does not have a good bare-metal builtin linker script (yet)

--- a/package-toolchain.sh
+++ b/package-toolchain.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 # Copyright (c) 2020, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
@@ -14,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-#!/bin/bash
 
 package_toolchain() {
   echo "$VERSION_STRING" > $TARGET_LLVM_PATH/VERSION.txt

--- a/prepare-source.sh
+++ b/prepare-source.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 # Copyright (c) 2020, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
@@ -14,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-#!/bin/bash
 
 prepare_source() {
   if [ ! -x $VENV_DIR/bin/repos.py ]; then

--- a/scripts/repos.py
+++ b/scripts/repos.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 #
 # Copyright (c) 2020, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
@@ -14,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-#!/usr/bin/env python3
 
 import argparse
 import yaml

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 #
 # Copyright (c) 2020, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
@@ -14,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-#!/usr/bin/env python3
 
 from setuptools import setup, find_packages
 setup(

--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 # Copyright (c) 2020, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
@@ -14,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-#!/bin/bash
 
 python3 -m venv venv
 


### PR DESCRIPTION
Many scripts had a #! line below the license text, where it has no
effect: the kernel only looks for #! at the very start of the file.
Without that, an executable script will only run successfully if the
shell it's launched from contains fallback processing of some kind for
when the exec system call fails.

Now all bash and Python scripts have an appropriate #! at the very
start, and all of them are consistently marked executable (a few were
missing that as well).