### PR TITLE
Support building and running code samples on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # LLVM Embedded Toolchain for Arm
 
-This repository contains build scripts and auxiliary material for building a bare-metal LLVM based toolchain targeting Arm based on:
+This repository contains build scripts and auxiliary material for building a
+bare-metal LLVM based toolchain targeting Arm based on:
 * clang + llvm
 * lld
 * libc++abi
@@ -8,11 +9,15 @@ This repository contains build scripts and auxiliary material for building a bar
 * compiler-rt
 * newlib
 
-Currently, only Armv6-M can be targeted, and only one library variant is provided targeting the Armv6-M architecture without any optional features.
+Currently, only Armv6-M can be targeted, and only one library variant is
+provided targeting the Armv6-M architecture without any optional features.
 
 ## Goal
 
-The goal is to provide a LLVM based bare-metal toolchain that can target the Arm architecture family from Armv6-M and newer. The toolchain follows the ABI for the Arm Architectue and attempts to provide typical features needed for embedded and realtime operating systems.
+The goal is to provide an LLVM based bare-metal toolchain that can target the
+Arm architecture family from Armv6-M and newer. The toolchain follows the ABI
+for the Arm Architecture and attempts to provide typical features needed for
+embedded and realtime operating systems.
 
 ## Components
 
@@ -27,10 +32,11 @@ newlib     | https://sourceware.org/newlib
 
 Content of this repository is licensed under Apache-2.0. See ``LICENSE.txt``.
 
-The resulting binaries are covered under their respective open source licenses, see component links above.
+The resulting binaries are covered under their respective open source licenses,
+see component links above.
 
 In addition, if the toolchain is cross-compiled to run on Windows (see
-[Cross-compiling the toolchain for Windows](##cross-compiling-the-toolchain-for-windows)
+[Cross-compiling the toolchain for Windows](#cross-compiling-the-toolchain-for-windows)
 for details) several Mingw-w64 runtime libraries residing on your machine
 may be copied to the ``bin`` directory of the toolchain and included in the
 generated ``.tar.gz`` archive if you choose to do so.
@@ -47,7 +53,8 @@ The libraries are covered under their respective open source licenses.
 
 ## Contributions and Pull Requests
 
-Contributions are accepted under Apache-2.0. Only submit contributions where you have authored all of the code.
+Contributions are accepted under Apache-2.0. Only submit contributions where
+you have authored all of the code.
 
 ### Coding style
 
@@ -57,16 +64,18 @@ following command to check the scripts before submitting a pull request
 (assuming that pylint is installed):
 
 ```
-pylint --rcfile=scripts/.pylintrc scripts
+$ pylint --rcfile=scripts/.pylintrc scripts
 ```
 
 ## How to provide feedback/report an issue
 
-Please raise an issue via  https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/issues
+Please raise an issue via
+https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/issues
 
 ## Host platforms
 
-The LLVM Embedded Toolchain for Arm has been built and tested on Linux/Ubuntu 18.04.5 LTS.
+The LLVM Embedded Toolchain for Arm has been built and tested on Linux/Ubuntu
+18.04.5 LTS.
 
 ## Getting started
 
@@ -81,14 +90,15 @@ Build requirements
 * Git
 * GNU Make
 
-0. Install typically missing packages. There might be others depending on your setup.
+0. Install typically missing packages. There might be others depending on your
+   setup.
 ```
-sudo apt-get install clang # If the Clang version installed by the package manager is older than 6.0.0, download a recent version from https://releases.llvm.org or build from source
-sudo apt-get install python3
-sudo apt-get install python3-venv
-sudo apt-get install git
-sudo apt-get install make
-sudo apt-get install cmake # If the CMake version installed by the package manager is older than 3.13.4, download a recent version from https://cmake.org/download and add it to PATH
+# apt-get install clang # If the Clang version installed by the package manager is older than 6.0.0, download a recent version from https://releases.llvm.org or build from source
+# apt-get install python3
+# apt-get install python3-venv
+# apt-get install git
+# apt-get install make
+# apt-get install cmake # If the CMake version installed by the package manager is older than 3.13.4, download a recent version from https://cmake.org/download and add it to PATH
 ```
 
 1. Install the build scripts in a python virtual env (in directory ``venv``):
@@ -103,12 +113,14 @@ $ . ./venv/bin/activate
 ```
 $ build.py
 ```
-The script supports various command line options. To get a description of all options run:
+The script supports various command line options. To get a description of all
+options run:
 ```
 $ build.py -h
 ```
 Some notable options include:
-* ``--revision`` the LLVM Embedded Toolchain for Arm version. Default version is ``0.1``. The available toolchain versions can be listed with:
+* ``--revision`` the LLVM Embedded Toolchain for Arm version. Default version
+  is ``0.1``. The available toolchain versions can be listed with:
 ```
 $ repos.py list
 0.1
@@ -117,9 +129,12 @@ HEAD
 * ``--host-toolchain`` the toolchain type. The supported values are:
   * ``clang`` Clang (the default)
   * ``gcc`` GCC
-  * ``mingw`` Mingw-w64 (used for cross-compilation, see [Cross-compiling the toolchain for Windows](##cross-compiling-the-toolchain-for-windows))
-* ``--host-toolchain-dir`` the directory from Step 0 that the toolchain resides in. Default is ``/usr/bin``.
-* ``--install-dir`` the LLVM Embedded Toolchain for Arm installation directory. Default is ``./install-<revision>``.
+  * ``mingw`` Mingw-w64 (used for cross-compilation, see
+    [Cross-compiling the toolchain for Windows](#cross-compiling-the-toolchain-for-windows))
+* ``--host-toolchain-dir`` the directory from Step 0 that the toolchain resides
+  in. Default is ``/usr/bin``.
+* ``--install-dir`` the LLVM Embedded Toolchain for Arm installation directory.
+  Default is ``./install-<revision>``.
 
 The build script can optionally take advantage of some tools to speed up the
 build. Currently, these tools are ``ccache``, and ``ninja``.
@@ -131,29 +146,33 @@ $ build.py --use-ccache --use-ninja
 
 ### Use the toolchain
 
-Once built, you can use the generated config files to configure the compiler correctly. The available config files can be listed with `ls <install-dir>/LLVMEmbeddedToolchainForArm-<revision>/bin/*.cfg`
+Once built, you can use the generated config files to configure the compiler
+correctly. The available config files can be listed with
+`ls <install-dir>/LLVMEmbeddedToolchainForArm-<revision>/bin/*.cfg`
 
 ```
-PATH=<install-dir>/LLVMEmbeddedToolchainForArm-<revision>/bin:$PATH
-clang --config armv6m-none-eabi_rdimon -o example example.c
+$ PATH=<install-dir>/LLVMEmbeddedToolchainForArm-<revision>/bin:$PATH
+$ clang --config armv6m-none-eabi_rdimon -o example example.c
 ```
 
-Note that `armv6m-none-eabi_nosys` and `armv6m-none-eabi_rdimon_baremetal` require the linker script to be specifed with `-T`:
+Note that `armv6m-none-eabi_nosys` and `armv6m-none-eabi_rdimon_baremetal`
+require the linker script to be specified with `-T`:
 
 ```
-PATH=<install-dir>/LLVMEmbeddedToolchainForArm-<revision>/bin:$PATH
-clang --config armv6m-none-eabi_nosys -T device.ld -o example example.c
+$ PATH=<install-dir>/LLVMEmbeddedToolchainForArm-<revision>/bin:$PATH
+$ clang --config armv6m-none-eabi_nosys -T device.ld -o example example.c
 ```
 
 ### Test the toolchain
 
-See the `samples` folder for sample code and instructions on building, running and debugging.
+See the `samples` folder for sample code and instructions on building, running
+and debugging.
 
 ## Cross-compiling the toolchain for Windows
 
 The LLVM Embedded Toolchain for Arm can be cross-compiled to run on Windows.
 The compilation itself still happens on Linux. In addition to the prerequisites
-mentioned in the [Build the toolchain](###build-the-toolchain) section you will
+mentioned in the [Build the toolchain](#build-the-toolchain) section you will
 also need a Mingw-w64 toolchain based on GCC 5.1.0 or above installed. For
 example, to install it on Ubuntu Linux use the following command:
 
@@ -184,7 +203,7 @@ $ build.py --host-toolchain mingw \
 
 The script will prompt you whether it should copy the Mingw-w64 runtime
 libraries from your local machine to the toolchain ``bin`` directory. The
-libraries are distributed under their own [licenses](##license), this needs to
+libraries are distributed under their own [licenses](#license), this needs to
 be taken into consideration if you decide to redistribute the built toolchain.
 
 To avoid an interactive prompt use the ``--copy-runtime-dlls`` command line
@@ -194,14 +213,18 @@ $ build.py --host-toolchain mingw --copy-runtime-dlls no
 ```
 
 ## Known limitations
-* Depending on the state of the components, build errors may occur when ``--revision HEAD`` is used.
+* Depending on the state of the components, build errors may occur when
+  ``--revision HEAD`` is used.
 
 ## Divergences from upstream
 
 ### newlib:
-* clang does not support naked attribute on a C function, breaking the linux startup (out of scope).
+* Clang does not support the ``naked`` attribute on C functions, breaking the
+  Linux startup (out of scope).
 * Target triple ending with eabi is not considered an ELF target.
-* Revision 0.1 only: set the correct floating-point endianness when building with Clang.
+* Revision 0.1 only: set the correct floating-point endianness when building
+  with Clang.
 
 ### LLVM:
-* Recognize $@ in a config file argument to mean the directory of the config file, allowing toolchain relative paths.
+* Recognize $@ in a config file argument to mean the directory of the config
+  file, allowing toolchain relative paths.

--- a/samples/Makefile.conf
+++ b/samples/Makefile.conf
@@ -15,7 +15,9 @@
 # limitations under the License.
 #
 
+ifndef BIN_PATH
 ifndef VERSION
     VERSION=0.1
 endif
-BIN_PATH=../../../install-${VERSION}/LLVMEmbeddedToolchainForArm-${VERSION}/bin/
+BIN_PATH=../../../install-${VERSION}/LLVMEmbeddedToolchainForArm-${VERSION}/bin
+endif

--- a/samples/README.md
+++ b/samples/README.md
@@ -4,4 +4,5 @@ Samples of LLVM Embedded Toolchain for Arm
 
 * `ldscripts` - Linker scripts used by samples.
 * `startup` - Startup code used by samples.
-* `src` - Sample source code, Makefile and description, each sub-directory is a separate sample.
+* `src` - Sample source code, Makefile and description, each sub-directory is a
+  separate sample.

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,8 +1,53 @@
-Samples of LLVM Embedded Toolchain for Arm
+# Sample code for the LLVM Embedded Toolchain for Arm
 
-# Directory structure
+This directory contains sample code which demonstrates how to use the LLVM
+Embedded Toolchain for Arm.
 
-* `ldscripts` - Linker scripts used by samples.
-* `startup` - Startup code used by samples.
+## Directory structure
+
+* `ldscripts` - Linker scripts used by the samples.
+* `startup` - Startup code used by the samples.
 * `src` - Sample source code, Makefile and description, each sub-directory is a
   separate sample.
+
+## Prerequisites
+
+In order to compile the samples you will need the following tools:
+* LLVM Embedded Toolchain for Arm
+* GNU Make
+
+To run the samples you will need a QEMU emulator to be installed on your
+machine. The ``basic-semihosting`` sample uses the QEMU User space emulator,
+on Ubuntu Linux it can be installed using the following command:
+
+```
+# apt-get install qemu-user
+```
+
+The other two samples (``baremetal-semihosting`` and ``baremetal-uart``) rely on
+the QEMU Arm System emulator. On Ubuntu Linux it can be installed as follows:
+
+```
+# apt-get install qemu-system-arm
+```
+
+To debug the samples you will need to install GDB provided by the
+[GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads).
+
+## Compiling, running and debugging the samples
+
+Change to the directory of a specific sample (e.g. ``src/baremetal-uart``) and
+use the following commands to build, run or debug the sample:
+* `VERSION=0.1 make build` to build the sample.
+* `VERSION=0.1 make run` to run the sample with QEMU emulator.
+* `VERSION=0.1 make debug` to run the sample with QEMU emulator with GDB server
+  listening on the default port 1234.
+
+  To debug attach to QEMU with
+  [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
+  GDB:
+
+  ```
+  $ arm-none-eabi-gdb hello.elf
+  (gdb) target remote :1234
+  ```

--- a/samples/README.md
+++ b/samples/README.md
@@ -34,13 +34,31 @@ the QEMU Arm System emulator. On Ubuntu Linux it can be installed as follows:
 To debug the samples you will need to install GDB provided by the
 [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads).
 
-## Compiling, running and debugging the samples
+## Using the samples
+
+### Specifying the location of the installed toolchain
+
+The Makefiles of the code samples need the location of the installed LLVM
+Embedded Toolchain for Arm. There are several ways to specify the location:
+* Set the environment variable ``BIN_PATH`` to point to the ``bin`` directory
+  of the toolchain, or
+* Set the environment variable ``VERSION`` to the revision of the built
+  toolchain (e.g. ``0.1`` or ``HEAD``). The sample Makefiles will assume that
+  the toolchain is installed in the default directory used by the
+  ``build.py`` script (i.e.
+  ``install-<revision>/LLVMEmbeddedToolchainForArm-<revision>``
+  in the root of the ``LLVM-embedded-toolchain-for-Arm`` repository
+  checkout), or
+* Don't set any of the above variables. This will have the same effect as
+  setting ``VERSION=0.1``
+
+### Compiling, running and debugging the samples
 
 Change to the directory of a specific sample (e.g. ``src/baremetal-uart``) and
 use the following commands to build, run or debug the sample:
-* `VERSION=0.1 make build` to build the sample.
-* `VERSION=0.1 make run` to run the sample with QEMU emulator.
-* `VERSION=0.1 make debug` to run the sample with QEMU emulator with GDB server
+* ``$ make build`` to build the sample.
+* ``$ make run`` to run the sample with QEMU emulator.
+* ``$ make debug`` to run the sample with QEMU emulator with GDB server
   listening on the default port 1234.
 
   To debug attach to QEMU with
@@ -51,3 +69,10 @@ use the following commands to build, run or debug the sample:
   $ arm-none-eabi-gdb hello.elf
   (gdb) target remote :1234
   ```
+* ``$ make clean`` to delete the generated ``.elf`` and ``.hex`` files
+
+Note: you can set an environment variable for a command using the following
+syntax:
+```
+$ VERSION=HEAD make run
+```

--- a/samples/README.md
+++ b/samples/README.md
@@ -10,11 +10,18 @@ Embedded Toolchain for Arm.
 * `src` - Sample source code, Makefile and description, each sub-directory is a
   separate sample.
 
+## Supported environments
+
+The build scripts support three different environments:
+* Linux
+* Windows
+* Windows + [MSYS2](https://www.msys2.org/)
+
 ## Prerequisites
 
 In order to compile the samples you will need the following tools:
 * LLVM Embedded Toolchain for Arm
-* GNU Make
+* GNU Make (Linux and MSYS2)
 
 To run the samples you will need a QEMU emulator to be installed on your
 machine. The ``basic-semihosting`` sample uses the QEMU User space emulator,
@@ -24,6 +31,8 @@ on Ubuntu Linux it can be installed using the following command:
 # apt-get install qemu-user
 ```
 
+The User space emulator is only available for Linux.
+
 The other two samples (``baremetal-semihosting`` and ``baremetal-uart``) rely on
 the QEMU Arm System emulator. On Ubuntu Linux it can be installed as follows:
 
@@ -31,17 +40,22 @@ the QEMU Arm System emulator. On Ubuntu Linux it can be installed as follows:
 # apt-get install qemu-system-arm
 ```
 
+The Windows installer can be downloaded from
+https://www.qemu.org/download/#windows.
+
 To debug the samples you will need to install GDB provided by the
 [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads).
+Debugging is only supported on Linux.
 
-## Using the samples
-
-### Specifying the location of the installed toolchain
+## Specifying the location of the installed toolchain
 
 The Makefiles of the code samples need the location of the installed LLVM
-Embedded Toolchain for Arm. There are several ways to specify the location:
+Embedded Toolchain for Arm. There are several ways to specify the location,
+depending on the environment. The following option works in all environments:
 * Set the environment variable ``BIN_PATH`` to point to the ``bin`` directory
-  of the toolchain, or
+  of the toolchain.
+
+The following two options work on Linux and MSYS2:
 * Set the environment variable ``VERSION`` to the revision of the built
   toolchain (e.g. ``0.1`` or ``HEAD``). The sample Makefiles will assume that
   the toolchain is installed in the default directory used by the
@@ -50,16 +64,19 @@ Embedded Toolchain for Arm. There are several ways to specify the location:
   in the root of the ``LLVM-embedded-toolchain-for-Arm`` repository
   checkout), or
 * Don't set any of the above variables. This will have the same effect as
-  setting ``VERSION=0.1``
+  setting ``VERSION=0.1``.
 
-### Compiling, running and debugging the samples
+## Compiling, running and debugging the samples
+
+### Linux and MSYS2
 
 Change to the directory of a specific sample (e.g. ``src/baremetal-uart``) and
 use the following commands to build, run or debug the sample:
 * ``$ make build`` to build the sample.
 * ``$ make run`` to run the sample with QEMU emulator.
 * ``$ make debug`` to run the sample with QEMU emulator with GDB server
-  listening on the default port 1234.
+  listening on the default port 1234 (Note: ``debug`` is supported only on
+  Linux).
 
   To debug attach to QEMU with
   [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
@@ -76,3 +93,16 @@ syntax:
 ```
 $ VERSION=HEAD make run
 ```
+
+### Windows
+
+If you plan to run the compiled samples, ensure that the path of the directory
+containing QEMU (specifically, the ``qemu-system-arm.exe`` file) is present in
+the ``PATH`` environment variable.
+
+Start a Command Prompt (``cmd.exe``), change to the directory of a specific
+sample (e.g. ``src\baremetal-uart``) and use the following commands to build or
+run the sample:
+* ``> make.bat build`` to build the sample.
+* ``> make.bat run`` to run the sample with QEMU emulator.
+* ``> make.bat clean`` to delete the generated ``.elf`` and ``.hex`` files.

--- a/samples/src/baremetal-semihosting/Makefile
+++ b/samples/src/baremetal-semihosting/Makefile
@@ -20,19 +20,19 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	$(BIN_PATH)clang --config armv6m-none-eabi_rdimon_baremetal -g -T ../../ldscripts/microbit.ld -o hello.elf ../../startup/startup_ARMCM0.S $^
+	$(BIN_PATH)/clang --config armv6m-none-eabi_rdimon_baremetal -g -T ../../ldscripts/microbit.ld -o hello.elf ../../startup/startup_ARMCM0.S $^
 
 %.hex: %.elf
-	$(BIN_PATH)llvm-objcopy -O ihex $< $@
+	$(BIN_PATH)/llvm-objcopy -O ihex $< $@
 
+# -m option is a workaround to ensure correct initialization of semihosting
 run: hello.hex
-	# -m option is a workaround to ensure correct initialization of semihosting
 	qemu-system-arm -M microbit -semihosting -nographic -device loader,file=$< -m 1073741824k
 
 debug: hello.hex
 	qemu-system-arm -M microbit -semihosting -nographic -device loader,file=$< -m 1073741824k -s -S
 
 clean:
-	rm *.elf *.hex
+	rm -f *.elf *.hex
 
 .PHONY: clean run debug

--- a/samples/src/baremetal-semihosting/README.md
+++ b/samples/src/baremetal-semihosting/README.md
@@ -1,15 +1,21 @@
-This sample shows how to use semihosting with [QEMU Arm System emulator](https://www.qemu.org/docs/master/system/target-arm.html) targeting the [micro:bit board model](https://www.qemu.org/2019/05/22/microbit/).
+This sample shows how to use semihosting with
+[QEMU Arm System emulator](https://www.qemu.org/docs/master/system/target-arm.html)
+targeting the
+[micro:bit board model](https://www.qemu.org/2019/05/22/microbit/).
 
-It uses the startup code and the linker script file from the GNU Arm Embedded Toolchain samples.
+It uses the startup code and the linker script file from the GNU Arm Embedded
+Toolchain samples.
 
 Usage:
 * `VERSION=0.1 make build` to build the sample.
-* `VERSION=0.1 make run` to run the the sample with QEMU Arm System emulator.
-* `VERSION=0.1 make debug` to run the the sample with QEMU Arm System emulator with GDB server listening on the default port 1234.
+* `VERSION=0.1 make run` to run the sample with QEMU Arm System emulator.
+* `VERSION=0.1 make debug` to run the sample with QEMU Arm System emulator with
+  GDB server listening on the default port 1234.
 
-    To debug attach to QEMU with GDB provided by the [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads):
+  To debug attach to QEMU with GDB provided by the
+  [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads):
 
-    ```
-    $ arm-none-eabi-gdb hello.elf
-    (gdb) target remote :1234
-    ```
+  ```
+  $ arm-none-eabi-gdb hello.elf
+  (gdb) target remote :1234
+  ```

--- a/samples/src/baremetal-semihosting/README.md
+++ b/samples/src/baremetal-semihosting/README.md
@@ -1,3 +1,5 @@
+# Bare-metal semihosting sample
+
 This sample shows how to use semihosting with
 [QEMU Arm System emulator](https://www.qemu.org/docs/master/system/target-arm.html)
 targeting the
@@ -5,17 +7,3 @@ targeting the
 
 It uses the startup code and the linker script file from the GNU Arm Embedded
 Toolchain samples.
-
-Usage:
-* `VERSION=0.1 make build` to build the sample.
-* `VERSION=0.1 make run` to run the sample with QEMU Arm System emulator.
-* `VERSION=0.1 make debug` to run the sample with QEMU Arm System emulator with
-  GDB server listening on the default port 1234.
-
-  To debug attach to QEMU with GDB provided by the
-  [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads):
-
-  ```
-  $ arm-none-eabi-gdb hello.elf
-  (gdb) target remote :1234
-  ```

--- a/samples/src/baremetal-semihosting/make.bat
+++ b/samples/src/baremetal-semihosting/make.bat
@@ -1,0 +1,54 @@
+@REM Copyright (c) 2021, Arm Limited and affiliates.
+@REM SPDX-License-Identifier: Apache-2.0
+@REM
+@REM Licensed under the Apache License, Version 2.0 (the "License");
+@REM you may not use this file except in compliance with the License.
+@REM You may obtain a copy of the License at
+@REM
+@REM     http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing, software
+@REM distributed under the License is distributed on an "AS IS" BASIS,
+@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM See the License for the specific language governing permissions and
+@REM limitations under the License.
+
+@if [%1]==[] goto :target_empty
+@set target=%1
+@goto :make
+:target_empty
+@set target=build
+
+:make
+@if [%target%]==[build] goto :build
+@if [%target%]==[run] goto :run
+@if [%target%]==[clean] goto :clean
+@echo Error: unknown target "%target%"
+@exit /B 1
+
+:build
+@if [%BIN_PATH%]==[] goto :bin_path_empty
+@call :build_fn
+@exit /B
+
+:run
+@if exist hello.hex goto :do_run
+@if [%BIN_PATH%]==[] goto :bin_path_empty
+@call :build_fn
+:do_run
+qemu-system-arm.exe -M microbit -semihosting -nographic -device loader,file=hello.hex -m 1073741824k
+@exit /B
+
+:clean
+if exist hello.elf del /q hello.elf
+if exist hello.hex del /q hello.hex
+@exit /B
+
+:bin_path_empty
+@echo Error: BIN_PATH environment variable is not set
+@exit /B 1
+
+:build_fn
+%BIN_PATH%\clang.exe --config armv6m-none-eabi_rdimon_baremetal -g -T ..\..\ldscripts\microbit.ld -o hello.elf ..\..\startup\startup_ARMCM0.S hello.c
+%BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
+@exit /B

--- a/samples/src/baremetal-uart/Makefile
+++ b/samples/src/baremetal-uart/Makefile
@@ -20,11 +20,12 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	$(BIN_PATH)clang --config armv6m-none-eabi_nosys -g -T ../../ldscripts/microbit.ld -o hello.elf ../../startup/startup_ARMCM0.S $^
+	$(BIN_PATH)/clang --config armv6m-none-eabi_nosys -g -T ../../ldscripts/microbit.ld -o hello.elf ../../startup/startup_ARMCM0.S $^
 
 %.hex: %.elf
-	$(BIN_PATH)llvm-objcopy -O ihex $< $@
+	$(BIN_PATH)/llvm-objcopy -O ihex $< $@
 
+# -m option is a workaround to ensure correct initialization of semihosting
 run: hello.hex
 	qemu-system-arm -M microbit -semihosting -nographic -device loader,file=$< -m 1073741824k
 
@@ -32,6 +33,6 @@ debug: hello.hex
 	qemu-system-arm -M microbit -semihosting -nographic -device loader,file=$< -m 1073741824k -s -S
 
 clean:
-	rm *.elf *.hex
+	rm -f *.elf *.hex
 
 .PHONY: clean run debug

--- a/samples/src/baremetal-uart/README.md
+++ b/samples/src/baremetal-uart/README.md
@@ -1,3 +1,5 @@
+# Bare-metal sample without semihosting
+
 This sample shows how to use
 [QEMU Arm System emulator](https://www.qemu.org/docs/master/system/target-arm.html)
 without semihosting targeting the
@@ -6,19 +8,4 @@ without semihosting targeting the
 It uses the startup code and the linker script file from the GNU Arm Embedded
 Toolchain samples.
 
-Usage:
-* `VERSION=0.1 make build` to build the sample.
-* `VERSION=0.1 make run` to run the sample with QEMU Arm System emulator.
-
-  _Note: The sample code hangs at the end of the execution in an infinite loop!_
-
-* `VERSION=0.1 make debug` to run the sample with QEMU Arm System emulator with
-  GDB server listening on the default port 1234.
-
-  To debug attach to QEMU with GDB provided by the
-  [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads):
-
-  ```
-  $ arm-none-eabi-gdb hello.elf
-  (gdb) target remote :1234
-  ```
+_Note: The sample code hangs at the end of the execution in an infinite loop!_

--- a/samples/src/baremetal-uart/README.md
+++ b/samples/src/baremetal-uart/README.md
@@ -1,18 +1,24 @@
-This sample shows how to use [QEMU Arm System emulator](https://www.qemu.org/docs/master/system/target-arm.html) without semihosting targeting the [micro:bit board model](https://www.qemu.org/2019/05/22/microbit/).
+This sample shows how to use
+[QEMU Arm System emulator](https://www.qemu.org/docs/master/system/target-arm.html)
+without semihosting targeting the
+[micro:bit board model](https://www.qemu.org/2019/05/22/microbit/).
 
-It uses the startup code and the linker script file from the GNU Arm Embedded Toolchain samples.
+It uses the startup code and the linker script file from the GNU Arm Embedded
+Toolchain samples.
 
 Usage:
 * `VERSION=0.1 make build` to build the sample.
-* `VERSION=0.1 make run` to run the the sample with QEMU Arm System emulator.
+* `VERSION=0.1 make run` to run the sample with QEMU Arm System emulator.
 
-    _Note: The sample code hangs at the end of the execution in an infinate loop!_
+  _Note: The sample code hangs at the end of the execution in an infinite loop!_
 
-* `VERSION=0.1 make debug` to run the the sample with QEMU Arm System emulator with GDB server listening on the default port 1234.
+* `VERSION=0.1 make debug` to run the sample with QEMU Arm System emulator with
+  GDB server listening on the default port 1234.
 
-    To debug attach to QEMU with GDB provided by the [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads):
+  To debug attach to QEMU with GDB provided by the
+  [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads):
 
-    ```
-    $ arm-none-eabi-gdb hello.elf
-    (gdb) target remote :1234
-    ```
+  ```
+  $ arm-none-eabi-gdb hello.elf
+  (gdb) target remote :1234
+  ```

--- a/samples/src/baremetal-uart/make.bat
+++ b/samples/src/baremetal-uart/make.bat
@@ -1,0 +1,54 @@
+@REM Copyright (c) 2021, Arm Limited and affiliates.
+@REM SPDX-License-Identifier: Apache-2.0
+@REM
+@REM Licensed under the Apache License, Version 2.0 (the "License");
+@REM you may not use this file except in compliance with the License.
+@REM You may obtain a copy of the License at
+@REM
+@REM     http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing, software
+@REM distributed under the License is distributed on an "AS IS" BASIS,
+@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM See the License for the specific language governing permissions and
+@REM limitations under the License.
+
+@if [%1]==[] goto :target_empty
+@set target=%1
+@goto :make
+:target_empty
+@set target=build
+
+:make
+@if [%target%]==[build] goto :build
+@if [%target%]==[run] goto :run
+@if [%target%]==[clean] goto :clean
+@echo Error: unknown target "%target%"
+@exit /B 1
+
+:build
+@if [%BIN_PATH%]==[] goto :bin_path_empty
+@call :build_fn
+@exit /B
+
+:run
+@if exist hello.hex goto :do_run
+@if [%BIN_PATH%]==[] goto :bin_path_empty
+@call :build_fn
+:do_run
+qemu-system-arm.exe -M microbit -semihosting -nographic -device loader,file=hello.hex -m 1073741824k
+@exit /B
+
+:clean
+if exist hello.elf del /q hello.elf
+if exist hello.hex del /q hello.hex
+@exit /B
+
+:bin_path_empty
+@echo Error: BIN_PATH environment variable is not set
+@exit /B 1
+
+:build_fn
+%BIN_PATH%\clang.exe --config armv6m-none-eabi_nosys -g -T ..\..\ldscripts\microbit.ld -o hello.elf ..\..\startup\startup_ARMCM0.S hello.c
+%BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
+@exit /B

--- a/samples/src/basic-semihosting/Makefile
+++ b/samples/src/basic-semihosting/Makefile
@@ -20,7 +20,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	$(BIN_PATH)clang --config armv6m-none-eabi_rdimon -g -o hello.elf $^
+	$(BIN_PATH)/clang --config armv6m-none-eabi_rdimon -g -o hello.elf $^
 
 run: hello.elf
 	qemu-arm -cpu cortex-m0 $<
@@ -29,6 +29,6 @@ debug: hello.elf
 	qemu-arm -cpu cortex-m0 -g 1234 $<
 
 clean:
-	rm *.elf
+	rm -f *.elf
 
 .PHONY: clean run debug

--- a/samples/src/basic-semihosting/README.md
+++ b/samples/src/basic-semihosting/README.md
@@ -1,13 +1,16 @@
-This sample shows how to use semihosting with [QEMU User space emulator](https://www.qemu.org/docs/master/user/main.html).
+This sample shows how to use semihosting with
+[QEMU User space emulator](https://www.qemu.org/docs/master/user/main.html).
 
 Usage:
 * `VERSION=0.1 make build` to build the sample.
-* `VERSION=0.1 make run` to run the the sample with QEMU User space emulator.
-* `VERSION=0.1 make debug` to run the the sample with QEMU User space emulator with GDB server listening on the default port 1234.
+* `VERSION=0.1 make run` to run the sample with QEMU User space emulator.
+* `VERSION=0.1 make debug` to run the sample with QEMU User space emulator with
+  GDB server listening on the default port 1234.
 
-    To debug attach to QEMU with GDB provided by the [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads):
+  To debug attach to QEMU with GDB provided by the
+  [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads):
 
-    ```
-    $ arm-none-eabi-gdb hello.elf
-    (gdb) target remote :1234
-    ```
+  ```
+  $ arm-none-eabi-gdb hello.elf
+  (gdb) target remote :1234
+  ```

--- a/samples/src/basic-semihosting/README.md
+++ b/samples/src/basic-semihosting/README.md
@@ -1,16 +1,4 @@
+# User space semihosting sample
+
 This sample shows how to use semihosting with
 [QEMU User space emulator](https://www.qemu.org/docs/master/user/main.html).
-
-Usage:
-* `VERSION=0.1 make build` to build the sample.
-* `VERSION=0.1 make run` to run the sample with QEMU User space emulator.
-* `VERSION=0.1 make debug` to run the sample with QEMU User space emulator with
-  GDB server listening on the default port 1234.
-
-  To debug attach to QEMU with GDB provided by the
-  [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads):
-
-  ```
-  $ arm-none-eabi-gdb hello.elf
-  (gdb) target remote :1234
-  ```

--- a/samples/src/basic-semihosting/README.md
+++ b/samples/src/basic-semihosting/README.md
@@ -2,3 +2,7 @@
 
 This sample shows how to use semihosting with
 [QEMU User space emulator](https://www.qemu.org/docs/master/user/main.html).
+
+Note: QEMU User space emulator
+[does not support](https://qemu-project.gitlab.io/qemu/user/main.html#supported-operating-systems)
+Windows, so this sample can be compiled but cannot be run on Windows.

--- a/samples/src/basic-semihosting/make.bat
+++ b/samples/src/basic-semihosting/make.bat
@@ -1,0 +1,39 @@
+@REM Copyright (c) 2021, Arm Limited and affiliates.
+@REM SPDX-License-Identifier: Apache-2.0
+@REM
+@REM Licensed under the Apache License, Version 2.0 (the "License");
+@REM you may not use this file except in compliance with the License.
+@REM You may obtain a copy of the License at
+@REM
+@REM     http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing, software
+@REM distributed under the License is distributed on an "AS IS" BASIS,
+@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM See the License for the specific language governing permissions and
+@REM limitations under the License.
+
+@if [%1]==[] goto :target_empty
+@set target=%1
+@goto :make
+:target_empty
+@set target=build
+
+:make
+@if [%target%]==[build] goto :build
+@if [%target%]==[clean] goto :clean
+@echo Error: unknown target "%target%"
+@exit /B 1
+
+:build
+@if [%BIN_PATH%]==[] goto :bin_path_empty
+%BIN_PATH%\clang.exe --config armv6m-none-eabi_rdimon -g -o hello.elf hello.c
+@exit /B
+
+:clean
+if exist hello.elf del /q hello.elf
+@exit /B
+
+:bin_path_empty
+@echo Error: BIN_PATH environment variable is not set
+@exit /B 1


### PR DESCRIPTION
This patch series tidies up documentation and Makefiles of the code samples and adds support for building and running the samples on Windows.