### PR TITLE
Change llvm master reference to main

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -30,7 +30,7 @@
   Modules:
     - Name: llvm.git
       URL:  https://github.com/llvm/llvm-project.git
-      Branch: master
+      Branch: main
       Revision: HEAD
       Patch: llvm-0.1.patch
     - Name: newlib.git


### PR DESCRIPTION
Upstream llvm renamed the master branch to main, this updates the
reference to match.