### PR TITLE
Fix the baremetal semihosting sample

### DIFF
--- a/samples/ldscripts/microbit.ld
+++ b/samples/ldscripts/microbit.ld
@@ -170,7 +170,7 @@ SECTIONS
 		__bss_end__ = .;
 	} > RAM
 	
-	.heap (COPY):
+	.heap (NOLOAD):
 	{
 		__end__ = .;
 		PROVIDE(end = .);
@@ -181,7 +181,7 @@ SECTIONS
 	/* .stack_dummy section doesn't contains any symbols. It is only
 	 * used for linker to calculate size of stack sections, and assign
 	 * values to stack symbols later */
-	.stack_dummy (COPY):
+	.stack_dummy (NOLOAD):
 	{
 		*(.stack*)
 	} > RAM

--- a/samples/startup/startup_ARMCM0.S
+++ b/samples/startup/startup_ARMCM0.S
@@ -34,7 +34,7 @@
 	.syntax	unified
 	.arch	armv6-m
 
-	.section .stack
+	.section .stack, "a", %nobits
 	.align	3
 #ifdef __STACK_SIZE
 	.equ	Stack_Size, __STACK_SIZE
@@ -49,7 +49,7 @@ __StackLimit:
 __StackTop:
 	.size	__StackTop, . - __StackTop
 
-	.section .heap
+	.section .heap, "a", %nobits
 	.align	3
 #ifdef __HEAP_SIZE
 	.equ	Heap_Size, __HEAP_SIZE


### PR DESCRIPTION
https://reviews.llvm.org/D85867 changed the way lld treats
non-SHF_ALLOC sections. Now, unlike GNU ld which places non-SHF_ALLOC
sections after SHF_ALLOC sections, lld sets their addresses to 0.

Because of this the .heap and .stack sections in our baremetal
semihosting sample are now placed incorrectly.

In order to fix the issue this patch:
* sets the "a" (allocatable) flag on the input sections .stack and
  .heap (in startup code)
* changes the type of the output sections .heap and .stack_dummy from
  COPY to NOLOAD in the linker script (otherwise the linker would
  clear the SHF_ALLOC flag)