### PR TITLE
Miscellaneous bug fixes in Python build scripts

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -70,10 +70,11 @@ def parse_args_to_config() -> Config:
                         help='path to directory containing LLVM and newlib '
                              'repositories (default: ./repos-<revision>)')
     parser.add_argument('--host-toolchain-dir', type=str, metavar='PATH',
-                        default='/bin',
+                        default='/usr/bin',
                         help='path to the directory containing the host Clang '
-                             'compiler binary (v. {} or '
-                             'later)'.format(check.MIN_CLANG_VERSION))
+                             'compiler binary v. {} or later '
+                             '(default: /usr/bin)'.format(
+                                 check.MIN_CLANG_VERSION))
     parser.add_argument('--skip-checks',
                         help='skip checks of build prerequisites',
                         action='store_true')

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -91,8 +91,8 @@ def _check_host_compiler(cfg: config.Config) -> bool:
 
     args = [cfg.host_c_compiler, '--version']
     ver_line = execution.run_stdout(args)[0]
-    assert 'clang version' in ver_line
-    ver_str = ver_line.split(' ')[-1]
+    assert ver_line.startswith('clang version ')
+    ver_str = ver_line.split(' ')[2]
     # Remove distribution suffix (if any) and convert to a tuple
     ver = _str_to_ver(ver_str.split('-')[0])
     if ver < MIN_CLANG_VERSION:

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -123,10 +123,10 @@ class Config:  # pylint: disable=too-many-instance-attributes
 
     def _fill_args(self, args: argparse.Namespace):
         if 'all' in args.variants:
-            self.variants = LIBRARY_SPECS
+            variant_names = LIBRARY_SPECS.keys()
         else:
-            self.variants = [LIBRARY_SPECS[v] for v in
-                             sorted(set(args.variants))]
+            variant_names = set(args.variants)
+        self.variants = [LIBRARY_SPECS[v] for v in sorted(variant_names)]
 
         if not args.actions or Action.ALL.value in args.actions:
             self.actions = set(action for action in Action


### PR DESCRIPTION
1. Fix handling of --variants all (the default value)
2. Correctly parse Clang versions which include git tag, e.g.
   "clang version 6.0.0-1ubuntu2 (tags/RELEASE_600/final)"
3. Use /usr/bin as the default host toolchain directory, this allows
   building on both Ubuntu 18.04 and 20.04 without having to specify
   the toolchain directory manually.