### PR TITLE
support for v7 and v8 targets

### DIFF
--- a/build-compiler-rt.sh
+++ b/build-compiler-rt.sh
@@ -35,6 +35,8 @@ build_compilerrt () {
     -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
     -DLLVM_CONFIG_PATH="$BUILD_DIR/llvm/bin/llvm-config" \
     -DCMAKE_C_COMPILER="$TARGET_LLVM_PATH/bin/clang" \
+    -DCMAKE_C_FLAGS="${FLAGS}" \
+    -DCMAKE_ASM_FLAGS="${FLAGS}" \
     -DCMAKE_AR="$TARGET_LLVM_PATH/bin/llvm-ar" \
     -DCMAKE_NM="$TARGET_LLVM_PATH/bin/llvm-nm" \
     -DCMAKE_RANLIB="$TARGET_LLVM_PATH/bin/llvm-ranlib" \

--- a/build-newlib.sh
+++ b/build-newlib.sh
@@ -20,8 +20,14 @@
 build_newlib () {
   pushToCleanDir $BUILD_DIR/newlib
 
+  NEWLIB_HW_FP="--disable-newlib-hw-fp"
+  if [ $NEWLIB_FP_SUPPORT = true ]; then
+      NEWLIB_HW_FP="--enable-newlib-hw-fp"
+  fi
+
   CC_FOR_TARGET="$TARGET_LLVM_PATH/bin/clang -target $TARGET -ffreestanding" \
   CXX_FOR_TARGET="$TARGET_LLVM_PATH/bin/clang++ -target $TARGET -ffreestanding" \
+  CFLAGS_FOR_TARGET="${FLAGS}" \
   AR_FOR_TARGET="$TARGET_LLVM_PATH/bin/llvm-ar" \
   NM_FOR_TARGET="$TARGET_LLVM_PATH/bin/llvm-nm" \
   AS_FOR_TARGET="$TARGET_LLVM_PATH/bin/llvm-as" \
@@ -37,7 +43,8 @@ build_newlib () {
     --disable-newlib-supplied-syscalls \
     --enable-newlib-io-c99-formats \
     --disable-nls \
-    --enable-lite-exit
+    --enable-lite-exit \
+    $NEWLIB_HW_FP
 
   make -j$NPROC
   make install

--- a/config.sh
+++ b/config.sh
@@ -28,12 +28,30 @@ readonly HOST_LLVM_PATH="${HOST_LLVM_PATH:-/usr/bin}"
 # How many CPUs to use for building the LLVM baremetal toolchain for Arm:
 readonly NPROC="${NPROC:-$(getconf _NPROCESSORS_ONLN)}"
 
-# Default triple of the toolchain:
-readonly TARGET=armv6m-none-eabi
+# The Arm sub-arch we want to use:
+readonly ARCH=${ARCH:-"armv6m"}
+
+# Architecture options:
+# (good overview: https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html)
+readonly ARCH_OPTIONS=${ARCH_OPTIONS:-""}
+
+# Float ABI
+readonly FLOAT_ABI=${FLOAT_ABI:-"soft"}
 
 #
 # No modification should be necessary beyond this point.
 #
+# Default triple of the toolchain:
+NEWLIB_FP_SUPPORT=false
+if [ $FLOAT_ABI != "soft" ]; then
+    NEWLIB_FP_SUPPORT=true
+fi
+
+readonly TARGET=$ARCH-none-eabi
+
+# CFLAGS/ASM_FLAGS
+readonly FLAGS="-mfloat-abi=${FLOAT_ABI} -march=${ARCH}${ARCH_OPTIONS}"
+
 readonly SOURCE_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Install directory of the LLVM baremetal toolchain for Arm:
 readonly INSTALL_ROOT_DIR=${INSTALL_ROOT_DIR:-$SOURCE_ROOT_DIR}

--- a/configure-toolchain.sh
+++ b/configure-toolchain.sh
@@ -26,6 +26,7 @@ configure_toolchain() {
   # no semihosting and no linker script
   cat > "$TARGET_LLVM_PATH/bin/${TARGET}_nosys.cfg" <<-EOF
 	--target=$TARGET
+    $FLAGS
 	-fuse-ld=lld
 	\$@/../lib/clang-runtimes/$TARGET/lib/crt0.o
 	-lnosys
@@ -34,6 +35,7 @@ configure_toolchain() {
   # semihosting and linker script provided
   cat > "$TARGET_LLVM_PATH/bin/${TARGET}_rdimon.cfg" <<-EOF
 	--target=$TARGET
+    $FLAGS
 	-fuse-ld=lld
 	-Wl,-T\$@/../lib/clang-runtimes/$TARGET/base.ld
 	\$@/../lib/clang-runtimes/$TARGET/lib/rdimon-crt0.o
@@ -43,6 +45,7 @@ configure_toolchain() {
   # semihosting, but no linker script, e.g. to use with QEMU Arm System emulator
   cat > "$TARGET_LLVM_PATH/bin/${TARGET}_rdimon_baremetal.cfg" <<-EOF
 	--target=$TARGET
+    $FLAGS
 	-fuse-ld=lld
 	\$@/../lib/clang-runtimes/$TARGET/lib/rdimon-crt0.o
 	-lrdimon

--- a/patches/llvm-0.1.patch
+++ b/patches/llvm-0.1.patch
@@ -1,5 +1,40 @@
+diff --git a/compiler-rt/cmake/builtin-config-ix.cmake b/compiler-rt/cmake/builtin-config-ix.cmake
+index ad3b98799c5c..49b7ce6dd068 100644
+--- a/compiler-rt/cmake/builtin-config-ix.cmake
++++ b/compiler-rt/cmake/builtin-config-ix.cmake
+@@ -37,7 +37,7 @@ asm(\"cas w0, w1, [x2]\");
+ ")
+ 
+ set(ARM64 aarch64)
+-set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k)
++set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k armv8m.main armv8.1m.main)
+ set(HEXAGON hexagon)
+ set(X86 i386)
+ set(X86_64 x86_64)
+diff --git a/compiler-rt/lib/builtins/CMakeLists.txt b/compiler-rt/lib/builtins/CMakeLists.txt
+index 73b6bead8424..7a58fb712ca0 100644
+--- a/compiler-rt/lib/builtins/CMakeLists.txt
++++ b/compiler-rt/lib/builtins/CMakeLists.txt
+@@ -559,6 +559,8 @@ set(arm64e_SOURCES ${aarch64_SOURCES})
+ set(armv6m_SOURCES ${thumb1_SOURCES})
+ set(armv7m_SOURCES ${arm_SOURCES})
+ set(armv7em_SOURCES ${arm_SOURCES})
++set(armv8m.main_SOURCES ${arm_SOURCES})
++set(armv8.1m.main_SOURCES ${arm_SOURCES})
+ 
+ # hexagon arch
+ set(hexagon_SOURCES
+@@ -694,7 +696,7 @@ else ()
+   foreach (arch ${BUILTIN_SUPPORTED_ARCH})
+     if (CAN_TARGET_${arch})
+       # For ARM archs, exclude any VFP builtins if VFP is not supported
+-      if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7m|armv7em)$")
++      if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7m|armv7em|armv8m.main|armv8.1m.main)$")
+         string(REPLACE ";" " " _TARGET_${arch}_CFLAGS "${TARGET_${arch}_CFLAGS}")
+         check_compile_definition(__ARM_FP "${CMAKE_C_FLAGS} ${_TARGET_${arch}_CFLAGS}" COMPILER_RT_HAS_${arch}_VFP)
+         if(NOT COMPILER_RT_HAS_${arch}_VFP)
 diff --git a/llvm/lib/Support/CommandLine.cpp b/llvm/lib/Support/CommandLine.cpp
-index aa7e79652..ec55d9aca 100644
+index e2f014d1815b..52f78a5e239e 100644
 --- a/llvm/lib/Support/CommandLine.cpp
 +++ b/llvm/lib/Support/CommandLine.cpp
 @@ -1112,12 +1112,57 @@ static llvm::Error ExpandResponseFile(

--- a/patches/newlib-0.1.patch
+++ b/patches/newlib-0.1.patch
@@ -1,5 +1,30 @@
+diff --git a/configure b/configure
+index 5db527014..05b82fbfc 100755
+--- a/configure
++++ b/configure
+@@ -6791,6 +6791,20 @@ if test "x$CFLAGS_FOR_TARGET" = x; then
+   fi
+ fi
+ 
++# Check whether --enable-newlib_hw_fp was given.
++if test "${enable_newlib_hw_fp+set}" = set; then :
++  enableval=$enable_newlib_hw_fp; case "${enableval}" in
++   yes) newlib_hw_fp=true ;;
++   no)  newlib_hw_fp=false ;;
++   *) as_fn_error $? "bad value ${enableval} for --enable-newlib-hw-fp" "$LINENO" 5 ;;
++ esac
++else
++  newlib_hw_fp=false
++fi
++
++if test $newlib_hw_fp = true; then
++    CFLAGS_FOR_TARGET="$CFLAGS_FOR_TARGET -DNEWLIB_HW_FP"
++fi
+ 
+ if test "x$CXXFLAGS_FOR_TARGET" = x; then
+   if test "x${is_cross_compiler}" = xyes; then
 diff --git a/libgloss/arm/crt0.S b/libgloss/arm/crt0.S
-index 8490bde..8b85b28 100644
+index 8490bde2f..8b85b28f4 100644
 --- a/libgloss/arm/crt0.S
 +++ b/libgloss/arm/crt0.S
 @@ -565,7 +565,7 @@ change_back:
@@ -12,7 +37,7 @@ index 8490bde..8b85b28 100644
  #ifdef ARM_RDI_MONITOR
  	.word	HeapBase
 diff --git a/libgloss/arm/linux-crt0.c b/libgloss/arm/linux-crt0.c
-index 6b2d62a..000a2c7 100644
+index 6b2d62a9b..000a2c728 100644
 --- a/libgloss/arm/linux-crt0.c
 +++ b/libgloss/arm/linux-crt0.c
 @@ -29,7 +29,7 @@ asm("\n"
@@ -25,7 +50,7 @@ index 6b2d62a..000a2c7 100644
  #endif
  {
 diff --git a/libgloss/arm/syscalls.c b/libgloss/arm/syscalls.c
-index fc394f9..0b3287d 100644
+index fc394f94b..0b3287df4 100644
 --- a/libgloss/arm/syscalls.c
 +++ b/libgloss/arm/syscalls.c
 @@ -180,7 +180,7 @@ initialise_monitor_handles (void)
@@ -55,7 +80,7 @@ index fc394f9..0b3287d 100644
  	 : "i" (SWI_Open),"r"(name)
  	 : "r0","r1");
 diff --git a/libgloss/arm/trap.S b/libgloss/arm/trap.S
-index 845ad01..2056c2a 100644
+index 845ad0173..2056c2adf 100644
 --- a/libgloss/arm/trap.S
 +++ b/libgloss/arm/trap.S
 @@ -5,7 +5,7 @@
@@ -68,7 +93,7 @@ index 845ad01..2056c2a 100644
          .global __rt_stkovf_split_small
  
 diff --git a/libgloss/libnosys/configure b/libgloss/libnosys/configure
-index 7c23c7a..2fc5841 100755
+index 7c23c7a0a..2fc584169 100755
 --- a/libgloss/libnosys/configure
 +++ b/libgloss/libnosys/configure
 @@ -2058,7 +2058,7 @@ case "${target}" in
@@ -81,7 +106,7 @@ index 7c23c7a..2fc5841 100755
  
  
 diff --git a/newlib/libc/sys/arm/crt0.S b/newlib/libc/sys/arm/crt0.S
-index 5e677a2..6faf740 100644
+index 5e677a23c..6faf74096 100644
 --- a/newlib/libc/sys/arm/crt0.S
 +++ b/newlib/libc/sys/arm/crt0.S
 @@ -556,7 +556,7 @@ change_back:
@@ -94,7 +119,7 @@ index 5e677a2..6faf740 100644
  #ifdef ARM_RDI_MONITOR
  	.word	HeapBase
 diff --git a/newlib/libc/sys/arm/trap.S b/newlib/libc/sys/arm/trap.S
-index 681b3db..8a49f39 100644
+index 681b3dbe0..8a49f39f3 100644
 --- a/newlib/libc/sys/arm/trap.S
 +++ b/newlib/libc/sys/arm/trap.S
 @@ -4,7 +4,7 @@
@@ -106,3 +131,172 @@ index 681b3db..8a49f39 100644
          .global __rt_stkovf_split_big
          .global __rt_stkovf_split_small
  
+diff --git a/newlib/libm/machine/arm/e_sqrt.c b/newlib/libm/machine/arm/e_sqrt.c
+index 6f3eb8301..40c5d1193 100644
+--- a/newlib/libm/machine/arm/e_sqrt.c
++++ b/newlib/libm/machine/arm/e_sqrt.c
+@@ -24,7 +24,7 @@
+  * SUCH DAMAGE.
+  */
+ 
+-#if (__ARM_FP & 0x8) && !defined(__SOFTFP__)
++#if (__ARM_FP & 0x8) && !defined(__SOFTFP__) && defined NEWLIB_HW_FP
+ #include <math.h>
+ 
+ double
+diff --git a/newlib/libm/machine/arm/ef_sqrt.c b/newlib/libm/machine/arm/ef_sqrt.c
+index 3a1ba6cb4..a77547af5 100644
+--- a/newlib/libm/machine/arm/ef_sqrt.c
++++ b/newlib/libm/machine/arm/ef_sqrt.c
+@@ -24,7 +24,7 @@
+  * SUCH DAMAGE.
+  */
+ 
+-#if (__ARM_FP & 0x4) && !defined(__SOFTFP__)
++#if (__ARM_FP & 0x4) && !defined(__SOFTFP__) && defined NEWLIB_HW_FP
+ #include <math.h>
+ 
+ float
+diff --git a/newlib/libm/machine/arm/s_ceil.c b/newlib/libm/machine/arm/s_ceil.c
+index ed1e85a3c..891708975 100644
+--- a/newlib/libm/machine/arm/s_ceil.c
++++ b/newlib/libm/machine/arm/s_ceil.c
+@@ -24,7 +24,7 @@
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ 
+-#if __ARM_ARCH >= 8 && (__ARM_FP & 0x8) && !defined (__SOFTFP__)
++#if __ARM_ARCH >= 8 && (__ARM_FP & 0x8) && !defined (__SOFTFP__) && defined NEWLIB_HW_FP
+ #include <math.h>
+ 
+ double
+diff --git a/newlib/libm/machine/arm/s_floor.c b/newlib/libm/machine/arm/s_floor.c
+index d25132f0d..82843a4f1 100644
+--- a/newlib/libm/machine/arm/s_floor.c
++++ b/newlib/libm/machine/arm/s_floor.c
+@@ -24,7 +24,7 @@
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ 
+-#if __ARM_ARCH >= 8 && (__ARM_FP & 0x8) && !defined (__SOFTFP__)
++#if __ARM_ARCH >= 8 && (__ARM_FP & 0x8) && !defined (__SOFTFP__) && defined NEWLIB_HW_FP
+ #include <math.h>
+ 
+ double
+diff --git a/newlib/libm/machine/arm/s_nearbyint.c b/newlib/libm/machine/arm/s_nearbyint.c
+index 7ead69b12..ce26bb9a0 100644
+--- a/newlib/libm/machine/arm/s_nearbyint.c
++++ b/newlib/libm/machine/arm/s_nearbyint.c
+@@ -24,7 +24,7 @@
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ 
+-#if __ARM_ARCH >= 8 && (__ARM_FP & 0x8) && !defined (__SOFTFP__)
++#if __ARM_ARCH >= 8 && (__ARM_FP & 0x8) && !defined (__SOFTFP__) && defined NEWLIB_HW_FP
+ #include <math.h>
+ 
+ double
+diff --git a/newlib/libm/machine/arm/s_rint.c b/newlib/libm/machine/arm/s_rint.c
+index 02c102250..20ad71a87 100644
+--- a/newlib/libm/machine/arm/s_rint.c
++++ b/newlib/libm/machine/arm/s_rint.c
+@@ -24,7 +24,7 @@
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ 
+-#if __ARM_ARCH >= 8 && (__ARM_FP & 0x8) && !defined (__SOFTFP__)
++#if __ARM_ARCH >= 8 && (__ARM_FP & 0x8) && !defined (__SOFTFP__) && defined NEWLIB_HW_FP
+ #include <math.h>
+ 
+ double
+diff --git a/newlib/libm/machine/arm/s_trunc.c b/newlib/libm/machine/arm/s_trunc.c
+index 6fb696814..a277331b4 100644
+--- a/newlib/libm/machine/arm/s_trunc.c
++++ b/newlib/libm/machine/arm/s_trunc.c
+@@ -24,7 +24,7 @@
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ 
+-#if __ARM_ARCH >= 8 && (__ARM_FP & 0x8) && !defined (__SOFTFP__)
++#if __ARM_ARCH >= 8 && (__ARM_FP & 0x8) && !defined (__SOFTFP__) && defined NEWLIB_HW_FP
+ #include <math.h>
+ 
+ double
+diff --git a/newlib/libm/machine/arm/sf_ceil.c b/newlib/libm/machine/arm/sf_ceil.c
+index b6efbff0b..27aeb6168 100644
+--- a/newlib/libm/machine/arm/sf_ceil.c
++++ b/newlib/libm/machine/arm/sf_ceil.c
+@@ -24,7 +24,7 @@
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ 
+-#if __ARM_ARCH >= 8 && !defined (__SOFTFP__)
++#if __ARM_ARCH >= 8 && !defined (__SOFTFP__) && defined NEWLIB_HW_FP
+ #include <math.h>
+ 
+ float
+diff --git a/newlib/libm/machine/arm/sf_floor.c b/newlib/libm/machine/arm/sf_floor.c
+index 7bc95808c..8d9b1c087 100644
+--- a/newlib/libm/machine/arm/sf_floor.c
++++ b/newlib/libm/machine/arm/sf_floor.c
+@@ -24,7 +24,7 @@
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ 
+-#if __ARM_ARCH >= 8 && !defined (__SOFTFP__)
++#if __ARM_ARCH >= 8 && !defined (__SOFTFP__) && defined NEWLIB_HW_FP
+ #include <math.h>
+ 
+ float
+diff --git a/newlib/libm/machine/arm/sf_nearbyint.c b/newlib/libm/machine/arm/sf_nearbyint.c
+index c70d84442..bb2a4a442 100644
+--- a/newlib/libm/machine/arm/sf_nearbyint.c
++++ b/newlib/libm/machine/arm/sf_nearbyint.c
+@@ -24,7 +24,7 @@
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ 
+-#if __ARM_ARCH >= 8 && !defined (__SOFTFP__)
++#if __ARM_ARCH >= 8 && !defined (__SOFTFP__) && defined NEWLIB_HW_FP
+ #include <math.h>
+ 
+ float
+diff --git a/newlib/libm/machine/arm/sf_rint.c b/newlib/libm/machine/arm/sf_rint.c
+index d9c383a7e..c9b0b1b12 100644
+--- a/newlib/libm/machine/arm/sf_rint.c
++++ b/newlib/libm/machine/arm/sf_rint.c
+@@ -24,7 +24,7 @@
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ 
+-#if __ARM_ARCH >= 8 && !defined (__SOFTFP__)
++#if __ARM_ARCH >= 8 && !defined (__SOFTFP__) && defined NEWLIB_HW_FP
+ #include <math.h>
+ 
+ float
+diff --git a/newlib/libm/machine/arm/sf_round.c b/newlib/libm/machine/arm/sf_round.c
+index 232fc0848..b647b0d42 100644
+--- a/newlib/libm/machine/arm/sf_round.c
++++ b/newlib/libm/machine/arm/sf_round.c
+@@ -24,7 +24,7 @@
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ 
+-#if __ARM_ARCH >= 8 && !defined (__SOFTFP__)
++#if __ARM_ARCH >= 8 && !defined (__SOFTFP__) && defined NEWLIB_HW_FP
+ #include <math.h>
+ 
+ float
+diff --git a/newlib/libm/machine/arm/sf_trunc.c b/newlib/libm/machine/arm/sf_trunc.c
+index 64e4aeb9a..c0e5e9049 100644
+--- a/newlib/libm/machine/arm/sf_trunc.c
++++ b/newlib/libm/machine/arm/sf_trunc.c
+@@ -24,7 +24,7 @@
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ 
+-#if __ARM_ARCH >= 8 && !defined (__SOFTFP__)
++#if __ARM_ARCH >= 8 && !defined (__SOFTFP__) && defined NEWLIB_HW_FP
+ #include <math.h>
+ 
+ float


### PR DESCRIPTION
I've added a number of armv7 and armv8 target configurations to the buildscript. To account for more than one options, I've added an environment variable, `LIBRARY_SPEC`, that can be populated with the following values:

    armv8.1m.main_hard_fp_mve
    armv8.1m.main_hard_fp_nomve
    armv8.1m.main_soft_nofp_nomve
    armv8m.main_hard_fp
    armv8m.main_soft_nofp
    armv7em_hard_fpv4_sp_d16
    armv7em_hard_fpv5_d16
    armv7em_soft_nofp
    armv7m_soft_nofp
    armv6m_soft_nofp

hard and soft stand for fp linkage

They all build correctly with newlib and compiler-rt, and seem to do the right thing with regards to compiler-rt floating-point files to choose from: do we support double float, just single float, or neither of these.

At least two things I'd like input on:
- are we happy with these options for v7 and v8
- are we happy with the naming of these options

I've roughly based the options on which explicit cores LLVM supports.

Currently the generated files for these are dispatched to folders that are only differentiated by arch name. So if we build armv8.1m.main with soft and hard fp in succession, the one will overwrite the other. This week we removed being able to specify non-default folders for newlib and compiler-rt and the clang config file, so I thought not to put extra effort into this. I guess this will be resolved when properly implementing multilib support.