### PR TITLE
Update the LLVM tag for version 0.1 to llvmorg-12.0.0-rc3

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -19,7 +19,7 @@
   Modules:
     - Name: llvm.git
       URL:  https://github.com/llvm/llvm-project.git
-      Revision: llvmorg-11.0.0-rc4
+      Revision: llvmorg-12.0.0-rc3
       Patch: llvm-0.1.patch
     - Name: newlib.git
       URL:  https://github.com/mirror/newlib-cygwin.git


### PR DESCRIPTION
The build scripts have been updated to reflect the new sysroot used in
LLVM (see commit 91cee46ca7610c1de9084f8089300ec98c866965). This
change bumps the LLVM tag used in the 0.1 version of the toolchain to
llvmorg-12.0.0-rc3 to make it compatible with the build scripts.