### PR TITLE
Implement packaging of code samples

### DIFF
--- a/samples/Makefile.conf
+++ b/samples/Makefile.conf
@@ -16,8 +16,5 @@
 #
 
 ifndef BIN_PATH
-ifndef VERSION
-    VERSION=0.1
-endif
-BIN_PATH=../../../install-${VERSION}/LLVMEmbeddedToolchainForArm-${VERSION}/bin
+BIN_PATH=../../../bin
 endif

--- a/samples/README.md
+++ b/samples/README.md
@@ -50,21 +50,14 @@ Debugging is only supported on Linux.
 ## Specifying the location of the installed toolchain
 
 The Makefiles of the code samples need the location of the installed LLVM
-Embedded Toolchain for Arm. There are several ways to specify the location,
-depending on the environment. The following option works in all environments:
-* Set the environment variable ``BIN_PATH`` to point to the ``bin`` directory
-  of the toolchain.
+Embedded Toolchain for Arm.
 
-The following two options work on Linux and MSYS2:
-* Set the environment variable ``VERSION`` to the revision of the built
-  toolchain (e.g. ``13.0.0`` or ``HEAD``). The sample Makefiles will assume that
-  the toolchain is installed in the default directory used by the
-  ``build.py`` script (i.e.
-  ``install-<revision>/LLVMEmbeddedToolchainForArm-<revision>``
-  in the root of the ``LLVM-embedded-toolchain-for-Arm`` repository
-  checkout), or
-* Don't set any of the above variables. This will have the same effect as
-  setting ``VERSION=0.1``.
+If you are using Linux or MSYS2 and running the samples directly from the
+installation directory the Makefiles will determine the correct location
+automatically.
+
+Otherwise you will need to set the environment variable ``BIN_PATH`` to point
+to the ``bin`` directory of the toolchain.
 
 ## Compiling, running and debugging the samples
 
@@ -87,12 +80,6 @@ use the following commands to build, run or debug the sample:
   (gdb) target remote :1234
   ```
 * ``$ make clean`` to delete the generated ``.elf`` and ``.hex`` files
-
-Note: you can set an environment variable for a command using the following
-syntax:
-```
-$ VERSION=HEAD make run
-```
 
 ### Windows
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -356,6 +356,7 @@ def main() -> int:
 
         def do_package():
             package.write_version_file(cfg, version)
+            package.copy_samples(cfg)
             package.package_toolchain(cfg)
         run_or_skip(cfg, Action.PACKAGE, do_package, 'packaging')
     except util.ToolchainBuildError:

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -346,6 +346,7 @@ class Config:  # pylint: disable=too-many-instance-attributes
         self.newlib_repo_dir = join(self.repos_dir, 'newlib.git')
         is_using_mingw = self.host_toolchain.kind == ToolchainKind.MINGW
         self.is_cross_compiling = (os.name == 'posix' and is_using_mingw)
+        self.is_windows = is_using_mingw
         self.cmake_generator = 'Ninja' if self.use_ninja else 'Unix Makefiles'
         self.release_mode = self.revision != 'HEAD'
         if self.release_mode:


### PR DESCRIPTION
This patch:
* Adjusts code samples to use a different Clang bin path: as if
  installed from a binary package rather than as if built from source
* Implements copying of code samples to the generated binary packages