### PR TITLE
Port build scripts from bash to Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .*.swp
+.idea
 repos*/
 build*/
 venv/
 *LLVMEmbeddedToolchainForArm*
+__pycache__

--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ The resulting binaries are covered under their respective open source licenses, 
 
 Contributions are accepted under Apache-2.0. Only submit contributions where you have authored all of the code.
 
+### Coding style
+
+The project uses the [PEP 8](https://www.python.org/dev/peps/pep-0008) style
+guide for all Python scripts. The scripts also must pass pylint checks. Use the
+following command to check the scripts before submitting a pull request
+(assuming that pylint is installed):
+
+```
+pylint --rcfile=scripts/.pylintrc scripts
+```
+
 ## How to provide feedback/report an issue
 
 Please raise an issue via  https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/issues
@@ -47,7 +58,7 @@ The LLVM Embedded Toolchain for Arm has been built and tested on Linux/Ubuntu 18
 Build requirements
 * clang 6.0.0 or above
 * cmake 3.13.4 or above
-* python version 3.5 or above and python3-venv
+* python version 3.6 or above and python3-venv
 * git
 * make
 

--- a/scripts/.pylintrc
+++ b/scripts/.pylintrc
@@ -1,3 +1,18 @@
+# Copyright (c) 2021, Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [MASTER]
 
 # A comma-separated list of package or module names from where C extensions may
@@ -431,7 +446,7 @@ logging-modules=logging
 [FORMAT]
 
 # Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
-expected-line-ending-format=
+expected-line-ending-format=LF
 
 # Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (c) 2021, Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+import logging
+import multiprocessing
+import os
+import sys
+import shutil
+from typing import Callable
+
+import cfg_files
+import check
+import config
+from config import Action, CheckoutMode, Config
+import make
+import repos
+import tarball
+import util
+
+
+def parse_args_to_config() -> Config:
+    """Parse command line arguments and create a Config object based on them."""
+    cwd = os.path.abspath(os.getcwd())
+    parser = argparse.ArgumentParser(
+        description='Build LLVM Embedded Toolchain for Arm',
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument('-v', '--verbose', help='log more information',
+                        action='store_true')
+    parser.add_argument('-r', '--revision', metavar='R', default='HEAD',
+                        help='revision to build (default: HEAD)')
+    variant_names = sorted(config.LIBRARY_SPECS.keys())
+    parser.add_argument('--variants', metavar='VAR', nargs='+',
+                        choices=variant_names + ['all'], default=['all'],
+                        help='library variants to build, a space-separated '
+                             'list of: {}, or "all" to build all variants. '
+                             'Default: all'.format(', '.join(variant_names)))
+    parser.add_argument('--source-dir', type=str, metavar='PATH', default=cwd,
+                        help='location of the LLVM Embedded '
+                             'Toolchain for Arm source checkout (default: .)')
+    parser.add_argument('--build-dir', type=str,  metavar='PATH',
+                        help='directory to use for build '
+                             '(default: ./build-<revision>)')
+    parser.add_argument('--install-dir', type=str, metavar='PATH',
+                        default=cwd,
+                        help='directory to install the toolchain to '
+                             '(default: .)')
+    parser.add_argument('--package-dir', type=str, metavar='PATH',
+                        default=cwd,
+                        help='directory to store the packaged toolchain in '
+                             '(default: .)')
+    parser.add_argument('--repositories-dir', type=str, metavar='PATH',
+                        help='path to directory containing LLVM and newlib '
+                             'repositories (default: ./repos-<revision>)')
+    parser.add_argument('--host-toolchain-dir', type=str, metavar='PATH',
+                        default='/bin',
+                        help='path to the directory containing the host Clang '
+                             'compiler binary (v. {} or '
+                             'later)'.format(check.MIN_CLANG_VERSION))
+    parser.add_argument('--skip-checks',
+                        help='skip checks of build prerequisites',
+                        action='store_true')
+    parser.add_argument('--use-ninja',
+                        help='use Ninja instead of GNU Make when building '
+                             'LLVM components',
+                        action='store_true')
+    parser.add_argument('--use-ccache',
+                        help='use CCache when building Clang (requires '
+                             'CCache v. {} or '
+                             'later)'.format(check.MIN_CCACHE_VERSION),
+                        action='store_true')
+    parser.add_argument('--checkout-mode', type=str,
+                        choices=util.values_of_enum(CheckoutMode),
+                        default=CheckoutMode.REUSE.value,
+                        help='specifies behaviour of repository checkout ('
+                             'default: reuse):\n'
+                             '  force - delete existing repositories, perform '
+                             'a checkout and apply patches\n'
+                             '  patch - check out only if one of repositories '
+                             'is missing, otherwise perform a hard reset and '
+                             'apply patches\n'
+                             '  reuse - check out and apply patches only if '
+                             'one of repositories is missing, otherwise use '
+                             'the checkout as-is')
+    cpu_count = multiprocessing.cpu_count()
+    parser.add_argument('-j', '--parallel', type=int, metavar='N',
+                        help='number of parallel threads to use in Make/Ninja '
+                        '(default: number of CPUs, {})'.format(cpu_count),
+                        default=cpu_count)
+    parser.add_argument('actions',  nargs=argparse.REMAINDER,
+                        choices=util.values_of_enum(Action),
+                        help='actions to perform, a list of:\n'
+                             '  prepare - check out and patch sources\n'
+                             '  clang - build and install Clang, lld and other '
+                             'binary utilities\n'
+                             '  newlib - build and install newlib for each '
+                             'target\n'
+                             '  compiler-rt - build and install compiler-rt '
+                             'for each target\n'
+                             '  configure - write target configuration files\n'
+                             '  package - create tarball\n'
+                             '  all - perform all of the above\n'
+                             'Default: all')
+    args = parser.parse_args()
+    return config.Config(args)
+
+
+def configure_logging() -> None:
+    """Set logging format and level threshold for the default logger."""
+    log_format = '%(levelname)s: %(message)s'
+    logging.basicConfig(format=log_format, level=logging.INFO)
+
+
+def prepare_repositories(cfg: config.Config,
+                         toolchain_ver: repos.LLVMBMTC) -> None:
+    """Prepare source repositories according to the selected --checkout-mode
+       option and the current state of repositories.
+    """
+    patches_dir = os.path.join(cfg.source_dir, 'patches')
+
+    # Determine which git action to perform
+    do_remove_and_clone = False
+    do_reset_and_patch = False
+    repo_dirs = [cfg.llvm_repo_dir, cfg.newlib_repo_dir]
+    if cfg.checkout_mode == CheckoutMode.FORCE:
+        # In the 'force' mode always remove existing checkouts, then clone the
+        # repositories.
+        do_remove_and_clone = True
+    elif cfg.checkout_mode == CheckoutMode.PATCH:
+        # In the 'patch' mode perform check out only when any of the
+        # repositories is not checked out, otherwise reset and patch existing
+        # repositories.
+        if all(os.path.exists(repo_dir) for repo_dir in repo_dirs):
+            do_reset_and_patch = True
+        else:
+            do_remove_and_clone = True
+    elif cfg.checkout_mode == CheckoutMode.REUSE:
+        # In the 'reuse' mode perform check out only when any of the
+        # repositories is not checked out, otherwise do nothing
+        if all(os.path.exists(repo_dir) for repo_dir in repo_dirs):
+            logging.info('Using existing checked out repositories')
+        else:
+            do_remove_and_clone = True
+    else:
+        # We should never get here
+        raise NotImplementedError('Unexpected checkout '
+                                  'mode {}'.format(cfg.checkout_mode))
+
+    # Perform selected action
+    ret = 0
+    if do_remove_and_clone:
+        if os.path.exists(cfg.repos_dir):
+            logging.info('Deleting checked out repositories')
+            shutil.rmtree(cfg.repos_dir)
+        logging.info('Cloning repositories and applying patches')
+        ret = repos.clone_repositories(cfg.repos_dir, toolchain_ver,
+                                       patches_dir)
+    elif do_reset_and_patch:
+        logging.info('Resetting repositories and applying patches')
+        ret = repos.patch_repositories(cfg.repos_dir, toolchain_ver,
+                                       patches_dir)
+    if ret != 0:
+        raise util.ToolchainBuildError
+
+
+def run_or_skip(cfg: Config, action: Action, func: Callable[[], None],
+                desc: str) -> None:
+    """Run func if action is specified in cfg.actions, otherwise log that
+       the step was skipped (only in verbose logs).
+    """
+    if action in cfg.actions:
+        func()
+    elif cfg.verbose:
+        logging.info('Skipping %s (not requested by the user)', desc)
+
+
+def build_all(cfg: Config) -> None:
+    """Build and install all components of the toolchain: Clang and LLVM
+       binutils, newlib, compiler_rt, configuration files.
+    """
+    builder = make.ToolchainBuild(cfg)
+    run_or_skip(cfg, Action.CLANG, builder.build_clang, 'Clang build')
+    if any(action in cfg.actions for action in
+           [Action.NEWLIB, Action.COMPILER_RT, Action.CONFIGURE]):
+        logging.info('Building library variants and/or configurations: %s',
+                     ', '.join(v.name for v in cfg.variants))
+
+    for lib_spec in cfg.variants:
+        run_or_skip(cfg, Action.NEWLIB,
+                    lambda lspec=lib_spec: builder.build_newlib(lspec),
+                    'newlib build for {}'.format(lib_spec.name))
+        run_or_skip(cfg, Action.COMPILER_RT,
+                    lambda lspec=lib_spec: builder.build_compiler_rt(lspec),
+                    'compiler-rt build for {}'.format(lib_spec.name))
+        run_or_skip(cfg, Action.CONFIGURE,
+                    lambda lspec=lib_spec: cfg_files.configure_target(cfg,
+                                                                      lspec),
+                    'generation of config files for {}'.format(lib_spec.name))
+
+
+def main() -> int:
+    configure_logging()
+    cfg = parse_args_to_config()
+    versions = repos.get_all_versions(os.path.join(cfg.source_dir,
+                                                   'versions.yml'))
+    if cfg.revision not in versions:
+        logging.error('Invalid revision %s', cfg.revision)
+        return 1
+
+    try:
+        if not cfg.skip_checks:
+            check.check_prerequisites(cfg)
+        run_or_skip(cfg, Action.PREPARE,
+                    lambda: prepare_repositories(cfg, versions[cfg.revision]),
+                    'source code checkout')
+        build_all(cfg)
+
+        def do_package():
+            tarball.write_version_file(cfg)
+            tarball.package_toolchain(cfg)
+        run_or_skip(cfg, Action.PACKAGE, do_package, 'packaging')
+    except util.ToolchainBuildError:
+        # By this time the error must have already been logged
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/cfg_files.py
+++ b/scripts/cfg_files.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2021, Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import shutil
+
+import config
+import util
+
+
+def copy_base_ld_script(cfg: config.Config, target: str) -> None:
+    """Copy the linker script to target-specific directory."""
+    base_ld_src = os.path.join(cfg.source_dir, 'ldscript', 'base.ld')
+    base_ld_dest = os.path.join(cfg.target_llvm_rt_dir, target, 'base.ld')
+    if cfg.verbose:
+        logging.info('Copying %s to %s', base_ld_src, base_ld_dest)
+    shutil.copy(base_ld_src, base_ld_dest)
+
+
+def write_cfg_files(cfg: config.Config, lib_spec: config.LibrarySpec) -> None:
+    """Create target-specific configuration files for a single library
+       variant."""
+    target = lib_spec.target
+    base_cfg_lines = [
+        '--target={}'.format(target),
+        lib_spec.flags,
+        '-fuse-ld=lld',
+    ]
+
+    # No semihosting and no linker script
+    nosys_lines = base_cfg_lines + [
+        '$@/../lib/clang-runtimes/{}/lib/crt0.o'.format(target),
+        '-lnosys',
+    ]
+    # Semihosting and linker script provided
+    rdimon_lines = base_cfg_lines + [
+        '-Wl,-T$@/../lib/clang-runtimes/{}/base.ld'.format(target),
+        '$@/../lib/clang-runtimes/{}/lib/rdimon-crt0.o'.format(target),
+        '-lrdimon',
+    ]
+    # Semihosting, but no linker script, e.g. to use with QEMU Arm System
+    # emulator
+    rdimon_baremetal_lines = base_cfg_lines + [
+        '$@/../lib/clang-runtimes/{}/lib/rdimon-crt0.o'.format(target),
+        '-lrdimon',
+    ]
+
+    cfg_files = [
+        ('nosys', nosys_lines),
+        ('rdimon', rdimon_lines),
+        ('rdimon_baremetal', rdimon_baremetal_lines),
+    ]
+
+    for name, lines in cfg_files:
+        file_name = '{}_{}.cfg'.format(target, name)
+        file_path = os.path.join(cfg.target_llvm_bin_dir, file_name)
+        if cfg.verbose:
+            logging.info('Writing %s', file_path)
+        util.write_lines(lines, file_path)
+
+
+def configure_target(cfg: config.Config, lib_spec: config.LibrarySpec) -> None:
+    """Create linker script and configuration files for a single library
+       variant."""
+    logging.info('Creating toolchain configuration files')
+    copy_base_ld_script(cfg, lib_spec.target)
+    write_cfg_files(cfg, lib_spec)

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2021, Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import logging
+import os
+import shutil
+import util
+
+import config
+import execution
+
+
+@functools.total_ordering
+class Version:
+    """Version number tuple."""
+    def __init__(self, *args):
+        self.ver = tuple(args)
+
+    def __str__(self) -> str:
+        """Convert version tuple into a dot-delimited version string."""
+        return '.'.join(str(v) for v in self.ver)
+
+    def __eq__(self, other):
+        if not isinstance(other, Version):
+            raise NotImplementedError
+        return self.ver == other.ver
+
+    def __lt__(self, other):
+        if not isinstance(other, Version):
+            raise NotImplementedError
+        return self.ver < other.ver
+
+
+# Minimum versions required by the LLVM Project
+MIN_CLANG_VERSION = Version(6, 0, 0)
+MIN_CMAKE_VERSION = Version(3, 14, 4)
+MIN_MAKE_VERSION = Version(3, 79)
+# If we use CCache, it must be recent enough. Older versions do weird things
+# with Clang.
+MIN_CCACHE_VERSION = Version(3, 2, 5)
+
+
+def _str_to_ver(version_str: str) -> Version:
+    """Covert version string to a tuple of numbers."""
+    return Version(*[int(v) for v in version_str.split('.')])
+
+
+def _print_version_error(program: str, path: str, actual_ver: Version,
+                         required_ver: Version) -> None:
+    """Print an error message saying the a given program version is not recent
+       enough.
+    """
+    if path is not None:
+        full_program = '{} {}'.format(program, path)
+    else:
+        full_program = program
+    logging.error('Your %s version %s is not recent enough. '
+                  'Please upgrade it to at least %s', full_program,
+                  actual_ver, required_ver)
+
+
+def _check_host_compiler(cfg: config.Config) -> bool:
+    """Check availability and version of the host compiler (Clang or GCC
+       depending on build configuration).
+    """
+    def check_compiler_executable(executable_path):
+        if not os.path.exists(executable_path):
+            logging.error('The specified host compiler path %s is '
+                          'invalid: %s not found', cfg.host_compiler_path,
+                          executable_path)
+            return False
+        return True
+
+    if not check_compiler_executable(cfg.host_c_compiler):
+        return False
+    if not check_compiler_executable(cfg.host_cpp_compiler):
+        return False
+
+    args = [cfg.host_c_compiler, '--version']
+    ver_line = execution.run_stdout(args)[0]
+    assert 'clang version' in ver_line
+    ver_str = ver_line.split(' ')[-1]
+    # Remove distribution suffix (if any) and convert to a tuple
+    ver = _str_to_ver(ver_str.split('-')[0])
+    if ver < MIN_CLANG_VERSION:
+        _print_version_error('Clang', cfg.host_c_compiler, ver,
+                             MIN_CLANG_VERSION)
+        return False
+    if cfg.verbose:
+        logging.info('Using host compiler: Clang version %s', ver_str)
+    return True
+
+
+def _check_availability(bin_name: str, name: str = None) -> bool:
+    """Check availability of a tool."""
+    if shutil.which(bin_name) is None:
+        if name is None:
+            name = bin_name
+        print('{} not found.'.format(name))
+        return False
+    return True
+
+
+def _check_tool(cfg: config.Config, bin_name: str, name: str,
+                min_version: Version) -> bool:
+    """Check availability and version of a tool."""
+    _check_availability(bin_name, name)
+    bin_path = shutil.which(bin_name)
+    ver_line = execution.run_stdout([bin_name, '--version'])[0]
+    assert '{} version'.format(bin_name) in ver_line
+    ver = _str_to_ver(ver_line.split(' ')[-1])
+    if ver < min_version:
+        _print_version_error(name, bin_path, ver, min_version)
+        return False
+    if cfg.verbose:
+        logging.info('Found %s version %s', name, ver)
+    return True
+
+
+def check_prerequisites(cfg: config.Config) -> None:
+    """Check availability and versions of all required prerequisite software."""
+    is_ok = True
+    is_ok = is_ok and _check_host_compiler(cfg)
+    is_ok = is_ok and _check_tool(cfg, 'cmake', 'CMake', MIN_CMAKE_VERSION)
+    if cfg.use_ccache:
+        is_ok = is_ok and _check_tool(cfg, 'ccache', 'CCache',
+                                      MIN_CCACHE_VERSION)
+    if cfg.use_ninja:
+        is_ok = is_ok and _check_availability('ninja', 'Ninja')
+    for tool in ['git', 'make', 'find', 'sort', 'tar', 'sed']:
+        is_ok = is_ok and _check_availability(tool)
+    if not is_ok:
+        logging.error('Prerequisites check failed')
+        raise util.ToolchainBuildError

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2021, Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import datetime
+import enum
+import os
+
+
+@enum.unique
+class FloatABI(enum.Enum):
+    """Enumeration for the -mfloat-abi compiler option values."""
+    SOFT_FP = 'soft'
+    HARD_FP = 'hard'
+
+
+@enum.unique
+class CheckoutMode(enum.Enum):
+    """Enumeration for the --checkout-mode options for the build script. See
+       build.py:parse_args_to_config() for description of each mode."""
+    FORCE = 'force'
+    PATCH = 'patch'
+    REUSE = 'reuse'
+
+
+@enum.unique
+class Action(enum.Enum):
+    """Enumerations for the positional command line arguments. See
+       build.py:parse_args_to_config() for description
+    """
+    PREPARE = 'prepare'
+    CLANG = 'clang'
+    NEWLIB = 'newlib'
+    COMPILER_RT = 'compiler-rt'
+    CONFIGURE = 'configure'
+    PACKAGE = 'package'
+    ALL = 'all'
+
+
+class LibrarySpec:
+    """Configuration for a single runtime library variant."""
+    def __init__(self, arch: str, float_abi: FloatABI, name_suffix: str,
+                 arch_options: str, other_flags: str = '',
+                 newlib_fp_support: bool = None):
+        # pylint: disable=too-many-arguments
+        if float_abi == FloatABI.SOFT_FP:
+            assert not newlib_fp_support
+            self.newlib_fp_support = False
+        else:
+            self.newlib_fp_support = (newlib_fp_support
+                                      if newlib_fp_support is not None
+                                      else True)
+        self.arch = arch
+        self.float_abi = float_abi
+        self.arch_options = arch_options
+        self.other_flags = other_flags
+        self.newlib_fp_support = newlib_fp_support
+        self.name = '{}_{}_{}'.format(arch,  float_abi.value, name_suffix)
+
+    @property
+    def target(self):
+        """Target triple"""
+        return self.arch + '-none-eabi'
+
+    @property
+    def flags(self):
+        """Compiler and assembler flags."""
+        res = '-mfloat-abi={} -march={}{}'.format(self.float_abi.value,
+                                                  self.arch, self.arch_options)
+        if self.other_flags:
+            res += ' ' + self.other_flags
+        return res
+
+
+def _make_library_specs():
+    """Create a dict of LibrarySpec-s for each library variant."""
+    hard = FloatABI.HARD_FP
+    soft = FloatABI.SOFT_FP
+    lib_specs = [
+        LibrarySpec('armv8.1m.main', hard, 'fp', '+fp'),
+        LibrarySpec('armv8.1m.main', hard, 'nofp_mve', '+nofp+mve',
+                    newlib_fp_support=False),
+        LibrarySpec('armv8.1m.main', soft, 'nofp_nomve', '+nofp+nomve'),
+        LibrarySpec('armv8m.main', hard, 'fp', '+fp'),
+        LibrarySpec('armv8m.main', soft, 'nofp', '+nofp'),
+        LibrarySpec('armv7em', hard, 'fpv4_sp_d16', '', '-mfpu=fpv4-sp-d16'),
+        LibrarySpec('armv7em', hard, 'fpv5_d16', '', '-mfpu=fpv5-d16'),
+        LibrarySpec('armv7em', soft, 'nofp', '', '-mfpu=none'),
+        LibrarySpec('armv7m', soft, 'nofp', '+nofp'),
+        LibrarySpec('armv6m', soft, 'nofp', '')
+    ]
+    return {lib_spec.name: lib_spec for lib_spec in lib_specs}
+
+
+LIBRARY_SPECS = _make_library_specs()
+ARCH_ORDER = ['armv6m', 'armv7m', 'armv7em', 'armv8m.main', 'armv8.1m.main']
+
+
+def _assign_dir(arg, default, rev):
+    if arg is not None:
+        res = arg
+    else:
+        dir_name = '{}-{}'.format(default, rev)
+        res = os.path.join(os.getcwd(), dir_name)
+    return os.path.abspath(res)
+
+
+class Config:  # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-few-public-methods
+    """Configuration for the whole build process"""
+
+    def _fill_args(self, args: argparse.Namespace):
+        if 'all' in args.variants:
+            self.variants = LIBRARY_SPECS
+        else:
+            self.variants = [LIBRARY_SPECS[v] for v in
+                             sorted(set(args.variants))]
+
+        if not args.actions or Action.ALL.value in args.actions:
+            self.actions = set(action for action in Action
+                               if action != Action.ALL)
+        else:
+            self.actions = set(Action(act_str) for act_str in args.actions)
+
+        # Default value for the -target option: use the minimum architecture
+        # version among the ones listed in self.variants
+        archs = set(v.arch for v in self.variants)
+        min_arch = min(archs, key=ARCH_ORDER.index)
+        self.default_target = '{}-none-eabi'.format(min_arch)
+
+        rev = args.revision
+        self.revision = rev
+        self.source_dir = os.path.abspath(args.source_dir)
+        self.repos_dir = _assign_dir(args.repositories_dir, 'repos', rev)
+        self.build_dir = _assign_dir(args.build_dir, 'build', rev)
+        self.install_dir = os.path.abspath(args.install_dir)
+        self.package_dir = os.path.abspath(args.package_dir)
+        self.host_compiler_path = os.path.abspath(args.host_toolchain_dir)
+        self.checkout_mode = CheckoutMode(args.checkout_mode)
+
+        self.use_ninja = args.use_ninja
+        self.use_ccache = args.use_ccache
+        self.skip_checks = args.skip_checks
+        self.verbose = args.verbose
+        self.num_threads = args.parallel
+
+    def _fill_inferred(self):
+        """Fill in additional fields that can be inferred from the
+           configuration, but are still useful for convenience."""
+        self.llvm_repo_dir = os.path.join(self.repos_dir, 'llvm.git')
+        self.newlib_repo_dir = os.path.join(self.repos_dir, 'newlib.git')
+        self.host_c_compiler = os.path.join(self.host_compiler_path, 'clang')
+        self.host_cpp_compiler = \
+            os.path.join(self.host_compiler_path, 'clang++')
+        self.cmake_generator = 'Ninja' if self.use_ninja else 'Unix Makefiles'
+        self.release_mode = self.revision != 'HEAD'
+        if self.release_mode:
+            version_suffix = '-' + self.revision
+            self.version_string = self.revision
+        else:
+            version_suffix = ''
+            now = datetime.datetime.now()
+            self.version_string = now.strftime('%Y-%m-%d-%H:%M:%S')
+        product_name = 'LLVMEmbeddedToolchainForArm'
+        self.tarball_base_name = product_name + version_suffix
+        self.target_llvm_dir = os.path.join(
+            self.install_dir,
+            '{}-{}'.format(product_name, self.revision))
+        self.target_llvm_bin_dir = os.path.join(self.target_llvm_dir, 'bin')
+        self.target_llvm_rt_dir = os.path.join(self.target_llvm_dir,  'lib',
+                                               'clang-runtimes')
+
+    def __init__(self, args: argparse.Namespace):
+        self._fill_args(args)
+        self._fill_inferred()

--- a/scripts/execution.py
+++ b/scripts/execution.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2021, Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import shlex
+import sys
+import subprocess
+from typing import List, Mapping, Sequence
+
+
+class Runner:
+    """Class for running external process, the class stores the last current
+       working directory (for logging).
+    """
+
+    def __init__(self, verbose: bool = False):
+        self.verbose = verbose
+        self.last_cwd = None
+
+    def reset_cwd(self):
+        """Reset current working directory. So that an 'Entering directory'
+           message is logged next time.
+        """
+        self.last_cwd = None
+
+    def run(self, args: Sequence[str], cwd: str = None,
+            env: Mapping[str, str] = None) -> None:
+        """Run a specified program with arguments, optionally change current
+           directory and change the environment. Note: env does not replace
+           parent environment, but amends it for the subprocess."""
+        if env is not None:
+            env_strings = ['{}={} '.format(key, shlex.quote(env[key]))
+                           for key in sorted(env.keys())]
+        else:
+            env_strings = []
+        if cwd is not None:
+            if cwd != self.last_cwd:
+                logging.info('Entering directory "%s"', cwd)
+            self.last_cwd = cwd
+        logging.info('Executing: "%s%s"', ''.join(env_strings),
+                     ' '.join(shlex.quote(arg) for arg in args))
+
+        if env is not None:
+            env = dict(os.environ, **env)
+        stdout = sys.stdout if self.verbose else subprocess.DEVNULL
+        stderr = sys.stderr if self.verbose else subprocess.PIPE
+        try:
+            subprocess.run(args, stdout=stdout, stderr=stderr, check=True,
+                           cwd=cwd, env=env)
+        except subprocess.CalledProcessError as ex:
+            lines = ex.stderr.decode('utf-8', errors='replace').split('\n')
+            if len(lines) > 30:
+                lines = ['...'] + lines[-30:]
+            logging.error('Command failed with return code %d, stderr:\n%s',
+                          ex.returncode, '\n'.join(lines))
+            raise
+
+
+def run(args: Sequence[str], cwd: str = None, env: Mapping[str, str] = None,
+        verbose: bool = False) -> None:
+    """A wrapper for the Runner class which invokes run once."""
+    runner = Runner(verbose)
+    runner.run(args, cwd, env)
+
+
+def run_stdout(args: Sequence[str]) -> List[str]:
+    """Run a process and return its stdout split into lines."""
+    res = subprocess.run(args, stdout=subprocess.PIPE,
+                         stderr=sys.stderr,
+                         check=True)
+    lines = res.stdout.decode('utf-8').strip().split('\n')
+    return [line.strip() for line in lines]

--- a/scripts/make.py
+++ b/scripts/make.py
@@ -1,0 +1,259 @@
+#  Copyright (c) 2021, Arm Limited and affiliates.
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+import os
+from typing import Mapping
+import subprocess
+import shutil
+
+import execution
+import config
+import util
+
+
+class ToolchainBuild:
+    """Class for configuring/building/installing all toolchain components: LLVM,
+       newlib, compiler_rt.
+    """
+    def __init__(self, cfg: config.Config):
+        self.cfg = cfg
+        self.runner = execution.Runner(cfg.verbose)
+
+    def _cmake_configure(self, source_dir: str, build_dir: str,
+                         defs: Mapping[str, str],
+                         env: Mapping[str, str] = None) -> None:
+        """Run the "configure" stage of CMake."""
+        cmake_args = [
+            'cmake',
+            '-G', self.cfg.cmake_generator,
+            source_dir,
+        ]
+        for def_name in sorted(defs.keys()):
+            cmake_args.append('-D{}={}'.format(def_name, defs[def_name]))
+        try:
+            self.runner.run(cmake_args, cwd=build_dir, env=env)
+        except subprocess.CalledProcessError as ex:
+            raise util.ToolchainBuildError from ex
+
+    def _cmake_build(self, build_dir: str, target: str = None) -> None:
+        """Run a build tool (GNU Make or Ninja) using 'cmake --build'."""
+        args = [
+            'cmake',
+            '--build', build_dir,
+            '--parallel', str(self.cfg.num_threads),
+        ]
+        if target is not None:
+            args += ['--target', target]
+        try:
+            self.runner.run(args)
+        except subprocess.CalledProcessError as ex:
+            raise util.ToolchainBuildError from ex
+
+    def _write_llvm_index(self) -> None:
+        """Record the list of files and links installed by Clang."""
+        flist = []
+        install_dir = self.cfg.target_llvm_dir
+        for root, _, files in os.walk(install_dir):
+            for fname in files:
+                full_path = os.path.abspath(os.path.join(root, fname))
+                if os.path.isfile(full_path) or os.path.islink(full_path):
+                    flist.append(os.path.relpath(full_path, install_dir))
+        util.write_lines(sorted(flist),
+                         os.path.join(self.cfg.build_dir, 'llvm-index.txt'))
+
+    def build_clang(self) -> None:
+        """Build and install Clang, LLD and LLVM binutils-like tools."""
+        self.runner.reset_cwd()
+        cfg = self.cfg
+        llvm_build_dir = os.path.join(cfg.build_dir, 'llvm')
+        llvm_source_dir = os.path.join(cfg.llvm_repo_dir, 'llvm')
+        if not os.path.exists(llvm_build_dir):
+            os.makedirs(llvm_build_dir)
+
+        projects = [
+            'clang',
+            'lld',
+        ]
+
+        dist_comps = [
+            'clang-format',
+            'clang-resource-headers',
+            'clang',
+            'dsymutil',
+            'lld',
+            'llvm-ar',
+            'llvm-config',
+            'llvm-cov',
+            'llvm-cxxfilt',
+            'llvm-dwarfdump',
+            'llvm-nm',
+            'llvm-objdump',
+            'llvm-profdata',
+            'llvm-ranlib',
+            'llvm-readelf',
+            'llvm-readobj',
+            'llvm-size',
+            'llvm-strip',
+            'llvm-symbolizer',
+            'LTO',
+        ]
+
+        cmake_defs = {
+            'LLVM_TARGETS_TO_BUILD:STRING': 'ARM',
+            'LLVM_DEFAULT_TARGET_TRIPLE:STRING': cfg.default_target,
+            'CMAKE_BUILD_TYPE:STRING': 'Release',
+            'CMAKE_INSTALL_PREFIX:STRING': cfg.target_llvm_dir,
+            'LLVM_ENABLE_PROJECTS:STRING': ';'.join(projects),
+            'LLVM_DISTRIBUTION_COMPONENTS:STRING': ';'.join(dist_comps),
+        }
+        if cfg.use_ccache:
+            cmake_defs['LLVM_CCACHE_BUILD:BOOL'] = 'ON'
+
+        cmake_env = {
+            'CC': cfg.host_c_compiler,
+            'CXX': cfg.host_cpp_compiler,
+        }
+
+        if os.path.exists(os.path.join(llvm_build_dir, 'CMakeCache.txt')):
+            logging.info('LLVM CMakeCache.txt already exists, '
+                         'skipping CMake configuration for LLVM')
+        else:
+            logging.info('Configuring LLVM projects: %s', ', '.join(projects))
+            self._cmake_configure(llvm_source_dir, llvm_build_dir, cmake_defs,
+                                  cmake_env)
+        logging.info('Building and installing LLVM components: %s',
+                     ', '.join(dist_comps))
+        self._cmake_build(llvm_build_dir,
+                          target='install-distribution-stripped')
+        # Record the list of files and links installed by clang
+        if cfg.release_mode:
+            self._write_llvm_index()
+
+    def build_compiler_rt(self, lib_spec: config.LibrarySpec) -> None:
+        """Build and install a single variant of compiler-rt."""
+        self.runner.reset_cwd()
+        cfg = self.cfg
+        target = lib_spec.target
+        join = os.path.join
+        rt_source_dir = join(cfg.llvm_repo_dir, 'compiler-rt')
+        rt_build_dir = join(cfg.build_dir, 'compiler-rt', lib_spec.name)
+        rt_install_dir = join(cfg.target_llvm_rt_dir, target)
+        if not os.path.exists(rt_build_dir):
+            os.makedirs(rt_build_dir)
+        cmake_defs = {
+            'CMAKE_BUILD_TYPE:STRING': 'Release',
+            'COMPILER_RT_BUILD_SANITIZERS:BOOL': 'OFF',
+            'COMPILER_RT_BUILD_XRAY:BOOL': 'OFF',
+            'COMPILER_RT_BUILD_LIBFUZZER:BOOL': 'OFF',
+            'COMPILER_RT_BUILD_PROFILE:BOOL': 'OFF',
+            'COMPILER_RT_BAREMETAL_BUILD:BOOL': 'ON',
+            'CMAKE_TRY_COMPILE_TARGET_TYPE': 'STATIC_LIBRARY',
+            'CMAKE_C_COMPILER_TARGET': target,
+            'CMAKE_C_FLAGS': lib_spec.flags,
+            'CMAKE_ASM_COMPILER_TARGET': target,
+            'CMAKE_ASM_FLAGS': lib_spec.flags,
+            'COMPILER_RT_DEFAULT_TARGET_ONLY': 'ON',
+            'LLVM_CONFIG_PATH': join(cfg.build_dir, 'llvm', 'bin',
+                                     'llvm-config'),
+            'CMAKE_C_COMPILER': join(cfg.target_llvm_bin_dir, 'clang'),
+            'CMAKE_AR': join(cfg.target_llvm_bin_dir, 'llvm-ar'),
+            'CMAKE_NM': join(cfg.target_llvm_bin_dir, 'llvm-nm'),
+            'CMAKE_RANLIB': join(cfg.target_llvm_bin_dir, 'llvm-ranlib'),
+            'CMAKE_EXE_LINKER_FLAGS': '-fuse-ld=lld',
+            'CMAKE_INSTALL_PREFIX': rt_install_dir,
+        }
+        if os.path.exists(os.path.join(rt_build_dir, 'CMakeCache.txt')):
+            logging.info('%s compiler-rt CMakeCache.txt already exists, '
+                         'skipping CMake configuration', lib_spec.name)
+        else:
+            logging.info('Configuring compiler-rt for %s', lib_spec.name)
+            self._cmake_configure(rt_source_dir, rt_build_dir, cmake_defs)
+        logging.info('Building and installing compiler-rt for %s',
+                     lib_spec.name)
+        self._cmake_build(rt_build_dir)
+        self._cmake_build(rt_build_dir, target='install')
+
+        # Move the libraries from lib/linux to lib
+        lib_dir = join(rt_install_dir, 'lib')
+        linux_dir = join(lib_dir, 'linux')
+        for name in os.listdir(linux_dir):
+            assert name != 'linux'
+            src = join(linux_dir, name)
+            dest = join(lib_dir, name)
+            if cfg.verbose:
+                logging.info('Moving %s to %s', src, dest)
+            shutil.move(src, dest)
+        if cfg.verbose:
+            logging.info('Removing %s', linux_dir)
+        shutil.rmtree(linux_dir)
+
+    def build_newlib(self, lib_spec: config.LibrarySpec) -> None:
+        """Build and install a single variant of newlib."""
+        self.runner.reset_cwd()
+        cfg = self.cfg
+        join = os.path.join
+        newlib_build_dir = join(cfg.build_dir, 'newlib', lib_spec.name)
+        if not os.path.exists(newlib_build_dir):
+            os.makedirs(newlib_build_dir)
+        newlib_src_dir = cfg.newlib_repo_dir
+
+        def compiler_str(bin_name: str) -> str:
+            bin_path = join(cfg.target_llvm_bin_dir, bin_name)
+            return '{} -target {} -ffreestanding'.format(bin_path,
+                                                         lib_spec.target)
+
+        config_env = {
+            'CC_FOR_TARGET': compiler_str('clang'),
+            'CXX_FOR_TARGET': compiler_str('clang++'),
+            'CFLAGS_FOR_TARGET': lib_spec.flags,
+        }
+        for tool in ['ar', 'nm', 'as', 'ranlib', 'strip', 'readelf', 'objdump']:
+            var_name = '{}_FOR_TARGET'.format(tool.upper())
+            tool_path = join(cfg.target_llvm_bin_dir, 'llvm-{}'.format(tool))
+            config_env[var_name] = tool_path
+
+        newlib_hw_fp = ('--enable-newlib-hw-fp' if lib_spec.newlib_fp_support
+                        else '--disable-newlib-hw-fp')
+        configure_args = [
+            join(newlib_src_dir, 'configure'),
+            '--target={}'.format(lib_spec.target),
+            '--prefix={}'.format(cfg.target_llvm_dir),
+            '--exec-prefix={}'.format(cfg.target_llvm_rt_dir),
+            '--enable-newlib-io-long-long',
+            '--enable-newlib-register-fini',
+            '--disable-newlib-supplied-syscalls',
+            '--enable-newlib-io-c99-formats',
+            '--disable-nls',
+            '--enable-lite-exit',
+            newlib_hw_fp,
+        ]
+        make_args = [
+            'make',
+            '-j{}'.format(cfg.num_threads),
+        ]
+        try:
+            if os.path.exists(join(newlib_build_dir, 'Makefile')):
+                logging.info('%s newlib Makefile already exists, '
+                             'skipping the "configure" stage', lib_spec.name)
+            else:
+                logging.info('Configuring newlib for %s', lib_spec.name)
+                self.runner.run(configure_args, cwd=newlib_build_dir,
+                                env=config_env)
+            logging.info('Building and installing newlib for %s', lib_spec.name)
+            self.runner.run(make_args, cwd=newlib_build_dir)
+            self.runner.run(['make', 'install'], cwd=newlib_build_dir)
+        except subprocess.SubprocessError as ex:
+            raise util.ToolchainBuildError from ex

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (c) 2020, Arm Limited and affiliates.
+# Copyright (c) 2020-2021, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,13 @@ setup(name="LLVMEmbeddedToolchainForArm",
       version="0.1",
       packages=find_packages(),
       scripts=[
+          'build.py',
+          'check.py',
+          'cfg_files.py',
+          'config.py',
+          'execution.py',
           'repos.py',
+          'tarball.py',
+          'util.py'
       ],
       install_requires=['pyyaml', 'gitpython'])

--- a/scripts/tarball.py
+++ b/scripts/tarball.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2021, Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import subprocess
+
+import config
+import execution
+import util
+
+
+def write_version_file(cfg: config.Config) -> None:
+    """Create VERSION.txt in the install directory."""
+    dest = os.path.join(cfg.target_llvm_dir, 'VERSION.txt')
+    if cfg.verbose:
+        logging.info('Writing "%s" to %s', cfg.version_string, dest)
+    util.write_lines([cfg.version_string], dest)
+
+
+def package_toolchain(cfg: config.Config) -> None:
+    """Create a tarball with a newly built toolchain."""
+    if not os.path.exists(cfg.package_dir):
+        os.makedirs(cfg.package_dir)
+    dest_bin = os.path.join(cfg.package_dir, cfg.tarball_base_name + '.tar.gz')
+    logging.info('Creating package %s', dest_bin)
+    args = [
+        'tar',
+        '--create',
+        '--file={}'.format(dest_bin),
+        '-a',
+        '--owner=root',
+        '--group=root',
+    ]
+    if cfg.verbose:
+        args.append('--verbose')
+    args.append(os.path.relpath(cfg.target_llvm_dir, cfg.install_dir))
+    try:
+        execution.run(args, cwd=cfg.install_dir, verbose=cfg.verbose)
+    except subprocess.CalledProcessError as ex:
+        logging.error('Failed to create %s', dest_bin)
+        raise util.ToolchainBuildError from ex

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -1,0 +1,33 @@
+#  Copyright (c) 2021, Arm Limited and affiliates.
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Any, Sequence, List
+
+
+class ToolchainBuildError(RuntimeError):
+    """A single error for all failures related to toolchain build: this includes
+       git errors, errors that occur during CMake, configure, Ninja and Make
+       runs, as well as packaging."""
+
+
+def values_of_enum(enum_class: Sequence[Any]) -> List[str]:
+    """Create a list of strings from Enum values."""
+    return [str(enumerator.value) for enumerator in enum_class]
+
+
+def write_lines(lines: Sequence[str], dest: str) -> None:
+    """Write a list of lines to destination file."""
+    with open(dest, 'wt') as out_f:
+        out_f.writelines(line + '\n' for line in lines)

--- a/setup.sh
+++ b/setup.sh
@@ -21,11 +21,11 @@ set -e
 # If your python3 is not just "python3" edit this
 PYTHON3=python3
 
-python_err="Error: Python3.5 or newer is required."
+python_err="Error: Python 3.6 or newer is required."
 if command -v "$PYTHON3" --version &> /dev/null
 then
   pyv=$("$PYTHON3" -c 'from sys import version_info; print("".join(map(str, (version_info.major, version_info.minor))))')
-  if [ "$pyv" -lt 35 ]
+  if [ "$pyv" -lt 36 ]
   then
     echo "$python_err" && exit 1
   fi


### PR DESCRIPTION
This patch ports all functionality implemented as shell scripts to
Python with the following exceptions:
- build-misc.sh is not ported because it is unused
- source tarballs are not built because they need some rework: the
  Python scripts support out-of-tree build, whereas the current source
  tarball generation method relies on LLVM and newlib repositories
  being checked out in the main source tree
- lldb is not built because it is not being installed

The new scripts add several important new features:
- Control over locations of all directories related to the build
  process: source, external repositories, build directory, install
  directory, target directory for tarballs (out-of-tree build)
- Incremental builds
- Ability to specify a list of targets to build libraries for
- Two levels of logging verbosity

The existing shell scripts and the new Python scripts give identical
results (modulo whitespace differences in .cfg files) when used with
equivalent sets of command line options and environment variables.