### PR TITLE
add llvm-HEAD patch to follow divergence between 0.1 and head

### DIFF
--- a/patches/llvm-HEAD.patch
+++ b/patches/llvm-HEAD.patch
@@ -1,0 +1,66 @@
+diff --git a/compiler-rt/cmake/builtin-config-ix.cmake b/compiler-rt/cmake/builtin-config-ix.cmake
+index ad3b98799c5c..49b7ce6dd068 100644
+--- a/llvm/lib/Support/CommandLine.cpp
++++ b/llvm/lib/Support/CommandLine.cpp
+@@ -1112,12 +1112,57 @@ static llvm::Error ExpandResponseFile(
+   if (!RelativeNames)
+     return Error::success();
+   llvm::StringRef BasePath = llvm::sys::path::parent_path(FName);
+-  // If names of nested response files should be resolved relative to including
+-  // file, replace the included response file names with their full paths
+-  // obtained by required resolution.
++
++  // There is some semantics to the config file syntax.
++  // TODO: think about the syntax a bit, currently it's rather crude.
+   for (auto &Arg : NewArgv) {
++    if (!Arg)
++      continue;
++
++    // Recognize variables when they start with $
++    // The special variable $@ expands to the current path
++    // To get a literal $, use $$
++    StringRef Val(Arg);
++    StringRef::size_type Pos = Val.find('$');
++    if (Pos != StringRef::npos) {
++      SmallString<128> ExpandedVar;
++      size_t from = 0;
++
++      do {
++        //copy until variable
++        ExpandedVar.append(Val.substr(from, Pos));
++
++        // handle variable
++        Pos++;
++        switch (Val[Pos]) {
++        case '$':
++          ExpandedVar.append(1, '$');
++          break;
++        case '@':
++          ExpandedVar.append(llvm::sys::path::parent_path(FName));
++          break;
++        default:
++          // TODO: emit diagnostic
++          assert(!"unknown variable in config file");
++          break;
++        }
++        Pos++;
++
++        //continue the search
++        from = Pos;
++        Pos = Val.find('$', from);
++      } while (Pos != StringRef::npos);
++
++      //copy the rest of the argument over
++      ExpandedVar.append(Val.substr(from));
++      Arg = Saver.save(ExpandedVar.c_str()).data();
++    }
++    // If names of nested response files should be resolved relative to including
++    // file, replace the included response file names with their full paths
++    // obtained by required resolution.
++
+     // Skip non-rsp file arguments.
+-    if (!Arg || Arg[0] != '@')
++    if (Arg[0] != '@')
+       continue;
+ 
+     StringRef FileName(Arg + 1);

--- a/versions.yml
+++ b/versions.yml
@@ -32,7 +32,7 @@
       URL:  https://github.com/llvm/llvm-project.git
       Branch: main
       Revision: HEAD
-      Patch: llvm-0.1.patch
+      Patch: llvm-HEAD.patch
     - Name: newlib.git
       URL:  https://github.com/mirror/newlib-cygwin.git
       Branch: master


### PR DESCRIPTION
Previously the changes needing to be done for the llvm codebase was the same for
HEAD and 0.1, so they used the same patch. But as one change in that patch has
been merged upstream, we need separate patch files for the versions.