### PR TITLE
Add special case for Clang in deciding floating-point endianness

### DIFF
--- a/patches/newlib-0.1.patch
+++ b/patches/newlib-0.1.patch
@@ -300,3 +300,23 @@ index 64e4aeb9a..c0e5e9049 100644
  #include <math.h>
  
  float
+diff --git a/newlib/libc/include/machine/ieeefp.h b/newlib/libc/include/machine/ieeefp.h
+index aa8a1903b..19be99ecc 100644
+--- a/newlib/libc/include/machine/ieeefp.h
++++ b/newlib/libc/include/machine/ieeefp.h
+@@ -72,7 +72,14 @@
+    byte ordering was big or little endian depending upon the target.
+    Modern floating-point formats are naturally ordered; in this case
+    __VFP_FP__ will be defined, even if soft-float.  */
+-#ifdef __VFP_FP__
++/* Clang does not target any ARM architecture that uses the FPA architecture,
++   where double-precision floating-point values are big-endian at word level
++   and have a target-dependent endianness at byte level. Moreover, contrary
++   to gcc, Clang can leave __VFP_FP__ undefined even in modern architectures.
++   This is the case when the FPU is disabled or not present. Hence, in clang,
++   the endianness at word level is always the same as the one at byte level.
++*/
++#if defined(__VFP_FP__) || defined(__clang__)
+ # ifdef __ARMEL__
+ #  define __IEEE_LITTLE_ENDIAN
+ # else


### PR DESCRIPTION
newlib's ieeefp.h determines floating-point endianness by checking the
\_\_VFP_FP__ macro. If this macro is defined, then newlib assumes that the
target architecture uses the VFP architecture for FPs. In this sort of
arch, IEEE FP values have their word-level endianness the same as their
byte-level endianness.

For example, a double-precision FP value of 1 would be represented in
memory like this (in little-endian ARM targets):

<- lowest addr    highest addr ->
1  0  0  0 | 0  0  0  0

Otherwise, i.e. if \_\_VFP_FP__ macro is undefined, then newlib assumes the
FPA architecture for FPs instead. In this case, IEEE FP values are
always big-endian at word level, while at the byte-level they follow the
target architecture's endianness.

For example, the same double-precision FP value of 1 would be
represented like this (in little-endian ARM targets):

<- lowest addr    highest addr ->
0  0  0  0 | 1  0  0  0

The problem is: \_\_VFP_FP__ cannot be used to determine that if using
Clang. In this compiler, the property:

\_\_VFP_FP__ is defined if and only if the VFP architecture is in use.

is false. That's because Clang only defines \_\_VFP_FP__ if an FPU is
enabled, which is not the case when, for instance, soft-float ABI is in
place.

This patch adds another preprocessor check to ieefp.h. Now, if the
compiler used is Clang, newlib can assume the endianness defined by VFP.