### PR TITLE
Fix the list of scripts in setup.py

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -24,12 +24,6 @@ setup(name="LLVMEmbeddedToolchainForArm",
       packages=find_packages(),
       scripts=[
           'build.py',
-          'check.py',
-          'cfg_files.py',
-          'config.py',
-          'execution.py',
           'repos.py',
-          'tarball.py',
-          'util.py'
       ],
       install_requires=['pyyaml', 'gitpython'])


### PR DESCRIPTION
The scripts list should only contain Python scripts that need to be
installed in the bin directory of the Python sandbox.

This fixes the build of Python sandbox (virual environment) with
Python 3.6.