### PR TITLE
Check Python version before continuing in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -16,8 +16,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+set -e
 
-python3 -m venv venv
+# If your python3 is not just "python3" edit this
+PYTHON3=python3
+
+python_err="Error: Python3.5 or newer is required."
+if command -v "$PYTHON3" --version &> /dev/null
+then
+  pyv=$("$PYTHON3" -c 'from sys import version_info; print("".join(map(str, (version_info.major, version_info.minor))))')
+  if [ "$pyv" -lt 35 ]
+  then
+    echo "$python_err" && exit 1
+  fi
+else
+  echo "$python_err" && exit 1
+fi
+
+"$PYTHON3" -m venv venv
 
 . venv/bin/activate
 


### PR DESCRIPTION
We currently require 3.5, which happens to be the default for
Ubuntu Xenial:
python3/xenial,now 3.5.1-3 amd64 [installed,automatic]

Also add an intermeddiate var for the python3 command so
it can be something other than "python3".
This isn't so important now, but Python3 is EOL:
DEPRECATION: Python 3.5 reached the end of its life on September 13th,
2020.

So we'll probably move to 3.6 at some point. Meaning
people who install that from an extra repo won't have
it as "python3" but "python3.6". This saves them some hassle.

Ideally you'd be able to tell venv to use that new Python.
However when you use the "python -m venv" style it will only
use the python it's running on.