### PR TITLE
Add tests to the build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,17 @@ $ clang --config armv6m-none-eabi_nosys -T device.ld -o example example.c
 
 ### Test the toolchain
 
-See the `samples` folder for sample code and instructions on building, running
-and debugging.
+Once the toolchain is built, you can build smoke tests:
+
+```
+$ build.py test
+```
+
+If QEMU is installed and present in your system path, these tests will also be
+run.
+
+Furthermore, see the `samples` folder for sample code and instructions on
+building, running and debugging.
 
 ## Cross-compiling the toolchain for Windows
 

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -112,6 +112,8 @@ class Action(enum.Enum):
     CONFIGURE = 'configure'
     PACKAGE = 'package'
     ALL = 'all'
+    # The 'test' phase is not part of 'all'
+    TEST = 'test'
 
 
 class Toolchain:  # pylint: disable=too-few-public-methods
@@ -221,7 +223,8 @@ class Config:  # pylint: disable=too-many-instance-attributes
 
         if not args.actions or Action.ALL.value in args.actions:
             self.actions = set(action for action in Action
-                               if action != Action.ALL)
+                               if action != Action.ALL and
+                                  action != Action.TEST)
         else:
             self.actions = set(Action(act_str) for act_str in args.actions)
 

--- a/tests/Makefile.conf
+++ b/tests/Makefile.conf
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2021, Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+check-env:
+ifndef BIN_PATH
+	$(error BIN_PATH is not set)
+endif
+
+.PHONY: check-env

--- a/tests/smoketests/Makefile
+++ b/tests/smoketests/Makefile
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2021, Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include ../Makefile.conf
+
+build: check-env
+	@$(MAKE) -C basic-semihosting build
+
+run: check-env
+	@$(MAKE) -C basic-semihosting run
+
+.PHONY: build run

--- a/tests/smoketests/basic-semihosting/Makefile
+++ b/tests/smoketests/basic-semihosting/Makefile
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2021, Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+build: hello.elf
+
+hello.elf: *.c
+	@$(BIN_PATH)/clang --config armv6m-none-eabi_rdimon -g -o hello.elf $^
+
+run: hello.elf
+	@qemu-arm -cpu cortex-m0 $<
+
+.PHONY: build run

--- a/tests/smoketests/basic-semihosting/hello.c
+++ b/tests/smoketests/basic-semihosting/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(void) {
+  printf("Hello World!\n");
+  return 0;
+}

--- a/tests/smoketests/basic-semihosting/stdout
+++ b/tests/smoketests/basic-semihosting/stdout
@@ -1,0 +1,1 @@
+Hello World!


### PR DESCRIPTION
This patch adds a 'test' phase to the build system.

For now we have added one smoke test, which is the same as
baremetal-semihosting from the 'samples' directory.

If qemu-arm is present in PATH, tests are built and run. Otherwise,
they are only built.

Output checking is done using golden files. Each smoke test must have
one stdout and one stderr file that contain the expected outputs, which
are in turn checked against the test output.

This current test framework requires 'make' installed and in PATH.