### PR TITLE
Change sysroot to DRIVER_PATH/lib/clang-runtimes

### DIFF
--- a/build-compiler-rt.sh
+++ b/build-compiler-rt.sh
@@ -35,20 +35,19 @@ build_compilerrt () {
     -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
     -DLLVM_CONFIG_PATH="$BUILD_DIR/llvm/bin/llvm-config" \
     -DCMAKE_C_COMPILER="$TARGET_LLVM_PATH/bin/clang" \
-    -DCMAKE_C_FLAGS="--sysroot $TARGET_LLVM_PATH/targets/$TARGET" \
     -DCMAKE_AR="$TARGET_LLVM_PATH/bin/llvm-ar" \
     -DCMAKE_NM="$TARGET_LLVM_PATH/bin/llvm-nm" \
     -DCMAKE_RANLIB="$TARGET_LLVM_PATH/bin/llvm-ranlib" \
     -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
-    -DCMAKE_INSTALL_PREFIX="$TARGET_LLVM_PATH/targets/$TARGET"
+    -DCMAKE_INSTALL_PREFIX="$TARGET_LLVM_PATH/lib/clang-runtimes/$TARGET"
 
   build
 
   install
 
   # Cleanup the no longer necessary installed dir
-  mv "$TARGET_LLVM_PATH/targets/$TARGET/lib/linux/"* "$TARGET_LLVM_PATH/targets/$TARGET/lib/"
-  rmdir "$TARGET_LLVM_PATH/targets/$TARGET/lib/linux"
+  mv "$TARGET_LLVM_PATH/lib/clang-runtimes/$TARGET/lib/linux/"* "$TARGET_LLVM_PATH/lib/clang-runtimes/$TARGET/lib/"
+  rmdir "$TARGET_LLVM_PATH/lib/clang-runtimes/$TARGET/lib/linux"
 
   popd
 }

--- a/build-newlib.sh
+++ b/build-newlib.sh
@@ -31,7 +31,7 @@ build_newlib () {
   OBJDUMP_FOR_TARGET="$TARGET_LLVM_PATH/bin/llvm-objdump" \
   $REPOS_DIR/newlib.git/configure --target=$TARGET \
     --prefix=$TARGET_LLVM_PATH \
-    --exec-prefix="$TARGET_LLVM_PATH/targets" \
+    --exec-prefix="$TARGET_LLVM_PATH/lib/clang-runtimes" \
     --enable-newlib-io-long-long \
     --enable-newlib-register-fini \
     --disable-newlib-supplied-syscalls \

--- a/configure-toolchain.sh
+++ b/configure-toolchain.sh
@@ -19,38 +19,35 @@
 
 configure_toolchain() {
   # LLD does not have a good bare-metal builtin linker script (yet)
-  cp "$SOURCE_ROOT_DIR/ldscript/base.ld" "$TARGET_LLVM_PATH/targets/${TARGET}/base.ld"
+  cp "$SOURCE_ROOT_DIR/ldscript/base.ld" "$TARGET_LLVM_PATH/lib/clang-runtimes/${TARGET}/base.ld"
 
   # write config files
 
   # no semihosting and no linker script
   cat > "$TARGET_LLVM_PATH/bin/${TARGET}_nosys.cfg" <<-EOF
 	--target=$TARGET
-	--sysroot=\$@/../targets/$TARGET
 	-fuse-ld=lld
-	-L\$@/../targets/$TARGET/lib
-	\$@/../targets/$TARGET/lib/crt0.o
+	-L\$@/../lib/clang-runtimes/$TARGET/lib
+	\$@/../lib/clang-runtimes/$TARGET/lib/crt0.o
 	-lnosys
 	EOF
 
   # semihosting and linker script provided
   cat > "$TARGET_LLVM_PATH/bin/${TARGET}_rdimon.cfg" <<-EOF
 	--target=$TARGET
-	--sysroot=\$@/../targets/$TARGET
 	-fuse-ld=lld
-	-Wl,-T\$@/../targets/$TARGET/base.ld
-	-L\$@/../targets/$TARGET/lib
-	\$@/../targets/$TARGET/lib/rdimon-crt0.o
+	-Wl,-T\$@/../lib/clang-runtimes/$TARGET/base.ld
+	-L\$@/../lib/clang-runtimes/$TARGET/lib
+	\$@/../lib/clang-runtimes/$TARGET/lib/rdimon-crt0.o
 	-lrdimon
 	EOF
 
   # semihosting, but no linker script, e.g. to use with QEMU Arm System emulator
   cat > "$TARGET_LLVM_PATH/bin/${TARGET}_rdimon_baremetal.cfg" <<-EOF
 	--target=$TARGET
-	--sysroot=\$@/../targets/$TARGET
 	-fuse-ld=lld
-	-L\$@/../targets/$TARGET/lib
-	\$@/../targets/$TARGET/lib/rdimon-crt0.o
+	-L\$@/../lib/clang-runtimes/$TARGET/lib
+	\$@/../lib/clang-runtimes/$TARGET/lib/rdimon-crt0.o
 	-lrdimon
 	EOF
 }


### PR DESCRIPTION
Upstream LLVM was changed in 275592e714130345a481a5cb889c89b73a98614f to
specify a default path for sysroot when targeting bare metal.

This default path is DRIVER_PATH/lib/clang-runtimes/TARGET.

In order to shorten our own modifications on top of LLVM, present in
patches/, this patch reorganises our installation directory's hierarchy.
Newlib and compilerrt now install to the default path, and --sysroot is
removed from our configuration files.

It would be ideal to remove our entire local patch altogether. However,
our configuration files still rely on our patch in order to specify
relative paths to crt0 and -L.