### PR TITLE
Add builds based on LLVM 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,18 @@ $ build.py -h
 ```
 Some notable options include:
 * ``--revision`` the LLVM Embedded Toolchain for Arm version. Default version
-  is ``0.1``. The available toolchain versions can be listed with:
+  is ``13.0.0``. The available toolchain versions can be listed with:
 ```
 $ repos.py list
 0.1
+13.0.0
+branch-13
 HEAD
 ```
+  * 0.1 - to be removed
+  * 13.0.0 - based on LLVM 13.0.0 and newlib 4.1.0
+  * branch-13 - based on the tip of the LLVM 13 branch and newlib 4.1.0
+  * HEAD - based on the latest commits in the LLVM and newlib repositories
 * ``--host-toolchain`` the toolchain type. The supported values are:
   * ``clang`` Clang (the default)
   * ``gcc`` GCC

--- a/patches/llvm-13.patch
+++ b/patches/llvm-13.patch
@@ -1,0 +1,705 @@
+diff --git a/clang/lib/Driver/ToolChains/BareMetal.cpp b/clang/lib/Driver/ToolChains/BareMetal.cpp
+index ce73e39d1456..1f866e92d26f 100644
+--- a/clang/lib/Driver/ToolChains/BareMetal.cpp
++++ b/clang/lib/Driver/ToolChains/BareMetal.cpp
+@@ -125,6 +125,25 @@ static bool isARMBareMetal(const llvm::Triple &Triple) {
+   return true;
+ }
+ 
++/// Is the triple aarch64-none-elf or aarch64-none-eabi?
++static bool isAArch64BareMetal(const llvm::Triple &Triple) {
++  // This driver supports triple aarch64-none-elf
++  if (Triple.getArch() != llvm::Triple::aarch64)
++    return false;
++
++  if (Triple.getVendor() != llvm::Triple::UnknownVendor)
++    return false;
++
++  if (Triple.getOS() != llvm::Triple::UnknownOS)
++    return false;
++
++  if (Triple.getObjectFormat() != llvm::Triple::ELF)
++    return false;
++
++  return true;
++}
++
++
+ static bool isRISCVBareMetal(const llvm::Triple &Triple) {
+   if (Triple.getArch() != llvm::Triple::riscv32 &&
+       Triple.getArch() != llvm::Triple::riscv64)
+@@ -151,7 +170,8 @@ void BareMetal::findMultilibs(const Driver &D, const llvm::Triple &Triple,
+ }
+ 
+ bool BareMetal::handlesTarget(const llvm::Triple &Triple) {
+-  return isARMBareMetal(Triple) || isRISCVBareMetal(Triple);
++  return isARMBareMetal(Triple) || isAArch64BareMetal(Triple) ||
++	 isRISCVBareMetal(Triple);
+ }
+ 
+ Tool *BareMetal::buildLinker() const {
+diff --git a/libcxx/include/cmath b/libcxx/include/cmath
+index adf83c2b0a7b..2089a2555bec 100644
+--- a/libcxx/include/cmath
++++ b/libcxx/include/cmath
+@@ -531,7 +531,9 @@ using ::truncl _LIBCPP_USING_IF_EXISTS;
+ #if _LIBCPP_STD_VER > 14
+ inline _LIBCPP_INLINE_VISIBILITY float       hypot(       float x,       float y,       float z ) { return sqrt(x*x + y*y + z*z); }
+ inline _LIBCPP_INLINE_VISIBILITY double      hypot(      double x,      double y,      double z ) { return sqrt(x*x + y*y + z*z); }
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double hypot( long double x, long double y, long double z ) { return sqrt(x*x + y*y + z*z); }
++#endif
+ 
+ template <class _A1, class _A2, class _A3>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -633,8 +635,10 @@ lerp(float __a, float __b, float __t)                   _NOEXCEPT { return __ler
+ constexpr double
+ lerp(double __a, double __b, double __t)                _NOEXCEPT { return __lerp(__a, __b, __t); }
+ 
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ constexpr long double
+ lerp(long double __a, long double __b, long double __t) _NOEXCEPT { return __lerp(__a, __b, __t); }
++#endif
+ 
+ #endif // _LIBCPP_STD_VER > 17
+ 
+diff --git a/libcxx/include/math.h b/libcxx/include/math.h
+index 77762d554512..601c43330434 100644
+--- a/libcxx/include/math.h
++++ b/libcxx/include/math.h
+@@ -790,8 +790,10 @@ isunordered(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       acos(float __lcpp_x) _NOEXCEPT       {return ::acosf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double acos(long double __lcpp_x) _NOEXCEPT {return ::acosl(__lcpp_x);}
+ #endif
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -802,8 +804,10 @@ acos(_A1 __lcpp_x) _NOEXCEPT {return ::acos((double)__lcpp_x);}
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       asin(float __lcpp_x) _NOEXCEPT       {return ::asinf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double asin(long double __lcpp_x) _NOEXCEPT {return ::asinl(__lcpp_x);}
+ #endif
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -814,8 +818,10 @@ asin(_A1 __lcpp_x) _NOEXCEPT {return ::asin((double)__lcpp_x);}
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       atan(float __lcpp_x) _NOEXCEPT       {return ::atanf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double atan(long double __lcpp_x) _NOEXCEPT {return ::atanl(__lcpp_x);}
+ #endif
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -826,8 +832,10 @@ atan(_A1 __lcpp_x) _NOEXCEPT {return ::atan((double)__lcpp_x);}
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       atan2(float __lcpp_y, float __lcpp_x) _NOEXCEPT             {return ::atan2f(__lcpp_y, __lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double atan2(long double __lcpp_y, long double __lcpp_x) _NOEXCEPT {return ::atan2l(__lcpp_y, __lcpp_x);}
+ #endif
++#endif
+ 
+ template <class _A1, class _A2>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -849,8 +857,10 @@ atan2(_A1 __lcpp_y, _A2 __lcpp_x) _NOEXCEPT
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       ceil(float __lcpp_x) _NOEXCEPT       {return ::ceilf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double ceil(long double __lcpp_x) _NOEXCEPT {return ::ceill(__lcpp_x);}
+ #endif
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -861,8 +871,10 @@ ceil(_A1 __lcpp_x) _NOEXCEPT {return ::ceil((double)__lcpp_x);}
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       cos(float __lcpp_x) _NOEXCEPT       {return ::cosf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double cos(long double __lcpp_x) _NOEXCEPT {return ::cosl(__lcpp_x);}
+ #endif
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -873,8 +885,10 @@ cos(_A1 __lcpp_x) _NOEXCEPT {return ::cos((double)__lcpp_x);}
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       cosh(float __lcpp_x) _NOEXCEPT       {return ::coshf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double cosh(long double __lcpp_x) _NOEXCEPT {return ::coshl(__lcpp_x);}
+ #endif
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -885,8 +899,10 @@ cosh(_A1 __lcpp_x) _NOEXCEPT {return ::cosh((double)__lcpp_x);}
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       exp(float __lcpp_x) _NOEXCEPT       {return ::expf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double exp(long double __lcpp_x) _NOEXCEPT {return ::expl(__lcpp_x);}
+ #endif
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -897,8 +913,10 @@ exp(_A1 __lcpp_x) _NOEXCEPT {return ::exp((double)__lcpp_x);}
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       fabs(float __lcpp_x) _NOEXCEPT       {return ::fabsf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double fabs(long double __lcpp_x) _NOEXCEPT {return ::fabsl(__lcpp_x);}
+ #endif
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -909,8 +927,10 @@ fabs(_A1 __lcpp_x) _NOEXCEPT {return ::fabs((double)__lcpp_x);}
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       floor(float __lcpp_x) _NOEXCEPT       {return ::floorf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double floor(long double __lcpp_x) _NOEXCEPT {return ::floorl(__lcpp_x);}
+ #endif
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -921,8 +941,10 @@ floor(_A1 __lcpp_x) _NOEXCEPT {return ::floor((double)__lcpp_x);}
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       fmod(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::fmodf(__lcpp_x, __lcpp_y);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double fmod(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::fmodl(__lcpp_x, __lcpp_y);}
+ #endif
++#endif
+ 
+ template <class _A1, class _A2>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -944,8 +966,10 @@ fmod(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       frexp(float __lcpp_x, int* __lcpp_e) _NOEXCEPT       {return ::frexpf(__lcpp_x, __lcpp_e);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double frexp(long double __lcpp_x, int* __lcpp_e) _NOEXCEPT {return ::frexpl(__lcpp_x, __lcpp_e);}
+ #endif
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -956,8 +980,10 @@ frexp(_A1 __lcpp_x, int* __lcpp_e) _NOEXCEPT {return ::frexp((double)__lcpp_x, _
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       ldexp(float __lcpp_x, int __lcpp_e) _NOEXCEPT       {return ::ldexpf(__lcpp_x, __lcpp_e);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double ldexp(long double __lcpp_x, int __lcpp_e) _NOEXCEPT {return ::ldexpl(__lcpp_x, __lcpp_e);}
+ #endif
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -968,8 +994,10 @@ ldexp(_A1 __lcpp_x, int __lcpp_e) _NOEXCEPT {return ::ldexp((double)__lcpp_x, __
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       log(float __lcpp_x) _NOEXCEPT       {return ::logf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double log(long double __lcpp_x) _NOEXCEPT {return ::logl(__lcpp_x);}
+ #endif
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -980,8 +1008,10 @@ log(_A1 __lcpp_x) _NOEXCEPT {return ::log((double)__lcpp_x);}
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       log10(float __lcpp_x) _NOEXCEPT       {return ::log10f(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double log10(long double __lcpp_x) _NOEXCEPT {return ::log10l(__lcpp_x);}
+ #endif
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -992,15 +1022,19 @@ log10(_A1 __lcpp_x) _NOEXCEPT {return ::log10((double)__lcpp_x);}
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       modf(float __lcpp_x, float* __lcpp_y) _NOEXCEPT             {return ::modff(__lcpp_x, __lcpp_y);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double modf(long double __lcpp_x, long double* __lcpp_y) _NOEXCEPT {return ::modfl(__lcpp_x, __lcpp_y);}
+ #endif
++#endif
+ 
+ // pow
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       pow(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::powf(__lcpp_x, __lcpp_y);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double pow(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::powl(__lcpp_x, __lcpp_y);}
+ #endif
++#endif
+ 
+ template <class _A1, class _A2>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1022,8 +1056,10 @@ pow(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       sin(float __lcpp_x) _NOEXCEPT       {return ::sinf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double sin(long double __lcpp_x) _NOEXCEPT {return ::sinl(__lcpp_x);}
+ #endif
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1034,8 +1070,10 @@ sin(_A1 __lcpp_x) _NOEXCEPT {return ::sin((double)__lcpp_x);}
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       sinh(float __lcpp_x) _NOEXCEPT       {return ::sinhf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double sinh(long double __lcpp_x) _NOEXCEPT {return ::sinhl(__lcpp_x);}
+ #endif
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1046,8 +1084,10 @@ sinh(_A1 __lcpp_x) _NOEXCEPT {return ::sinh((double)__lcpp_x);}
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       sqrt(float __lcpp_x) _NOEXCEPT       {return ::sqrtf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double sqrt(long double __lcpp_x) _NOEXCEPT {return ::sqrtl(__lcpp_x);}
+ #endif
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1058,8 +1098,10 @@ sqrt(_A1 __lcpp_x) _NOEXCEPT {return ::sqrt((double)__lcpp_x);}
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       tan(float __lcpp_x) _NOEXCEPT       {return ::tanf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double tan(long double __lcpp_x) _NOEXCEPT {return ::tanl(__lcpp_x);}
+ #endif
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1070,8 +1112,10 @@ tan(_A1 __lcpp_x) _NOEXCEPT {return ::tan((double)__lcpp_x);}
+ 
+ #if !(defined(_AIX) || defined(__sun__))
+ inline _LIBCPP_INLINE_VISIBILITY float       tanh(float __lcpp_x) _NOEXCEPT       {return ::tanhf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double tanh(long double __lcpp_x) _NOEXCEPT {return ::tanhl(__lcpp_x);}
+ #endif
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1081,7 +1125,9 @@ tanh(_A1 __lcpp_x) _NOEXCEPT {return ::tanh((double)__lcpp_x);}
+ // acosh
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       acosh(float __lcpp_x) _NOEXCEPT       {return ::acoshf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double acosh(long double __lcpp_x) _NOEXCEPT {return ::acoshl(__lcpp_x);}
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1091,7 +1137,9 @@ acosh(_A1 __lcpp_x) _NOEXCEPT {return ::acosh((double)__lcpp_x);}
+ // asinh
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       asinh(float __lcpp_x) _NOEXCEPT       {return ::asinhf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double asinh(long double __lcpp_x) _NOEXCEPT {return ::asinhl(__lcpp_x);}
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1101,7 +1149,10 @@ asinh(_A1 __lcpp_x) _NOEXCEPT {return ::asinh((double)__lcpp_x);}
+ // atanh
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       atanh(float __lcpp_x) _NOEXCEPT       {return ::atanhf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double atanh(long double __lcpp_x) _NOEXCEPT {return ::atanhl(__lcpp_x);}
++#endif
++
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1111,7 +1162,9 @@ atanh(_A1 __lcpp_x) _NOEXCEPT {return ::atanh((double)__lcpp_x);}
+ // cbrt
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       cbrt(float __lcpp_x) _NOEXCEPT       {return ::cbrtf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double cbrt(long double __lcpp_x) _NOEXCEPT {return ::cbrtl(__lcpp_x);}
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1142,6 +1195,7 @@ inline _LIBCPP_INLINE_VISIBILITY double __libcpp_copysign(double __lcpp_x, doubl
+ #endif
+ }
+ 
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ #if __has_builtin(__builtin_copysignl)
+ _LIBCPP_CONSTEXPR
+ #endif
+@@ -1152,6 +1206,7 @@ inline _LIBCPP_INLINE_VISIBILITY long double __libcpp_copysign(long double __lcp
+   return ::copysignl(__lcpp_x, __lcpp_y);
+ #endif
+ }
++#endif
+ 
+ template <class _A1, class _A2>
+ #if __has_builtin(__builtin_copysign)
+@@ -1179,9 +1234,11 @@ inline _LIBCPP_INLINE_VISIBILITY float copysign(float __lcpp_x, float __lcpp_y)
+   return ::__libcpp_copysign(__lcpp_x, __lcpp_y);
+ }
+ 
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double copysign(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {
+   return ::__libcpp_copysign(__lcpp_x, __lcpp_y);
+ }
++#endif
+ 
+ template <class _A1, class _A2>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1198,7 +1255,9 @@ typename std::_EnableIf
+ // erf
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       erf(float __lcpp_x) _NOEXCEPT       {return ::erff(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double erf(long double __lcpp_x) _NOEXCEPT {return ::erfl(__lcpp_x);}
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1208,7 +1267,9 @@ erf(_A1 __lcpp_x) _NOEXCEPT {return ::erf((double)__lcpp_x);}
+ // erfc
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       erfc(float __lcpp_x) _NOEXCEPT       {return ::erfcf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double erfc(long double __lcpp_x) _NOEXCEPT {return ::erfcl(__lcpp_x);}
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1218,7 +1279,9 @@ erfc(_A1 __lcpp_x) _NOEXCEPT {return ::erfc((double)__lcpp_x);}
+ // exp2
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       exp2(float __lcpp_x) _NOEXCEPT       {return ::exp2f(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double exp2(long double __lcpp_x) _NOEXCEPT {return ::exp2l(__lcpp_x);}
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1228,7 +1291,9 @@ exp2(_A1 __lcpp_x) _NOEXCEPT {return ::exp2((double)__lcpp_x);}
+ // expm1
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       expm1(float __lcpp_x) _NOEXCEPT       {return ::expm1f(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double expm1(long double __lcpp_x) _NOEXCEPT {return ::expm1l(__lcpp_x);}
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1238,7 +1303,9 @@ expm1(_A1 __lcpp_x) _NOEXCEPT {return ::expm1((double)__lcpp_x);}
+ // fdim
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       fdim(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::fdimf(__lcpp_x, __lcpp_y);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double fdim(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::fdiml(__lcpp_x, __lcpp_y);}
++#endif
+ 
+ template <class _A1, class _A2>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1266,6 +1333,7 @@ inline _LIBCPP_INLINE_VISIBILITY float       fma(float __lcpp_x, float __lcpp_y,
+     return ::fmaf(__lcpp_x, __lcpp_y, __lcpp_z);
+ #endif
+ }
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double fma(long double __lcpp_x, long double __lcpp_y, long double __lcpp_z) _NOEXCEPT
+ {
+ #if __has_builtin(__builtin_fmal)
+@@ -1274,6 +1342,7 @@ inline _LIBCPP_INLINE_VISIBILITY long double fma(long double __lcpp_x, long doub
+     return ::fmal(__lcpp_x, __lcpp_y, __lcpp_z);
+ #endif
+ }
++#endif
+ 
+ template <class _A1, class _A2, class _A3>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1300,7 +1369,9 @@ fma(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) _NOEXCEPT
+ // fmax
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       fmax(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::fmaxf(__lcpp_x, __lcpp_y);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double fmax(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::fmaxl(__lcpp_x, __lcpp_y);}
++#endif
+ 
+ template <class _A1, class _A2>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1321,7 +1392,9 @@ fmax(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+ // fmin
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       fmin(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::fminf(__lcpp_x, __lcpp_y);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double fmin(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::fminl(__lcpp_x, __lcpp_y);}
++#endif
+ 
+ template <class _A1, class _A2>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1342,7 +1415,9 @@ fmin(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+ // hypot
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       hypot(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::hypotf(__lcpp_x, __lcpp_y);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double hypot(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::hypotl(__lcpp_x, __lcpp_y);}
++#endif
+ 
+ template <class _A1, class _A2>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1363,7 +1438,9 @@ hypot(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+ // ilogb
+ 
+ inline _LIBCPP_INLINE_VISIBILITY int ilogb(float __lcpp_x) _NOEXCEPT       {return ::ilogbf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY int ilogb(long double __lcpp_x) _NOEXCEPT {return ::ilogbl(__lcpp_x);}
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1373,7 +1450,9 @@ ilogb(_A1 __lcpp_x) _NOEXCEPT {return ::ilogb((double)__lcpp_x);}
+ // lgamma
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       lgamma(float __lcpp_x) _NOEXCEPT       {return ::lgammaf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double lgamma(long double __lcpp_x) _NOEXCEPT {return ::lgammal(__lcpp_x);}
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1390,6 +1469,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llrint(float __lcpp_x) _NOEXCEPT
+     return ::llrintf(__lcpp_x);
+ #endif
+ }
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long long llrint(long double __lcpp_x) _NOEXCEPT
+ {
+ #if __has_builtin(__builtin_llrintl)
+@@ -1398,6 +1478,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llrint(long double __lcpp_x) _NOEXCEP
+     return ::llrintl(__lcpp_x);
+ #endif
+ }
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1421,6 +1502,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llround(float __lcpp_x) _NOEXCEPT
+     return ::llroundf(__lcpp_x);
+ #endif
+ }
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long long llround(long double __lcpp_x) _NOEXCEPT
+ {
+ #if __has_builtin(__builtin_llroundl)
+@@ -1429,6 +1511,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llround(long double __lcpp_x) _NOEXCE
+     return ::llroundl(__lcpp_x);
+ #endif
+ }
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1445,7 +1528,9 @@ llround(_A1 __lcpp_x) _NOEXCEPT
+ // log1p
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       log1p(float __lcpp_x) _NOEXCEPT       {return ::log1pf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double log1p(long double __lcpp_x) _NOEXCEPT {return ::log1pl(__lcpp_x);}
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1455,7 +1540,9 @@ log1p(_A1 __lcpp_x) _NOEXCEPT {return ::log1p((double)__lcpp_x);}
+ // log2
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       log2(float __lcpp_x) _NOEXCEPT       {return ::log2f(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double log2(long double __lcpp_x) _NOEXCEPT {return ::log2l(__lcpp_x);}
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1465,7 +1552,9 @@ log2(_A1 __lcpp_x) _NOEXCEPT {return ::log2((double)__lcpp_x);}
+ // logb
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       logb(float __lcpp_x) _NOEXCEPT       {return ::logbf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double logb(long double __lcpp_x) _NOEXCEPT {return ::logbl(__lcpp_x);}
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1539,7 +1628,9 @@ lround(_A1 __lcpp_x) _NOEXCEPT
+ // nearbyint
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       nearbyint(float __lcpp_x) _NOEXCEPT       {return ::nearbyintf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double nearbyint(long double __lcpp_x) _NOEXCEPT {return ::nearbyintl(__lcpp_x);}
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1549,7 +1640,9 @@ nearbyint(_A1 __lcpp_x) _NOEXCEPT {return ::nearbyint((double)__lcpp_x);}
+ // nextafter
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       nextafter(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::nextafterf(__lcpp_x, __lcpp_y);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double nextafter(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::nextafterl(__lcpp_x, __lcpp_y);}
++#endif
+ 
+ template <class _A1, class _A2>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1569,6 +1662,7 @@ nextafter(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+ 
+ // nexttoward
+ 
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY float       nexttoward(float __lcpp_x, long double __lcpp_y) _NOEXCEPT       {return ::nexttowardf(__lcpp_x, __lcpp_y);}
+ inline _LIBCPP_INLINE_VISIBILITY long double nexttoward(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::nexttowardl(__lcpp_x, __lcpp_y);}
+ 
+@@ -1576,11 +1670,14 @@ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+ typename std::enable_if<std::is_integral<_A1>::value, double>::type
+ nexttoward(_A1 __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::nexttoward((double)__lcpp_x, __lcpp_y);}
++#endif
+ 
+ // remainder
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       remainder(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::remainderf(__lcpp_x, __lcpp_y);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double remainder(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::remainderl(__lcpp_x, __lcpp_y);}
++#endif
+ 
+ template <class _A1, class _A2>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1601,7 +1698,9 @@ remainder(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+ // remquo
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       remquo(float __lcpp_x, float __lcpp_y, int* __lcpp_z) _NOEXCEPT             {return ::remquof(__lcpp_x, __lcpp_y, __lcpp_z);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double remquo(long double __lcpp_x, long double __lcpp_y, int* __lcpp_z) _NOEXCEPT {return ::remquol(__lcpp_x, __lcpp_y, __lcpp_z);}
++#endif
+ 
+ template <class _A1, class _A2>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1684,7 +1783,9 @@ round(_A1 __lcpp_x) _NOEXCEPT
+ // scalbln
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       scalbln(float __lcpp_x, long __lcpp_y) _NOEXCEPT       {return ::scalblnf(__lcpp_x, __lcpp_y);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double scalbln(long double __lcpp_x, long __lcpp_y) _NOEXCEPT {return ::scalblnl(__lcpp_x, __lcpp_y);}
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1694,7 +1795,9 @@ scalbln(_A1 __lcpp_x, long __lcpp_y) _NOEXCEPT {return ::scalbln((double)__lcpp_
+ // scalbn
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       scalbn(float __lcpp_x, int __lcpp_y) _NOEXCEPT       {return ::scalbnf(__lcpp_x, __lcpp_y);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double scalbn(long double __lcpp_x, int __lcpp_y) _NOEXCEPT {return ::scalbnl(__lcpp_x, __lcpp_y);}
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+@@ -1704,7 +1807,9 @@ scalbn(_A1 __lcpp_x, int __lcpp_y) _NOEXCEPT {return ::scalbn((double)__lcpp_x,
+ // tgamma
+ 
+ inline _LIBCPP_INLINE_VISIBILITY float       tgamma(float __lcpp_x) _NOEXCEPT       {return ::tgammaf(__lcpp_x);}
++#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
+ inline _LIBCPP_INLINE_VISIBILITY long double tgamma(long double __lcpp_x) _NOEXCEPT {return ::tgammal(__lcpp_x);}
++#endif
+ 
+ template <class _A1>
+ inline _LIBCPP_INLINE_VISIBILITY
+diff --git a/llvm/lib/Support/CommandLine.cpp b/llvm/lib/Support/CommandLine.cpp
+index 6c140863b13c..caab14d29020 100644
+--- a/llvm/lib/Support/CommandLine.cpp
++++ b/llvm/lib/Support/CommandLine.cpp
+@@ -1112,12 +1112,57 @@ static llvm::Error ExpandResponseFile(
+   if (!RelativeNames)
+     return Error::success();
+   llvm::StringRef BasePath = llvm::sys::path::parent_path(FName);
+-  // If names of nested response files should be resolved relative to including
+-  // file, replace the included response file names with their full paths
+-  // obtained by required resolution.
++
++  // There is some semantics to the config file syntax.
++  // TODO: think about the syntax a bit, currently it's rather crude.
+   for (auto &Arg : NewArgv) {
++    if (!Arg)
++      continue;
++
++    // Recognize variables when they start with $
++    // The special variable $@ expands to the current path
++    // To get a literal $, use $$
++    StringRef Val(Arg);
++    StringRef::size_type Pos = Val.find('$');
++    if (Pos != StringRef::npos) {
++      SmallString<128> ExpandedVar;
++      size_t from = 0;
++
++      do {
++        //copy until variable
++        ExpandedVar.append(Val.substr(from, Pos));
++
++        // handle variable
++        Pos++;
++        switch (Val[Pos]) {
++        case '$':
++          ExpandedVar.append(1, '$');
++          break;
++        case '@':
++          ExpandedVar.append(llvm::sys::path::parent_path(FName));
++          break;
++        default:
++          // TODO: emit diagnostic
++          assert(!"unknown variable in config file");
++          break;
++        }
++        Pos++;
++
++        //continue the search
++        from = Pos;
++        Pos = Val.find('$', from);
++      } while (Pos != StringRef::npos);
++
++      //copy the rest of the argument over
++      ExpandedVar.append(Val.substr(from));
++      Arg = Saver.save(ExpandedVar.c_str()).data();
++    }
++    // If names of nested response files should be resolved relative to including
++    // file, replace the included response file names with their full paths
++    // obtained by required resolution.
++
+     // Skip non-rsp file arguments.
+-    if (!Arg || Arg[0] != '@')
++    if (Arg[0] != '@')
+       continue;
+ 
+     StringRef FileName(Arg + 1);

--- a/patches/newlib-4.1.0-llvm-13.patch
+++ b/patches/newlib-4.1.0-llvm-13.patch
@@ -1,0 +1,315 @@
+diff --git a/libgloss/arm/crt0.S b/libgloss/arm/crt0.S
+index 8490bde2f..8b85b28f4 100644
+--- a/libgloss/arm/crt0.S
++++ b/libgloss/arm/crt0.S
+@@ -565,7 +565,7 @@ change_back:
+ 
+ 	/* For Thumb, constants must be after the code since only 
+ 	   positive offsets are supported for PC relative addresses.  */
+-	.align 0
++	.p2align 2
+ .LC0:
+ #ifdef ARM_RDI_MONITOR
+ 	.word	HeapBase
+diff --git a/libgloss/arm/linux-crt0.c b/libgloss/arm/linux-crt0.c
+index 6b2d62a9b..000a2c728 100644
+--- a/libgloss/arm/linux-crt0.c
++++ b/libgloss/arm/linux-crt0.c
+@@ -29,7 +29,7 @@ asm("\n"
+ __attribute__((naked, used))
+ static void _start_thumb(void)
+ #else
+-__attribute__((naked))
++//__attribute__((naked))
+ void _start(void)
+ #endif
+ {
+diff --git a/libgloss/arm/syscalls.c b/libgloss/arm/syscalls.c
+index fc394f94b..0b3287df4 100644
+--- a/libgloss/arm/syscalls.c
++++ b/libgloss/arm/syscalls.c
+@@ -180,7 +180,7 @@ initialise_monitor_handles (void)
+   const char * name;
+ 
+   name = ":tt";
+-  asm ("mov r0,%2; mov r1, #0; swi %a1; mov %0, r0"
++  asm ("movs r0,%2; movs r1, #0; swi %a1; mov %0, r0"
+        : "=r"(fh)
+        : "i" (SWI_Open),"r"(name)
+        : "r0","r1");
+@@ -189,14 +189,14 @@ initialise_monitor_handles (void)
+   if (_has_ext_stdout_stderr ())
+   {
+     name = ":tt";
+-    asm ("mov r0,%2; mov r1, #4; swi %a1; mov %0, r0"
++    asm ("movs r0,%2; movs r1, #4; swi %a1; mov %0, r0"
+ 	 : "=r"(fh)
+ 	 : "i" (SWI_Open),"r"(name)
+ 	 : "r0","r1");
+     monitor_stdout = fh;
+ 
+     name = ":tt";
+-    asm ("mov r0,%2; mov r1, #8; swi %a1; mov %0, r0"
++    asm ("movs r0,%2; movs r1, #8; swi %a1; mov %0, r0"
+ 	 : "=r"(fh)
+ 	 : "i" (SWI_Open),"r"(name)
+ 	 : "r0","r1");
+diff --git a/libgloss/arm/trap.S b/libgloss/arm/trap.S
+index 845ad0173..2056c2adf 100644
+--- a/libgloss/arm/trap.S
++++ b/libgloss/arm/trap.S
+@@ -5,7 +5,7 @@
+ 
+ /* .text is used instead of .section .text so it works with arm-aout too.  */
+ 	.text
+-        .align 0
++        .p2align 2
+         .global __rt_stkovf_split_big
+         .global __rt_stkovf_split_small
+ 
+diff --git a/libgloss/libnosys/configure b/libgloss/libnosys/configure
+index 7c23c7a0a..2fc584169 100755
+--- a/libgloss/libnosys/configure
++++ b/libgloss/libnosys/configure
+@@ -2058,7 +2058,7 @@ case "${target}" in
+ esac
+ 
+ case "${target}" in
+-  *-*-elf)
++  *-*-elf|*-*-eabi*)
+         $as_echo "#define HAVE_ELF 1" >>confdefs.h
+ 
+ 
+diff --git a/newlib/libc/machine/aarch64/memchr.S b/newlib/libc/machine/aarch64/memchr.S
+index 53f5d6bc0..81fcecccd 100644
+--- a/newlib/libc/machine/aarch64/memchr.S
++++ b/newlib/libc/machine/aarch64/memchr.S
+@@ -110,7 +110,7 @@ def_fn memchr
+ 	and	vhas_chr2.16b, vhas_chr2.16b, vrepmask.16b
+ 	addp	vend.16b, vhas_chr1.16b, vhas_chr2.16b		/* 256->128 */
+ 	addp	vend.16b, vend.16b, vend.16b			/* 128->64 */
+-	mov	synd, vend.2d[0]
++	mov	synd, vend.d[0]
+ 	/* Clear the soff*2 lower bits */
+ 	lsl	tmp, soff, #1
+ 	lsr	synd, synd, tmp
+@@ -130,7 +130,7 @@ def_fn memchr
+ 	/* Use a fast check for the termination condition */
+ 	orr	vend.16b, vhas_chr1.16b, vhas_chr2.16b
+ 	addp	vend.2d, vend.2d, vend.2d
+-	mov	synd, vend.2d[0]
++	mov	synd, vend.d[0]
+ 	/* We're not out of data, loop if we haven't found the character */
+ 	cbz	synd, .Lloop
+ 
+@@ -140,7 +140,7 @@ def_fn memchr
+ 	and	vhas_chr2.16b, vhas_chr2.16b, vrepmask.16b
+ 	addp	vend.16b, vhas_chr1.16b, vhas_chr2.16b		/* 256->128 */
+ 	addp	vend.16b, vend.16b, vend.16b			/* 128->64 */
+-	mov	synd, vend.2d[0]
++	mov	synd, vend.d[0]
+ 	/* Only do the clear for the last possible block */
+ 	b.hi	.Ltail
+ 
+diff --git a/newlib/libc/machine/aarch64/strchr.S b/newlib/libc/machine/aarch64/strchr.S
+index 2448dbc7d..706107836 100644
+--- a/newlib/libc/machine/aarch64/strchr.S
++++ b/newlib/libc/machine/aarch64/strchr.S
+@@ -117,7 +117,7 @@ def_fn strchr
+ 	addp	vend1.16b, vend1.16b, vend2.16b		// 128->64
+ 	lsr	tmp1, tmp3, tmp1
+ 
+-	mov	tmp3, vend1.2d[0]
++	mov	tmp3, vend1.d[0]
+ 	bic	tmp1, tmp3, tmp1	// Mask padding bits.
+ 	cbnz	tmp1, .Ltail
+ 
+@@ -132,7 +132,7 @@ def_fn strchr
+ 	orr	vend2.16b, vhas_nul2.16b, vhas_chr2.16b
+ 	orr	vend1.16b, vend1.16b, vend2.16b
+ 	addp	vend1.2d, vend1.2d, vend1.2d
+-	mov	tmp1, vend1.2d[0]
++	mov	tmp1, vend1.d[0]
+ 	cbz	tmp1, .Lloop
+ 
+ 	/* Termination condition found.  Now need to establish exactly why
+@@ -146,7 +146,7 @@ def_fn strchr
+ 	addp	vend1.16b, vend1.16b, vend2.16b		// 256->128
+ 	addp	vend1.16b, vend1.16b, vend2.16b		// 128->64
+ 
+-	mov	tmp1, vend1.2d[0]
++	mov	tmp1, vend1.d[0]
+ .Ltail:
+ 	/* Count the trailing zeros, by bit reversing...  */
+ 	rbit	tmp1, tmp1
+diff --git a/newlib/libc/machine/aarch64/strchrnul.S b/newlib/libc/machine/aarch64/strchrnul.S
+index a0ac13b7f..fd2002f0d 100644
+--- a/newlib/libc/machine/aarch64/strchrnul.S
++++ b/newlib/libc/machine/aarch64/strchrnul.S
+@@ -109,7 +109,7 @@ def_fn strchrnul
+ 	addp	vend1.16b, vend1.16b, vend1.16b		// 128->64
+ 	lsr	tmp1, tmp3, tmp1
+ 
+-	mov	tmp3, vend1.2d[0]
++	mov	tmp3, vend1.d[0]
+ 	bic	tmp1, tmp3, tmp1	// Mask padding bits.
+ 	cbnz	tmp1, .Ltail
+ 
+@@ -124,7 +124,7 @@ def_fn strchrnul
+ 	orr	vhas_chr2.16b, vhas_nul2.16b, vhas_chr2.16b
+ 	orr	vend1.16b, vhas_chr1.16b, vhas_chr2.16b
+ 	addp	vend1.2d, vend1.2d, vend1.2d
+-	mov	tmp1, vend1.2d[0]
++	mov	tmp1, vend1.d[0]
+ 	cbz	tmp1, .Lloop
+ 
+ 	/* Termination condition found.  Now need to establish exactly why
+@@ -134,7 +134,7 @@ def_fn strchrnul
+ 	addp	vend1.16b, vhas_chr1.16b, vhas_chr2.16b		// 256->128
+ 	addp	vend1.16b, vend1.16b, vend1.16b		// 128->64
+ 
+-	mov	tmp1, vend1.2d[0]
++	mov	tmp1, vend1.d[0]
+ .Ltail:
+ 	/* Count the trailing zeros, by bit reversing...  */
+ 	rbit	tmp1, tmp1
+diff --git a/newlib/libc/machine/aarch64/strrchr.S b/newlib/libc/machine/aarch64/strrchr.S
+index d64fc09b1..1b6f07562 100644
+--- a/newlib/libc/machine/aarch64/strrchr.S
++++ b/newlib/libc/machine/aarch64/strrchr.S
+@@ -120,10 +120,10 @@ def_fn strrchr
+ 	addp	vhas_chr1.16b, vhas_chr1.16b, vhas_chr2.16b	// 256->128
+ 	addp	vhas_nul1.16b, vhas_nul1.16b, vhas_nul1.16b	// 128->64
+ 	addp	vhas_chr1.16b, vhas_chr1.16b, vhas_chr1.16b	// 128->64
+-	mov	nul_match, vhas_nul1.2d[0]
++	mov	nul_match, vhas_nul1.d[0]
+ 	lsl	tmp1, tmp1, #1
+ 	mov	const_m1, #~0
+-	mov	chr_match, vhas_chr1.2d[0]
++	mov	chr_match, vhas_chr1.d[0]
+ 	lsr	tmp3, const_m1, tmp1
+ 
+ 	bic	nul_match, nul_match, tmp3	// Mask padding bits.
+@@ -146,15 +146,15 @@ def_fn strrchr
+ 	addp	vhas_chr1.16b, vhas_chr1.16b, vhas_chr2.16b	// 256->128
+ 	addp	vend1.16b, vend1.16b, vend1.16b	// 128->64
+ 	addp	vhas_chr1.16b, vhas_chr1.16b, vhas_chr1.16b	// 128->64
+-	mov	nul_match, vend1.2d[0]
+-	mov	chr_match, vhas_chr1.2d[0]
++	mov	nul_match, vend1.d[0]
++	mov	chr_match, vhas_chr1.d[0]
+ 	cbz	nul_match, .Lloop
+ 
+ 	and	vhas_nul1.16b, vhas_nul1.16b, vrepmask_0.16b
+ 	and	vhas_nul2.16b, vhas_nul2.16b, vrepmask_0.16b
+ 	addp	vhas_nul1.16b, vhas_nul1.16b, vhas_nul2.16b
+ 	addp	vhas_nul1.16b, vhas_nul1.16b, vhas_nul1.16b
+-	mov	nul_match, vhas_nul1.2d[0]
++	mov	nul_match, vhas_nul1.d[0]
+ 
+ .Ltail:
+ 	/* Work out exactly where the string ends.  */
+diff --git a/newlib/libc/sys/arm/crt0.S b/newlib/libc/sys/arm/crt0.S
+index 5e677a23c..6faf74096 100644
+--- a/newlib/libc/sys/arm/crt0.S
++++ b/newlib/libc/sys/arm/crt0.S
+@@ -556,7 +556,7 @@ change_back:
+ 
+ 	/* For Thumb, constants must be after the code since only 
+ 	   positive offsets are supported for PC relative addresses.  */
+-	.align 0
++	.p2align 2
+ .LC0:
+ #ifdef ARM_RDI_MONITOR
+ 	.word	HeapBase
+diff --git a/newlib/libc/sys/arm/trap.S b/newlib/libc/sys/arm/trap.S
+index 681b3dbe0..8a49f39f3 100644
+--- a/newlib/libc/sys/arm/trap.S
++++ b/newlib/libc/sys/arm/trap.S
+@@ -4,7 +4,7 @@
+ 
+ /* .text is used instead of .section .text so it works with arm-aout too.  */
+ 	.text
+-        .align 0
++        .p2align 2
+         .global __rt_stkovf_split_big
+         .global __rt_stkovf_split_small
+ 
+diff --git a/newlib/libm/machine/arm/sf_ceil.c b/newlib/libm/machine/arm/sf_ceil.c
+index b6efbff0b..44fdf834a 100644
+--- a/newlib/libm/machine/arm/sf_ceil.c
++++ b/newlib/libm/machine/arm/sf_ceil.c
+@@ -24,7 +24,7 @@
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ 
+-#if __ARM_ARCH >= 8 && !defined (__SOFTFP__)
++#if __ARM_ARCH >= 8 && (__ARM_FP & 0x4) && !defined (__SOFTFP__)
+ #include <math.h>
+ 
+ float
+diff --git a/newlib/libm/machine/arm/sf_floor.c b/newlib/libm/machine/arm/sf_floor.c
+index 7bc95808c..44c38c42c 100644
+--- a/newlib/libm/machine/arm/sf_floor.c
++++ b/newlib/libm/machine/arm/sf_floor.c
+@@ -24,7 +24,7 @@
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ 
+-#if __ARM_ARCH >= 8 && !defined (__SOFTFP__)
++#if __ARM_ARCH >= 8 && (__ARM_FP & 0x4) && !defined (__SOFTFP__)
+ #include <math.h>
+ 
+ float
+diff --git a/newlib/libm/machine/arm/sf_nearbyint.c b/newlib/libm/machine/arm/sf_nearbyint.c
+index c70d84442..126673e97 100644
+--- a/newlib/libm/machine/arm/sf_nearbyint.c
++++ b/newlib/libm/machine/arm/sf_nearbyint.c
+@@ -24,7 +24,7 @@
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ 
+-#if __ARM_ARCH >= 8 && !defined (__SOFTFP__)
++#if __ARM_ARCH >= 8 && (__ARM_FP & 0x4) && !defined (__SOFTFP__)
+ #include <math.h>
+ 
+ float
+diff --git a/newlib/libm/machine/arm/sf_rint.c b/newlib/libm/machine/arm/sf_rint.c
+index d9c383a7e..5def21009 100644
+--- a/newlib/libm/machine/arm/sf_rint.c
++++ b/newlib/libm/machine/arm/sf_rint.c
+@@ -24,7 +24,7 @@
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ 
+-#if __ARM_ARCH >= 8 && !defined (__SOFTFP__)
++#if __ARM_ARCH >= 8 && (__ARM_FP & 0x4) && !defined (__SOFTFP__)
+ #include <math.h>
+ 
+ float
+diff --git a/newlib/libm/machine/arm/sf_round.c b/newlib/libm/machine/arm/sf_round.c
+index 232fc0848..88c53ba13 100644
+--- a/newlib/libm/machine/arm/sf_round.c
++++ b/newlib/libm/machine/arm/sf_round.c
+@@ -24,7 +24,7 @@
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ 
+-#if __ARM_ARCH >= 8 && !defined (__SOFTFP__)
++#if __ARM_ARCH >= 8 && (__ARM_FP & 0x4) && !defined (__SOFTFP__)
+ #include <math.h>
+ 
+ float
+diff --git a/newlib/libm/machine/arm/sf_trunc.c b/newlib/libm/machine/arm/sf_trunc.c
+index 64e4aeb9a..c08fa6fed 100644
+--- a/newlib/libm/machine/arm/sf_trunc.c
++++ b/newlib/libm/machine/arm/sf_trunc.c
+@@ -24,7 +24,7 @@
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ 
+-#if __ARM_ARCH >= 8 && !defined (__SOFTFP__)
++#if __ARM_ARCH >= 8 && (__ARM_FP & 0x4) && !defined (__SOFTFP__)
+ #include <math.h>
+ 
+ float

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -46,8 +46,8 @@ def parse_args_to_config() -> Config:
     )
     parser.add_argument('-v', '--verbose', help='log more information',
                         action='store_true')
-    parser.add_argument('-r', '--revision', metavar='R', default='0.1',
-                        help='revision to build (default: 0.1)')
+    parser.add_argument('-r', '--revision', metavar='R', default='13.0.0',
+                        help='revision to build (default: 13.0.0)')
     variant_names = sorted(config.LIBRARY_SPECS.keys())
     parser.add_argument('--variants', metavar='VAR', nargs='+',
                         choices=variant_names + ['all'], default=['all'],

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -20,7 +20,7 @@
 from setuptools import setup, find_packages  # type: ignore
 
 setup(name="LLVMEmbeddedToolchainForArm",
-      version="0.1",
+      version="13.0.0",
       packages=find_packages(),
       scripts=[
           'build.py',

--- a/versions.yml
+++ b/versions.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, Arm Limited and affiliates.
+# Copyright (c) 2020-2021, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,32 @@
       URL:  https://github.com/mirror/newlib-cygwin.git
       Revision: 7b1416c3abe890c8058001d6bb795802f80270af
       Patch: newlib-0.1.patch
+
+- Revision: "13.0.0"
+  Modules:
+    - Name: llvm.git
+      URL:  https://github.com/llvm/llvm-project.git
+      Branch: release/13.x
+      Revision: llvmorg-13.0.0
+      Patch: llvm-13.patch
+    - Name: newlib.git
+      URL:  https://github.com/mirror/newlib-cygwin.git
+      Branch: master
+      Revision: newlib-4.1.0
+      Patch: newlib-4.1.0-llvm-13.patch
+
+- Revision: branch-13
+  Modules:
+    - Name: llvm.git
+      URL:  https://github.com/llvm/llvm-project.git
+      Branch: release/13.x
+      Revision: HEAD
+      Patch: llvm-13.patch
+    - Name: newlib.git
+      URL:  https://github.com/mirror/newlib-cygwin.git
+      Branch: master
+      Revision: newlib-4.1.0
+      Patch: newlib-4.1.0-llvm-13.patch
 
 - Revision: HEAD
   Modules:


### PR DESCRIPTION
This patch adds two new versions to versions.yml:
- 13.0.0 - based on LLVM 13.0.0 and newlib 4.1.0
- branch-13 - based on the tip of the LLVM 13 branch and newlib 4.1.0

The patch for LLVM 13 is identical to the HEAD patch. The patch for
newlib is based on the exiting newlib-0.1.patch, except for the
newlib/libc/include/machine/ieeefp.h part (it is not needed anymore
because Clang 13 correctly defines the __VFP_FP__ macro).