### PR TITLE
Prerequisite patches for cross-compilation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,20 +56,22 @@ The LLVM Embedded Toolchain for Arm has been built and tested on Linux/Ubuntu 18
 ### Build the toolchain
 
 Build requirements
-* clang 6.0.0 or above
-* cmake 3.13.4 or above
-* python version 3.6 or above and python3-venv
-* git
-* make
+* a suitable compiler toolchain:
+  * Clang 6.0.0 or above, or
+  * GCC 5.1.0 or above
+* CMake 3.13.4 or above
+* Python version 3.6 or above and python3-venv
+* Git
+* GNU Make
 
 0. Install typically missing packages. There might be others depending on your setup.
 ```
-sudo apt-get install clang # If the clang version installed by the package manager is older than 6.0.0, download a recent version from https://releases.llvm.org or build from source
+sudo apt-get install clang # If the Clang version installed by the package manager is older than 6.0.0, download a recent version from https://releases.llvm.org or build from source
 sudo apt-get install python3
 sudo apt-get install python3-venv
 sudo apt-get install git
 sudo apt-get install make
-sudo apt-get install cmake # If the cmake version installed by the package manager is older than 3.13.4, download a recent version from https://cmake.org/download and add it to PATH
+sudo apt-get install cmake # If the CMake version installed by the package manager is older than 3.13.4, download a recent version from https://cmake.org/download and add it to PATH
 ```
 
 1. Install the build scripts in a python virtual env (in directory ``venv``):
@@ -95,11 +97,12 @@ $ repos.py list
 0.1
 HEAD
 ```
-* ``--host-toolchain-dir`` the directory from Step 0 that ``clang`` resides in. Default is ``/usr/bin``.
+* ``--host-toolchain`` the toolchain type. Either ``clang`` or ``gcc``. Default is ``clang``
+* ``--host-toolchain-dir`` the directory from Step 0 that ``clang`` or ``gcc`` resides in. Default is ``/usr/bin``.
 * ``--install-dir`` the LLVM Embedded Toolchain for Arm installation directory. Default is the current directory.
 
 The build script can optionally take advantage of some tools to speed up the
-build. Currently these tools are ``ccache``, and ``ninja``.
+build. Currently, these tools are ``ccache``, and ``ninja``.
 ```
 $ build.py --use-ccache --use-ninja
 ```

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -69,12 +69,16 @@ def parse_args_to_config() -> Config:
     parser.add_argument('--repositories-dir', type=str, metavar='PATH',
                         help='path to directory containing LLVM and newlib '
                              'repositories (default: ./repos-<revision>)')
+    default_toolchain = config.ToolchainKind.CLANG.value
+    parser.add_argument('--host-toolchain', type=str,
+                        choices=util.values_of_enum(config.ToolchainKind),
+                        default=default_toolchain,
+                        help='host toolchain type '
+                             '(default: {})'.format(default_toolchain))
     parser.add_argument('--host-toolchain-dir', type=str, metavar='PATH',
                         default='/usr/bin',
-                        help='path to the directory containing the host Clang '
-                             'compiler binary v. {} or later '
-                             '(default: /usr/bin)'.format(
-                                 check.MIN_CLANG_VERSION))
+                        help='path to the directory containing the host '
+                             'compiler binary (default: /usr/bin)')
     parser.add_argument('--skip-checks',
                         help='skip checks of build prerequisites',
                         action='store_true')

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -28,7 +28,7 @@ from typing import Callable
 import cfg_files
 import check
 import config
-from config import Action, CheckoutMode, Config
+from config import Action, BuildMode, CheckoutMode, Config
 import make
 import repos
 import tarball
@@ -104,6 +104,14 @@ def parse_args_to_config() -> Config:
                              '  reuse - check out and apply patches only if '
                              'one of repositories is missing, otherwise use '
                              'the checkout as-is')
+    parser.add_argument('--build-mode', type=str,
+                        choices=util.values_of_enum(BuildMode),
+                        default=BuildMode.INCREMENTAL.value,
+                        help='specifies behaviour of incremental builds '
+                             '(default: incremental):\n'
+                             '  rebuild - build everything from scratch\n'
+                             '  reconfigure - always rerun cmake/configure\n'
+                             '  incremental - avoid rerunning cmake/configure')
     cpu_count = multiprocessing.cpu_count()
     parser.add_argument('-j', '--parallel', type=int, metavar='N',
                         help='number of parallel threads to use in Make/Ninja '

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -51,6 +51,13 @@ class ToolchainKind(enum.Enum):
         return obj
 
 
+class BuildMode(enum.Enum):
+    """Enumerator for the --rebuild-mode option."""
+    REBUILD = 'rebuild'
+    RECONFIGURE = 'reconfigure'
+    INCREMENTAL = 'incremental'
+
+
 @enum.unique
 class Action(enum.Enum):
     """Enumerations for the positional command line arguments. See
@@ -184,6 +191,7 @@ class Config:  # pylint: disable=too-many-instance-attributes
         host_toolchain_dir = os.path.abspath(args.host_toolchain_dir)
         self.host_toolchain = Toolchain(host_toolchain_dir, host_toolchain_kind)
         self.checkout_mode = CheckoutMode(args.checkout_mode)
+        self.build_mode = BuildMode(args.build_mode)
 
         self.use_ninja = args.use_ninja
         self.use_ccache = args.use_ccache
@@ -205,6 +213,7 @@ class Config:  # pylint: disable=too-many-instance-attributes
             version_suffix = ''
             now = datetime.datetime.now()
             self.version_string = now.strftime('%Y-%m-%d-%H:%M:%S')
+        self.skip_reconfigure = self.build_mode == BuildMode.INCREMENTAL
         product_name = 'LLVMEmbeddedToolchainForArm'
         self.tarball_base_name = product_name + version_suffix
         self.target_llvm_dir = os.path.join(

--- a/scripts/make.py
+++ b/scripts/make.py
@@ -123,8 +123,8 @@ class ToolchainBuild:
             cmake_defs['LLVM_CCACHE_BUILD:BOOL'] = 'ON'
 
         cmake_env = {
-            'CC': cfg.host_c_compiler,
-            'CXX': cfg.host_cpp_compiler,
+            'CC': cfg.host_toolchain.c_compiler,
+            'CXX': cfg.host_toolchain.cpp_compiler,
         }
 
         if os.path.exists(os.path.join(llvm_build_dir, 'CMakeCache.txt')):


### PR DESCRIPTION
The first patch adds support for host toolchain kind selection (and GCC as an example). The second patch (--build-mode) just makes life a bit easier when switching between host toolchains.