### PR TITLE
Fixing the overwrite issue of multiple library builds

### DIFF
--- a/samples/src/baremetal-semihosting/Makefile
+++ b/samples/src/baremetal-semihosting/Makefile
@@ -20,7 +20,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	$(BIN_PATH)/clang --config armv6m-none-eabi_rdimon_baremetal -g -T ../../ldscripts/microbit.ld -o hello.elf ../../startup/startup_ARMCM0.S $^
+	$(BIN_PATH)/clang --config armv6m_soft_nofp_rdimon_baremetal -g -T ../../ldscripts/microbit.ld -o hello.elf ../../startup/startup_ARMCM0.S $^
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/baremetal-uart/Makefile
+++ b/samples/src/baremetal-uart/Makefile
@@ -20,7 +20,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	$(BIN_PATH)/clang --config armv6m-none-eabi_nosys -g -T ../../ldscripts/microbit.ld -o hello.elf ../../startup/startup_ARMCM0.S $^
+	$(BIN_PATH)/clang --config armv6m_soft_nofp_nosys -g -T ../../ldscripts/microbit.ld -o hello.elf ../../startup/startup_ARMCM0.S $^
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/basic-semihosting/Makefile
+++ b/samples/src/basic-semihosting/Makefile
@@ -20,7 +20,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	$(BIN_PATH)/clang --config armv6m-none-eabi_rdimon -g -o hello.elf $^
+	$(BIN_PATH)/clang --config armv6m_soft_nofp_rdimon -g -o hello.elf $^
 
 run: hello.elf
 	qemu-arm -cpu cortex-m0 $<

--- a/scripts/cfg_files.py
+++ b/scripts/cfg_files.py
@@ -21,10 +21,11 @@ import config
 import util
 
 
-def copy_base_ld_script(cfg: config.Config, target: str) -> None:
+def copy_base_ld_script(cfg: config.Config, lib_spec_name: str) -> None:
     """Copy the linker script to target-specific directory."""
     base_ld_src = os.path.join(cfg.source_dir, 'ldscript', 'base.ld')
-    base_ld_dest = os.path.join(cfg.target_llvm_rt_dir, target, 'base.ld')
+    base_ld_dest = os.path.join(cfg.target_llvm_rt_dir, lib_spec_name,
+                                'base.ld')
     if cfg.verbose:
         logging.info('Copying %s to %s', base_ld_src, base_ld_dest)
     shutil.copy(base_ld_src, base_ld_dest)
@@ -38,24 +39,26 @@ def write_cfg_files(cfg: config.Config, lib_spec: config.LibrarySpec) -> None:
         '--target={}'.format(target),
         lib_spec.flags,
         '-fuse-ld=lld',
-        '-fno-exceptions -fno-rtti'
+        '-fno-exceptions -fno-rtti',
+        '-L$@/../lib/clang-runtimes/{}/lib'.format(lib_spec.name),
+        '-isystem $@/../lib/clang-runtimes/{}/include'.format(lib_spec.name)
     ]
 
     # No semihosting and no linker script
     nosys_lines = base_cfg_lines + [
-        '$@/../lib/clang-runtimes/{}/lib/crt0.o'.format(target),
+        '$@/../lib/clang-runtimes/{}/lib/crt0.o'.format(lib_spec.name),
         '-lnosys',
     ]
     # Semihosting and linker script provided
     rdimon_lines = base_cfg_lines + [
-        '-Wl,-T$@/../lib/clang-runtimes/{}/base.ld'.format(target),
-        '$@/../lib/clang-runtimes/{}/lib/rdimon-crt0.o'.format(target),
+        '-Wl,-T$@/../lib/clang-runtimes/{}/base.ld'.format(lib_spec.name),
+        '$@/../lib/clang-runtimes/{}/lib/rdimon-crt0.o'.format(lib_spec.name),
         '-lrdimon',
     ]
     # Semihosting, but no linker script, e.g. to use with QEMU Arm System
     # emulator
     rdimon_baremetal_lines = base_cfg_lines + [
-        '$@/../lib/clang-runtimes/{}/lib/rdimon-crt0.o'.format(target),
+        '$@/../lib/clang-runtimes/{}/lib/rdimon-crt0.o'.format(lib_spec.name),
         '-lrdimon',
     ]
 
@@ -66,7 +69,7 @@ def write_cfg_files(cfg: config.Config, lib_spec: config.LibrarySpec) -> None:
     ]
 
     for name, lines in cfg_files:
-        file_name = '{}_{}.cfg'.format(target, name)
+        file_name = '{}_{}.cfg'.format(lib_spec.name, name)
         file_path = os.path.join(cfg.target_llvm_bin_dir, file_name)
         if cfg.verbose:
             logging.info('Writing %s', file_path)
@@ -77,5 +80,5 @@ def configure_target(cfg: config.Config, lib_spec: config.LibrarySpec) -> None:
     """Create linker script and configuration files for a single library
        variant."""
     logging.info('Creating toolchain configuration files')
-    copy_base_ld_script(cfg, lib_spec.target)
+    copy_base_ld_script(cfg, lib_spec.name)
     write_cfg_files(cfg, lib_spec)

--- a/tests/smoketests/basic-semihosting/Makefile
+++ b/tests/smoketests/basic-semihosting/Makefile
@@ -18,7 +18,7 @@
 build: hello.elf
 
 hello.elf: *.c
-	@$(BIN_PATH)/clang --config armv6m-none-eabi_rdimon -g -o hello.elf $^
+	@$(BIN_PATH)/clang --config armv6m_soft_nofp_rdimon -g -o hello.elf $^
 
 run: hello.elf
 	@qemu-arm -cpu cortex-m0 $<


### PR DESCRIPTION
Currently every library variant we build goes into a folder differentiated
by llvm target triple.But when building consecutive libraries that have the
same target triple but differ in other attributes (ex. soft vs hard fp),
the files will overwrite each other in the same directory.

This issue is fixed by
    * Changing the default installation path from INSTALL_DIR/lib/clang-runtimes/TARGET
      to INSTALL_DIR/lib/clang-runtimes/LIBRARY_SPEC_NAME .
    * Also need to mention the sysroot to this new path.
    * Since the default sysroot is changed, need to add the library and header path in the
      configuration files.

Change-Id: Ie86564d00695f3c391953cf12f42b64cf829e5ed