### PR TITLE
Add tests to the build process

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -156,6 +156,7 @@ def parse_args_to_config() -> Config:
                              '  libcxx - build and install libc++abi and '
                              'libc++ for each target\n'
                              '  configure - write target configuration files\n'
+                             '  test - run tests\n'
                              '  package - create tarball\n'
                              '  all - perform all of the above\n'
                              'Default: all')
@@ -255,6 +256,9 @@ def build_all(cfg: Config) -> None:
                     functools.partial(cfg_files.configure_target, cfg,
                                       lib_spec),
                     'generation of config files for {}'.format(lib_spec.name))
+        run_or_skip(cfg, Action.TEST,
+                    lambda lspec=lib_spec: builder.run_tests(lspec),
+                    'tests for {}'.format(lib_spec.name))
 
 
 def ask_about_runtime_dlls(cfg: Config) -> Optional[bool]:

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -110,6 +110,7 @@ class Action(enum.Enum):
     COMPILER_RT = 'compiler-rt'
     LIBCXX = 'libcxx'
     CONFIGURE = 'configure'
+    TEST = 'test'
     PACKAGE = 'package'
     ALL = 'all'
 

--- a/tests/Makefile.conf
+++ b/tests/Makefile.conf
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2021, Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+check-env:
+ifndef BIN_PATH
+	$(error BIN_PATH is not set)
+endif
+
+.PHONY: check-env

--- a/tests/smoketests/Makefile
+++ b/tests/smoketests/Makefile
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2021, Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include ../Makefile.conf
+
+build: check-env
+	@$(MAKE) -C basic-semihosting build
+
+run: check-env
+	@$(MAKE) -C basic-semihosting run
+
+.PHONY: build run

--- a/tests/smoketests/basic-semihosting/Makefile
+++ b/tests/smoketests/basic-semihosting/Makefile
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2021, Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+build: hello.elf
+
+hello.elf: *.c
+	$(BIN_PATH)/clang --config armv6m-none-eabi_rdimon -g -o hello.elf $^
+
+run: hello.elf
+	qemu-arm -cpu cortex-m0 $<
+
+.PHONY: build run

--- a/tests/smoketests/basic-semihosting/hello.c
+++ b/tests/smoketests/basic-semihosting/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(void) {
+  printf("Hello World!\n");
+  return 0;
+}


### PR DESCRIPTION
This patch adds a 'test' phase to the build system.

For now we have added one smoke test, which is the same as
baremetal-semihosting from the 'samples' directory.

If qemu-arm is present in PATH, tests are built and run. Otherwise,
they are only built.