### PR TITLE
Refactor and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,6 @@ embedded and realtime operating systems.
 - Armv8.1-M Mainline
 - AArch64 armv8.0 (experimental)
 
-## Components
-
-The LLVM Embedded Toolchain for Arm relies on the following upstream components
-
-Component  | Link
----------- | ------------------------------------
-LLVM       | https://github.com/llvm/llvm-project
-newlib     | https://sourceware.org/newlib
-
 ## C++ support
 
 C++ is partially supported with the use of libc++ and libc++abi from LLVM. Features
@@ -44,52 +35,22 @@ that are not supported include:
  - Locales and input/output streams
  - C++17's aligned operator new
 
+## Components
+
+The LLVM Embedded Toolchain for Arm relies on the following upstream components
+
+Component  | Link
+---------- | ------------------------------------
+LLVM       | https://github.com/llvm/llvm-project
+newlib     | https://sourceware.org/newlib
+
 ## License
 
-Content of this repository is licensed under Apache-2.0. See ``LICENSE.txt``.
+Content of this repository is licensed under Apache-2.0. See
+[LICENSE.txt](LICENSE.txt).
 
 The resulting binaries are covered under their respective open source licenses,
 see component links above.
-
-In addition, if the toolchain is cross-compiled to run on Windows (see
-[Cross-compiling the toolchain for Windows](#cross-compiling-the-toolchain-for-windows)
-for details) several Mingw-w64 runtime libraries residing on your machine
-may be copied to the ``bin`` directory of the toolchain and included in the
-generated ``.tar.gz`` archive if you choose to do so.
-
-The following three libraries are used:
-
-Library             | Project   | Link
---------------------|-----------|---------------------
-libstdc++-6.dll     | GCC       | https://gcc.gnu.org
-libgcc_s_seh-1.dll  | GCC       | https://gcc.gnu.org
-libwinpthread-1.dll | Mingw-w64 | http://mingw-w64.org
-
-The libraries are covered under their respective open source licenses.
-
-## Contributions and Pull Requests
-
-Contributions are accepted under Apache-2.0. Only submit contributions where
-you have authored all of the code.
-
-### Coding style
-
-The project uses the [PEP 8](https://www.python.org/dev/peps/pep-0008) style
-guide for all Python scripts. The scripts also must pass pylint and flake8
-checks as well as type-checking with mypy.
-
-Use the following commands to check the scripts before submitting a pull
-request:
-
-```
-$ ./setup.sh
-$ ./run-precommit-checks.sh
-```
-
-## How to provide feedback/report an issue
-
-Please raise an issue via
-https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/issues
 
 ## Host platforms
 
@@ -98,78 +59,42 @@ The LLVM Embedded Toolchain for Arm has been built and tested on Linux/Ubuntu
 
 ## Getting started
 
-### Build the toolchain
+Download a release of the toolchain for you platform using [Github
+releases](/ARM-software/LLVM-embedded-toolchain-for-Arm/releases) and extract
+the archive into an arbitrary directory.
 
-Build requirements
-* a suitable compiler toolchain:
-  * Clang 6.0.0 or above, or
-  * GCC 5.1.0 or above
-* CMake 3.13.4 or above
-* Python version 3.6 or above and python3-venv
-* Git
-* GNU Make
+### Downloading runtime libraries (Windows only)
 
-0. Install typically missing packages. There might be others depending on your
-   setup.
-```
-# apt-get install clang # If the Clang version installed by the package manager is older than 6.0.0, download a recent version from https://releases.llvm.org or build from source
-# apt-get install python3
-# apt-get install python3-venv
-# apt-get install git
-# apt-get install make
-# apt-get install cmake # If the CMake version installed by the package manager is older than 3.13.4, download a recent version from https://cmake.org/download and add it to PATH
-```
+We currently don't ship several Windows DLLs that are part of the GCC and
+Mingw-w64 projects due to licensing considerations.
 
-1. Install the build scripts in a python virtual env (in directory ``venv``):
-```
-$ ./setup.sh
-```
-2. Activate the virtual environment:
-```
-$ . ./venv/bin/activate
-```
-3. Build the toolchain with:
-```
-$ build.py
-```
-The script supports various command line options. To get a description of all
-options run:
-```
-$ build.py -h
-```
-Some notable options include:
-* ``--revision`` the LLVM Embedded Toolchain for Arm version. Default version
-  is ``13.0.0``. The available versions are:
-  * ``13.0.0`` - based on LLVM 13.0.0 and newlib 4.1.0
-  * ``branch-13`` - based on the tip of the LLVM 13 branch and newlib 4.1.0
-  * ``HEAD`` - based on the latest commits in the LLVM and newlib repositories
-* ``--host-toolchain`` the toolchain type. The supported values are:
-  * ``clang`` Clang (the default)
-  * ``gcc`` GCC
-  * ``mingw`` Mingw-w64 (used for cross-compilation, see
-    [Cross-compiling the toolchain for Windows](#cross-compiling-the-toolchain-for-windows))
-* ``--host-toolchain-dir`` the directory from Step 0 that the toolchain resides
-  in. Default is ``/usr/bin``.
-* ``--install-dir`` the LLVM Embedded Toolchain for Arm installation directory.
-  Default is ``./install-<revision>``.
+In order to use the toolchain on Windows you will need to provide the following
+three libraries manually.
 
-The build script can optionally take advantage of some tools to speed up the
-build. Currently, these tools are ``ccache``, and ``ninja``.
-```
-$ build.py --use-ccache --use-ninja
-```
-4. By now, you should have a working toolchain in directory
-   ``<install-dir>/LLVMEmbeddedToolchainForArm-<revision>``
+Library             | Project   | Link
+--------------------|-----------|---------------------
+libstdc++-6.dll     | GCC       | https://gcc.gnu.org
+libgcc_s_seh-1.dll  | GCC       | https://gcc.gnu.org
+libwinpthread-1.dll | Mingw-w64 | http://mingw-w64.org
 
-### Use the toolchain
+1. Download the [MinGW-W64 GCC-7.3.0 x86_64-posix-seh](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.3.0/threads-posix/seh/x86_64-7.3.0-release-posix-seh-rt_v5-rev0.7z) release from SourceForge
+2. Extract the archive and copy the three DLLs mentioned above from the
+   `mingw64/bin` directory to the `LLVMEmbeddedToolchainForArm-<revision>/bin`
+   directory
 
-Once built, you can use the generated config files to configure the compiler
-correctly. The available config files can be listed with
-`ls <install-dir>/LLVMEmbeddedToolchainForArm-<revision>/bin/*.cfg`
+### Using the toolchain
+
+To use the toolchain you need to provide a compiler configuration file on the
+command line, for example:
 
 ```
 $ PATH=<install-dir>/LLVMEmbeddedToolchainForArm-<revision>/bin:$PATH
 $ clang --config armv6m_soft_nofp_rdimon -o example example.c
+```
+
+The available configuration files can be listed using:
+```
+$ ls <install-dir>/LLVMEmbeddedToolchainForArm-<revision>/bin/*.cfg
 ```
 
 Note that configurations under the `nosys` or `rdimon_baremetal` categories
@@ -180,75 +105,16 @@ $ PATH=<install-dir>/LLVMEmbeddedToolchainForArm-<revision>/bin:$PATH
 $ clang --config armv6m_soft_nofp_nosys -T device.ld -o example example.c
 ```
 
-### Test the toolchain
+## Building from source
 
-Once the toolchain is built, you can build smoke tests:
+LLVM Embedded Toolchain for Arm is an open source project and thus can be built
+from source. Please see the [Building from source](docs/building-from-source.md)
+guide for detailed instructions.
 
-```
-$ build.py test
-```
+## Providing feedback and reporting issues
 
-If QEMU is installed and present in your system path, these tests will also be
-run.
+Please raise an issue via [Github issues](https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/issues).
 
-Furthermore, see the `samples` folder for sample code and instructions on
-building, running and debugging.
+## Contributions and Pull Requests
 
-## Cross-compiling the toolchain for Windows
-
-The LLVM Embedded Toolchain for Arm can be cross-compiled to run on Windows.
-The compilation itself still happens on Linux. In addition to the prerequisites
-mentioned in the [Build the toolchain](#build-the-toolchain) section you will
-also need a Mingw-w64 toolchain based on GCC 5.1.0 or above installed. For
-example, to install it on Ubuntu Linux use the following command:
-
-```
-# apt-get install mingw-w64
-```
-
-Then use ``build.py`` to build the toolchain:
-
-```
-$ build.py --host-toolchain mingw
-```
-
-Cross-compilation still requires a native toolchain, i.e. a compiler toolchain
-that  produces binaries that run on the build machine. The native toolchain can
-be specified using the following options:
-* ``--native-toolchain`` the toolchain type. Either ``clang`` or ``gcc``.
-  Default is ``clang``.
-* ``--native-toolchain-dir`` the directory that the toolchain resides in.
-  Default is ``/usr/bin``.
-
-For example:
-```
-$ build.py --host-toolchain mingw \
-           --native-toolchain gcc \
-           --native-toolchain-dir /opt/gcc-latest/bin
-```
-
-The script will prompt you whether it should copy the Mingw-w64 runtime
-libraries from your local machine to the toolchain ``bin`` directory. The
-libraries are distributed under their own [licenses](#license), this needs to
-be taken into consideration if you decide to redistribute the built toolchain.
-
-To avoid an interactive prompt use the ``--copy-runtime-dlls`` command line
-option, for example:
-```
-$ build.py --host-toolchain mingw --copy-runtime-dlls no
-```
-
-## Known limitations
-* Depending on the state of the components, build errors may occur when
-  ``--revision HEAD`` is used.
-
-## Divergences from upstream
-
-### newlib:
-* Clang does not support the ``naked`` attribute on C functions, breaking the
-  Linux startup (out of scope).
-* Target triple ending with eabi is not considered an ELF target.
-
-### LLVM:
-* Recognize $@ in a config file argument to mean the directory of the config
-  file, allowing toolchain relative paths.
+Please see the [Contribution Guide](docs/contributing.md) for details.

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -1,0 +1,161 @@
+# Building from source
+
+## Host platforms
+
+The LLVM Embedded Toolchain for Arm has been built and tested on Linux/Ubuntu
+18.04.5 LTS.
+
+## Installing prerequisites
+
+The build requires the following software to be installed:
+* a suitable compiler toolchain:
+  * Clang 6.0.0 or above, or
+  * GCC 5.1.0 or above
+* CMake 3.13.4 or above
+* Python version 3.6 or above and python3-venv
+* Git
+* GNU Make
+
+On a Ubuntu 18.04.5 LTS machine you can use the following commands to install
+the software mentioned above:
+```
+# apt-get install clang # If the Clang version installed by the package manager is older than 6.0.0, download a recent version from https://releases.llvm.org or build from source
+# apt-get install python3
+# apt-get install python3-venv
+# apt-get install git
+# apt-get install make
+# apt-get install cmake # If the CMake version installed by the package manager is older than 3.13.4, download a recent version from https://cmake.org/download and add it to PATH
+```
+
+## Preparing the environment
+
+The build scripts are written in Python and require a Python virtual environment
+to run. Use the following steps to create the environment.
+
+1. Install the build scripts in a Python virtual env (in directory ``venv``):
+```
+$ ./setup.sh
+```
+2. Activate the virtual environment:
+```
+$ . ./venv/bin/activate
+```
+
+## Using the `build.py` script
+
+The simplest way to build the toolchain is to invoke
+```
+$ build.py
+```
+in the Python. virtual environment.
+
+The build script supports various command line options. To get a description of
+all options run:
+```
+$ build.py -h
+```
+Some notable options include:
+* ``--revision`` the LLVM Embedded Toolchain for Arm version. Default version
+  is ``13.0.0``. The available versions are:
+  * ``13.0.0`` - based on LLVM 13.0.0 and newlib 4.1.0
+  * ``branch-13`` - based on the tip of the LLVM 13 branch and newlib 4.1.0
+  * ``HEAD`` - based on the latest commits in the LLVM and newlib repositories
+* ``--host-toolchain`` the toolchain type. The supported values are:
+  * ``clang`` Clang (the default)
+  * ``gcc`` GCC
+  * ``mingw`` Mingw-w64 (used for cross-compilation, see
+    [Cross-compiling the toolchain for Windows](#cross-compiling-the-toolchain-for-windows))
+* ``--host-toolchain-dir`` the directory from Step 0 that the toolchain resides
+  in. Default is ``/usr/bin``.
+* ``--install-dir`` the LLVM Embedded Toolchain for Arm installation directory.
+  Default is ``./install-<revision>``.
+
+The build script can optionally take advantage of some tools to speed up the
+build. Currently, these tools are ``ccache``, and ``ninja``.
+```
+$ build.py --use-ccache --use-ninja
+```
+4. By now, you should have a working toolchain in directory
+   ``<install-dir>/LLVMEmbeddedToolchainForArm-<revision>``
+
+## Testing the toolchain
+
+Once the toolchain is built, you can build smoke tests:
+
+```
+$ build.py test
+```
+
+If QEMU is installed and present in your system path, these tests will also be
+run.
+
+Furthermore, see the `samples` folder for sample code and instructions on
+building, running and debugging.
+
+## Cross-compiling the toolchain for Windows
+
+The LLVM Embedded Toolchain for Arm can be cross-compiled to run on Windows.
+The compilation itself still happens on Linux. In addition to the prerequisites
+mentioned in the [Installing prerequisites](#installing-prerequisites) section
+you will also need a Mingw-w64 toolchain based on GCC 5.1.0 or above installed.
+For example, to install it on Ubuntu Linux use the following command:
+
+```
+# apt-get install mingw-w64
+```
+
+Then use ``build.py`` to build the toolchain:
+
+```
+$ build.py --host-toolchain mingw
+```
+
+Cross-compilation still requires a native toolchain, i.e. a compiler toolchain
+that  produces binaries that run on the build machine. The native toolchain can
+be specified using the following options:
+* ``--native-toolchain`` the toolchain type. Either ``clang`` or ``gcc``.
+  Default is ``clang``.
+* ``--native-toolchain-dir`` the directory that the toolchain resides in.
+  Default is ``/usr/bin``.
+
+For example:
+```
+$ build.py --host-toolchain mingw \
+           --native-toolchain gcc \
+           --native-toolchain-dir /opt/gcc-latest/bin
+```
+
+The script will prompt you whether it should copy the Mingw-w64 runtime
+libraries from your local machine to the toolchain ``bin`` directory. 
+
+The following three libraries are used:
+
+Library             | Project   | Link
+--------------------|-----------|---------------------
+libstdc++-6.dll     | GCC       | https://gcc.gnu.org
+libgcc_s_seh-1.dll  | GCC       | https://gcc.gnu.org
+libwinpthread-1.dll | Mingw-w64 | http://mingw-w64.org
+
+The libraries are distributed under their own licenses, this needs to
+be taken into consideration if you decide to redistribute the built toolchain.
+
+To avoid an interactive prompt use the ``--copy-runtime-dlls`` command line
+option, for example:
+```
+$ build.py --host-toolchain mingw --copy-runtime-dlls no
+```
+
+## Known limitations
+* Depending on the state of the components, build errors may occur when
+  ``--revision HEAD`` is used.
+
+## Divergences from upstream
+
+### newlib:
+* Clang does not support the ``naked`` attribute on C functions, breaking the
+  Linux startup (out of scope).
+* Target triple ending with eabi is not considered an ELF target.
+
+### LLVM:
+* Recognize $@ in a config file argument to mean the directory of the config
+  file, allowing toolchain relative paths.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,18 @@
+# Contribution Guide
+
+Contributions are accepted under Apache-2.0. Only submit contributions where
+you have authored all of the code.
+
+## Coding style
+
+The project uses the [PEP 8](https://www.python.org/dev/peps/pep-0008) style
+guide for all Python scripts. The scripts also must pass pylint and flake8
+checks as well as type-checking with mypy.
+
+Use the following commands to check the scripts before submitting a pull
+request:
+
+```
+$ ./setup.sh
+$ ./run-precommit-checks.sh
+```


### PR DESCRIPTION
1. Split out "building from source" and "contributing" into separate
   documents
2. In the main README add a section about using binary distributions
   and downloading third-party MinGW DLLs.