### PR TITLE
Remove -L from configuration files

### DIFF
--- a/configure-toolchain.sh
+++ b/configure-toolchain.sh
@@ -27,7 +27,6 @@ configure_toolchain() {
   cat > "$TARGET_LLVM_PATH/bin/${TARGET}_nosys.cfg" <<-EOF
 	--target=$TARGET
 	-fuse-ld=lld
-	-L\$@/../lib/clang-runtimes/$TARGET/lib
 	\$@/../lib/clang-runtimes/$TARGET/lib/crt0.o
 	-lnosys
 	EOF
@@ -37,7 +36,6 @@ configure_toolchain() {
 	--target=$TARGET
 	-fuse-ld=lld
 	-Wl,-T\$@/../lib/clang-runtimes/$TARGET/base.ld
-	-L\$@/../lib/clang-runtimes/$TARGET/lib
 	\$@/../lib/clang-runtimes/$TARGET/lib/rdimon-crt0.o
 	-lrdimon
 	EOF
@@ -46,7 +44,6 @@ configure_toolchain() {
   cat > "$TARGET_LLVM_PATH/bin/${TARGET}_rdimon_baremetal.cfg" <<-EOF
 	--target=$TARGET
 	-fuse-ld=lld
-	-L\$@/../lib/clang-runtimes/$TARGET/lib
 	\$@/../lib/clang-runtimes/$TARGET/lib/rdimon-crt0.o
 	-lrdimon
 	EOF


### PR DESCRIPTION
After 73e1bdf4601d63b6bba47fe28e86b1e61401a461, sysroot defaults to
DRIVER_PATH/lib/clang-runtimes/TARGET_TRIPLE. This is also the library
path used to find the 'rdimon' library.

Currently we specify this library path to make 'rdimon' searchable. But
since the sysroot change, it shouldn't be necessary anymore.

Closes #9 