### PR TITLE
Fixing the overwrite issue of multiple library builds

### DIFF
--- a/samples/src/baremetal-semihosting/Makefile
+++ b/samples/src/baremetal-semihosting/Makefile
@@ -20,7 +20,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	$(BIN_PATH)/clang --config armv6m-none-eabi_rdimon_baremetal -g -T ../../ldscripts/microbit.ld -o hello.elf ../../startup/startup_ARMCM0.S $^
+	$(BIN_PATH)/clang --config armv6m_soft_nofp_rdimon_baremetal -g -T ../../ldscripts/microbit.ld -o hello.elf ../../startup/startup_ARMCM0.S $^
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/baremetal-uart/Makefile
+++ b/samples/src/baremetal-uart/Makefile
@@ -20,7 +20,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	$(BIN_PATH)/clang --config armv6m-none-eabi_nosys -g -T ../../ldscripts/microbit.ld -o hello.elf ../../startup/startup_ARMCM0.S $^
+	$(BIN_PATH)/clang --config armv6m_soft_nofp_nosys -g -T ../../ldscripts/microbit.ld -o hello.elf ../../startup/startup_ARMCM0.S $^
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/basic-semihosting/Makefile
+++ b/samples/src/basic-semihosting/Makefile
@@ -20,7 +20,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	$(BIN_PATH)/clang --config armv6m-none-eabi_rdimon -g -o hello.elf $^
+	$(BIN_PATH)/clang --config armv6m_soft_nofp_rdimon -g -o hello.elf $^
 
 run: hello.elf
 	qemu-arm -cpu cortex-m0 $<

--- a/scripts/make.py
+++ b/scripts/make.py
@@ -275,7 +275,8 @@ class ToolchainBuild:
         cfg = self.cfg
         join = os.path.join
         flags = (lib_spec.flags
-                 + ' -ffunction-sections -fdata-sections -fno-ident')
+                 + ' -ffunction-sections -fdata-sections -fno-ident'
+                 + ' --sysroot {}'.format(join(cfg.target_llvm_rt_dir, lib_spec.name)))
         defs = {
             'CMAKE_TRY_COMPILE_TARGET_TYPE': 'STATIC_LIBRARY',
             'CMAKE_C_COMPILER': join(cfg.native_llvm_bin_dir, 'clang'),
@@ -303,7 +304,7 @@ class ToolchainBuild:
         rt_source_dir = join(cfg.llvm_repo_dir, 'compiler-rt')
         rt_build_dir = join(cfg.build_dir, 'compiler-rt', lib_spec.name)
         self._prepare_build_dir(rt_build_dir)
-        rt_install_dir = join(cfg.target_llvm_rt_dir, lib_spec.target)
+        rt_install_dir = join(cfg.target_llvm_rt_dir, lib_spec.name)
         cmake_defs = self._get_common_cmake_defs(lib_spec)
         cmake_defs.update({
             'CMAKE_BUILD_TYPE:STRING': 'Release',
@@ -367,7 +368,7 @@ class ToolchainBuild:
            "-fno-exceptions" is specified on the command line.
         """
         dummy_unwind = os.path.join(self.cfg.target_llvm_rt_dir,
-                                    lib_spec.target, 'lib', 'libunwind.a')
+                                    lib_spec.name, 'lib', 'libunwind.a')
         logging.info('Creating dummy libunwind for %s', lib_spec.name)
         self.runner.run([
             os.path.join(self.cfg.native_llvm_bin_dir, 'llvm-ar'),
@@ -389,7 +390,7 @@ class ToolchainBuild:
         cxx_flags = (cmake_common_defs.get('CMAKE_CXX_FLAGS', '')
                      + ' -D_LIBCPP_HAS_NO_LIBRARY_ALIGNED_ALLOCATION')
         install_dir = os.path.join(self.cfg.target_llvm_rt_dir,
-                                   lib_spec.target)
+                                   lib_spec.name)
         cmake_common_defs.update({
             'CMAKE_BUILD_TYPE:STRING': 'MinSizeRel',
             'CMAKE_CXX_FLAGS': cxx_flags,
@@ -474,12 +475,37 @@ class ToolchainBuild:
         except shutil.Error as ex:
             raise util.ToolchainBuildError from ex
 
+    def _copy_newlib_headers_and_libs(self, source_dir: str, destination_dir: str) -> None:
+        """ Copying newlib headers and libraries from lib_spec_name/target/{lib|include}
+            to lib_spec_name/{lib|include} """
+        cfg = self.cfg
+        join = os.path.join
+        try:
+            if os.path.exists(source_dir):
+                if cfg.verbose:
+                    logging.info('Copying %s to %s', source_dir, destination_dir)
+                for root, dirs, files in os.walk(source_dir):
+                    dst_dir = root.replace(source_dir, destination_dir, 1)
+                    if not os.path.exists(dst_dir):
+                        os.makedirs(dst_dir)
+                    for file_ in files:
+                        src_file = join(root, file_)
+                        dst_file = join(dst_dir, file_)
+                        if os.path.exists(dst_file):
+                            if os.path.samefile(src_file,dst_file):
+                                continue
+                            os.remove(dst_file)
+                        shutil.copy(src_file, dst_dir)
+        except shutil.Error as ex:
+            raise util.ToolchainBuildError from ex
+
     def build_newlib(self, lib_spec: config.LibrarySpec) -> None:
         """Build and install a single variant of newlib."""
         self.runner.reset_cwd()
         cfg = self.cfg
         join = os.path.join
         newlib_build_dir = join(cfg.build_dir, 'newlib', lib_spec.name)
+        newlib_install_dir = join(cfg.target_llvm_rt_dir, lib_spec.name)
         self._prepare_build_dir(newlib_build_dir)
 
         def compiler_str(bin_name: str) -> str:
@@ -497,7 +523,9 @@ class ToolchainBuild:
             'CC_FOR_TARGET': compiler_str('clang'),
             'CXX_FOR_TARGET': compiler_str('clang++'),
             'CFLAGS_FOR_TARGET': lib_spec.flags + ' -D__USES_INITFINI__'
-                                                  ' -UHAVE_INIT_FINI',
+                                                  ' -UHAVE_INIT_FINI'
+                                                + ' --sysroot {}'.format(join(cfg.target_llvm_rt_dir,
+                                                                         lib_spec.name, lib_spec.target)),
         }
         for tool in ['ar', 'nm', 'as', 'ranlib',
                      'strip', 'readelf', 'objdump']:
@@ -509,7 +537,7 @@ class ToolchainBuild:
             join(cfg.newlib_repo_dir, 'configure'),
             '--target={}'.format(lib_spec.target),
             '--prefix={}'.format(cfg.target_llvm_dir),
-            '--exec-prefix={}'.format(cfg.target_llvm_rt_dir),
+            '--exec-prefix={}'.format(newlib_install_dir),
             '--enable-newlib-io-long-long',
             '--enable-newlib-register-fini',
             '--disable-newlib-supplied-syscalls',
@@ -533,6 +561,17 @@ class ToolchainBuild:
             raise util.ToolchainBuildError from ex
         if cfg.is_cross_compiling:
             self._copy_runtime_to_native(lib_spec)
+
+        # For newlib, the --with-target-subdir configure option is passed by default
+        # Due to that target libraries are normally built in a subdirectory whose
+        # name is the argument to --target (ie, here it is getting built in the path
+        # "INSTALL_DIR/lib/clang-runtimes/{lib_spec_name}/{target}".
+        # Copying these built libraries and headers into the correct path
+        # "INSTALL_DIR/lib/clang-runtimes/{lib_spec_name}"
+
+        self._copy_newlib_headers_and_libs(join(cfg.target_llvm_rt_dir, lib_spec.name, lib_spec.target,                                                   'lib'), join(cfg.target_llvm_rt_dir, lib_spec.name, 'lib'))
+        self._copy_newlib_headers_and_libs(join(cfg.target_llvm_rt_dir, lib_spec.name, lib_spec.target,
+                                           'include'), join(cfg.target_llvm_rt_dir, lib_spec.name, 'include'))
 
     def _run_smoke_tests(self, lib_spec: config.LibrarySpec) -> None:
         bin_path = self.cfg.target_llvm_bin_dir


### PR DESCRIPTION
Currently every library variant we build goes into a folder differentiated
by llvm target triple.But when building consecutive libraries that have the
same target triple but differ in other attributes (ex. soft vs hard fp),
the files will overwrite each other in the same directory.

This issue is fixed by
    * Changing the default installation path from INSTALL_DIR/lib/clang-runtimes/TARGET
      to INSTALL_DIR/lib/clang-runtimes/LIBRARY_SPEC_NAME .
    * Also need to mention the sysroot to this new path.
    * Since the default sysroot is changed, need to add the library and header path in the
      configuration files.