### PR TITLE
Fix config file names in Windows samples scripts

### DIFF
--- a/samples/src/baremetal-semihosting/make.bat
+++ b/samples/src/baremetal-semihosting/make.bat
@@ -49,6 +49,6 @@ if exist hello.hex del /q hello.hex
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang.exe --config armv6m-none-eabi_rdimon_baremetal -g -T ..\..\ldscripts\microbit.ld -o hello.elf ..\..\startup\startup_ARMCM0.S hello.c
+%BIN_PATH%\clang.exe --config armv6m_soft_nofp_rdimon_baremetal -g -T ..\..\ldscripts\microbit.ld -o hello.elf ..\..\startup\startup_ARMCM0.S hello.c
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B

--- a/samples/src/baremetal-uart/make.bat
+++ b/samples/src/baremetal-uart/make.bat
@@ -49,6 +49,6 @@ if exist hello.hex del /q hello.hex
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang.exe --config armv6m-none-eabi_nosys -g -T ..\..\ldscripts\microbit.ld -o hello.elf ..\..\startup\startup_ARMCM0.S hello.c
+%BIN_PATH%\clang.exe --config armv6m_soft_nofp_nosys -g -T ..\..\ldscripts\microbit.ld -o hello.elf ..\..\startup\startup_ARMCM0.S hello.c
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B

--- a/samples/src/basic-semihosting/make.bat
+++ b/samples/src/basic-semihosting/make.bat
@@ -27,7 +27,7 @@
 
 :build
 @if [%BIN_PATH%]==[] goto :bin_path_empty
-%BIN_PATH%\clang.exe --config armv6m-none-eabi_rdimon -g -o hello.elf hello.c
+%BIN_PATH%\clang.exe --config armv6m_soft_nofp_rdimon -g -o hello.elf hello.c
 @exit /B
 
 :clean


### PR DESCRIPTION
make.bat contained configuration file names that were outdated due do the recent changes to multilib support.

This is the fix. Tested in Windows (with PowerShell).