### PR TITLE
Add one c++ smoke test.

### DIFF
--- a/tests/smoketests/cpp-basic-semihosting/Makefile
+++ b/tests/smoketests/cpp-basic-semihosting/Makefile
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2021, Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+build: hello.elf
+
+hello.elf: *.cpp
+	@$(BIN_PATH)/clang++ --config armv6m_soft_nofp_rdimon -g -o hello.elf $^
+
+run: hello.elf
+	@qemu-arm -cpu cortex-m0 $<
+
+.PHONY: build run

--- a/tests/smoketests/cpp-basic-semihosting/hello.cpp
+++ b/tests/smoketests/cpp-basic-semihosting/hello.cpp
@@ -1,0 +1,9 @@
+#include <string>
+#include <cstdio>
+
+int main(void) {
+    std::string str = "Hello World!\n";
+    printf("%s", str.c_str());
+    return 0;
+}
+

--- a/tests/smoketests/cpp-basic-semihosting/stdout
+++ b/tests/smoketests/cpp-basic-semihosting/stdout
@@ -1,0 +1,1 @@
+Hello World!


### PR DESCRIPTION
Adding a c++ test to the smoke tests that compiles and
runs a "Hello world" program which makes use of the
std::string feature of c++ standard library.