### PR TITLE
Implement creation of source packages and building from source packages

### DIFF
--- a/patches/llvm-13.patch
+++ b/patches/llvm-13.patch
@@ -1,8 +1,18 @@
 diff --git a/clang/lib/Driver/ToolChains/BareMetal.cpp b/clang/lib/Driver/ToolChains/BareMetal.cpp
-index ce73e39d1456..1f866e92d26f 100644
+index ce73e39d1456..851d48383f4e 100644
 --- a/clang/lib/Driver/ToolChains/BareMetal.cpp
 +++ b/clang/lib/Driver/ToolChains/BareMetal.cpp
-@@ -125,6 +125,25 @@ static bool isARMBareMetal(const llvm::Triple &Triple) {
+@@ -6,6 +6,9 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// Modifications copyright (C) 2021 Arm Limited (or its affiliates).
++// All rights reserved.
++
+ #include "BareMetal.h"
+ 
+ #include "CommonArgs.h"
+@@ -125,6 +128,25 @@ static bool isARMBareMetal(const llvm::Triple &Triple) {
    return true;
  }
  
@@ -28,7 +38,7 @@ index ce73e39d1456..1f866e92d26f 100644
  static bool isRISCVBareMetal(const llvm::Triple &Triple) {
    if (Triple.getArch() != llvm::Triple::riscv32 &&
        Triple.getArch() != llvm::Triple::riscv64)
-@@ -151,7 +170,8 @@ void BareMetal::findMultilibs(const Driver &D, const llvm::Triple &Triple,
+@@ -151,7 +173,8 @@ void BareMetal::findMultilibs(const Driver &D, const llvm::Triple &Triple,
  }
  
  bool BareMetal::handlesTarget(const llvm::Triple &Triple) {
@@ -39,10 +49,20 @@ index ce73e39d1456..1f866e92d26f 100644
  
  Tool *BareMetal::buildLinker() const {
 diff --git a/libcxx/include/cmath b/libcxx/include/cmath
-index adf83c2b0a7b..2089a2555bec 100644
+index adf83c2b0a7b..420cc4052715 100644
 --- a/libcxx/include/cmath
 +++ b/libcxx/include/cmath
-@@ -531,7 +531,9 @@ using ::truncl _LIBCPP_USING_IF_EXISTS;
+@@ -7,6 +7,9 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// Modifications copyright (C) 2021 Arm Limited (or its affiliates).
++// All rights reserved.
++
+ #ifndef _LIBCPP_CMATH
+ #define _LIBCPP_CMATH
+ 
+@@ -531,7 +534,9 @@ using ::truncl _LIBCPP_USING_IF_EXISTS;
  #if _LIBCPP_STD_VER > 14
  inline _LIBCPP_INLINE_VISIBILITY float       hypot(       float x,       float y,       float z ) { return sqrt(x*x + y*y + z*z); }
  inline _LIBCPP_INLINE_VISIBILITY double      hypot(      double x,      double y,      double z ) { return sqrt(x*x + y*y + z*z); }
@@ -52,7 +72,7 @@ index adf83c2b0a7b..2089a2555bec 100644
  
  template <class _A1, class _A2, class _A3>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -633,8 +635,10 @@ lerp(float __a, float __b, float __t)                   _NOEXCEPT { return __ler
+@@ -633,8 +638,10 @@ lerp(float __a, float __b, float __t)                   _NOEXCEPT { return __ler
  constexpr double
  lerp(double __a, double __b, double __t)                _NOEXCEPT { return __lerp(__a, __b, __t); }
  
@@ -64,10 +84,20 @@ index adf83c2b0a7b..2089a2555bec 100644
  #endif // _LIBCPP_STD_VER > 17
  
 diff --git a/libcxx/include/math.h b/libcxx/include/math.h
-index 77762d554512..601c43330434 100644
+index 77762d554512..92291fd28710 100644
 --- a/libcxx/include/math.h
 +++ b/libcxx/include/math.h
-@@ -790,8 +790,10 @@ isunordered(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+@@ -7,6 +7,9 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// Modifications copyright (C) 2021 Arm Limited (or its affiliates).
++// All rights reserved.
++
+ #ifndef _LIBCPP_MATH_H
+ #define _LIBCPP_MATH_H
+ 
+@@ -790,8 +793,10 @@ isunordered(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       acos(float __lcpp_x) _NOEXCEPT       {return ::acosf(__lcpp_x);}
@@ -78,7 +108,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -802,8 +804,10 @@ acos(_A1 __lcpp_x) _NOEXCEPT {return ::acos((double)__lcpp_x);}
+@@ -802,8 +807,10 @@ acos(_A1 __lcpp_x) _NOEXCEPT {return ::acos((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       asin(float __lcpp_x) _NOEXCEPT       {return ::asinf(__lcpp_x);}
@@ -89,7 +119,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -814,8 +818,10 @@ asin(_A1 __lcpp_x) _NOEXCEPT {return ::asin((double)__lcpp_x);}
+@@ -814,8 +821,10 @@ asin(_A1 __lcpp_x) _NOEXCEPT {return ::asin((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       atan(float __lcpp_x) _NOEXCEPT       {return ::atanf(__lcpp_x);}
@@ -100,7 +130,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -826,8 +832,10 @@ atan(_A1 __lcpp_x) _NOEXCEPT {return ::atan((double)__lcpp_x);}
+@@ -826,8 +835,10 @@ atan(_A1 __lcpp_x) _NOEXCEPT {return ::atan((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       atan2(float __lcpp_y, float __lcpp_x) _NOEXCEPT             {return ::atan2f(__lcpp_y, __lcpp_x);}
@@ -111,7 +141,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -849,8 +857,10 @@ atan2(_A1 __lcpp_y, _A2 __lcpp_x) _NOEXCEPT
+@@ -849,8 +860,10 @@ atan2(_A1 __lcpp_y, _A2 __lcpp_x) _NOEXCEPT
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       ceil(float __lcpp_x) _NOEXCEPT       {return ::ceilf(__lcpp_x);}
@@ -122,7 +152,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -861,8 +871,10 @@ ceil(_A1 __lcpp_x) _NOEXCEPT {return ::ceil((double)__lcpp_x);}
+@@ -861,8 +874,10 @@ ceil(_A1 __lcpp_x) _NOEXCEPT {return ::ceil((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       cos(float __lcpp_x) _NOEXCEPT       {return ::cosf(__lcpp_x);}
@@ -133,7 +163,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -873,8 +885,10 @@ cos(_A1 __lcpp_x) _NOEXCEPT {return ::cos((double)__lcpp_x);}
+@@ -873,8 +888,10 @@ cos(_A1 __lcpp_x) _NOEXCEPT {return ::cos((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       cosh(float __lcpp_x) _NOEXCEPT       {return ::coshf(__lcpp_x);}
@@ -144,7 +174,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -885,8 +899,10 @@ cosh(_A1 __lcpp_x) _NOEXCEPT {return ::cosh((double)__lcpp_x);}
+@@ -885,8 +902,10 @@ cosh(_A1 __lcpp_x) _NOEXCEPT {return ::cosh((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       exp(float __lcpp_x) _NOEXCEPT       {return ::expf(__lcpp_x);}
@@ -155,7 +185,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -897,8 +913,10 @@ exp(_A1 __lcpp_x) _NOEXCEPT {return ::exp((double)__lcpp_x);}
+@@ -897,8 +916,10 @@ exp(_A1 __lcpp_x) _NOEXCEPT {return ::exp((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       fabs(float __lcpp_x) _NOEXCEPT       {return ::fabsf(__lcpp_x);}
@@ -166,7 +196,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -909,8 +927,10 @@ fabs(_A1 __lcpp_x) _NOEXCEPT {return ::fabs((double)__lcpp_x);}
+@@ -909,8 +930,10 @@ fabs(_A1 __lcpp_x) _NOEXCEPT {return ::fabs((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       floor(float __lcpp_x) _NOEXCEPT       {return ::floorf(__lcpp_x);}
@@ -177,7 +207,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -921,8 +941,10 @@ floor(_A1 __lcpp_x) _NOEXCEPT {return ::floor((double)__lcpp_x);}
+@@ -921,8 +944,10 @@ floor(_A1 __lcpp_x) _NOEXCEPT {return ::floor((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       fmod(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::fmodf(__lcpp_x, __lcpp_y);}
@@ -188,7 +218,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -944,8 +966,10 @@ fmod(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+@@ -944,8 +969,10 @@ fmod(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       frexp(float __lcpp_x, int* __lcpp_e) _NOEXCEPT       {return ::frexpf(__lcpp_x, __lcpp_e);}
@@ -199,7 +229,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -956,8 +980,10 @@ frexp(_A1 __lcpp_x, int* __lcpp_e) _NOEXCEPT {return ::frexp((double)__lcpp_x, _
+@@ -956,8 +983,10 @@ frexp(_A1 __lcpp_x, int* __lcpp_e) _NOEXCEPT {return ::frexp((double)__lcpp_x, _
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       ldexp(float __lcpp_x, int __lcpp_e) _NOEXCEPT       {return ::ldexpf(__lcpp_x, __lcpp_e);}
@@ -210,7 +240,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -968,8 +994,10 @@ ldexp(_A1 __lcpp_x, int __lcpp_e) _NOEXCEPT {return ::ldexp((double)__lcpp_x, __
+@@ -968,8 +997,10 @@ ldexp(_A1 __lcpp_x, int __lcpp_e) _NOEXCEPT {return ::ldexp((double)__lcpp_x, __
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       log(float __lcpp_x) _NOEXCEPT       {return ::logf(__lcpp_x);}
@@ -221,7 +251,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -980,8 +1008,10 @@ log(_A1 __lcpp_x) _NOEXCEPT {return ::log((double)__lcpp_x);}
+@@ -980,8 +1011,10 @@ log(_A1 __lcpp_x) _NOEXCEPT {return ::log((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       log10(float __lcpp_x) _NOEXCEPT       {return ::log10f(__lcpp_x);}
@@ -232,7 +262,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -992,15 +1022,19 @@ log10(_A1 __lcpp_x) _NOEXCEPT {return ::log10((double)__lcpp_x);}
+@@ -992,15 +1025,19 @@ log10(_A1 __lcpp_x) _NOEXCEPT {return ::log10((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       modf(float __lcpp_x, float* __lcpp_y) _NOEXCEPT             {return ::modff(__lcpp_x, __lcpp_y);}
@@ -252,7 +282,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1022,8 +1056,10 @@ pow(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+@@ -1022,8 +1059,10 @@ pow(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       sin(float __lcpp_x) _NOEXCEPT       {return ::sinf(__lcpp_x);}
@@ -263,7 +293,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1034,8 +1070,10 @@ sin(_A1 __lcpp_x) _NOEXCEPT {return ::sin((double)__lcpp_x);}
+@@ -1034,8 +1073,10 @@ sin(_A1 __lcpp_x) _NOEXCEPT {return ::sin((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       sinh(float __lcpp_x) _NOEXCEPT       {return ::sinhf(__lcpp_x);}
@@ -274,7 +304,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1046,8 +1084,10 @@ sinh(_A1 __lcpp_x) _NOEXCEPT {return ::sinh((double)__lcpp_x);}
+@@ -1046,8 +1087,10 @@ sinh(_A1 __lcpp_x) _NOEXCEPT {return ::sinh((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       sqrt(float __lcpp_x) _NOEXCEPT       {return ::sqrtf(__lcpp_x);}
@@ -285,7 +315,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1058,8 +1098,10 @@ sqrt(_A1 __lcpp_x) _NOEXCEPT {return ::sqrt((double)__lcpp_x);}
+@@ -1058,8 +1101,10 @@ sqrt(_A1 __lcpp_x) _NOEXCEPT {return ::sqrt((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       tan(float __lcpp_x) _NOEXCEPT       {return ::tanf(__lcpp_x);}
@@ -296,7 +326,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1070,8 +1112,10 @@ tan(_A1 __lcpp_x) _NOEXCEPT {return ::tan((double)__lcpp_x);}
+@@ -1070,8 +1115,10 @@ tan(_A1 __lcpp_x) _NOEXCEPT {return ::tan((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       tanh(float __lcpp_x) _NOEXCEPT       {return ::tanhf(__lcpp_x);}
@@ -307,7 +337,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1081,7 +1125,9 @@ tanh(_A1 __lcpp_x) _NOEXCEPT {return ::tanh((double)__lcpp_x);}
+@@ -1081,7 +1128,9 @@ tanh(_A1 __lcpp_x) _NOEXCEPT {return ::tanh((double)__lcpp_x);}
  // acosh
  
  inline _LIBCPP_INLINE_VISIBILITY float       acosh(float __lcpp_x) _NOEXCEPT       {return ::acoshf(__lcpp_x);}
@@ -317,7 +347,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1091,7 +1137,9 @@ acosh(_A1 __lcpp_x) _NOEXCEPT {return ::acosh((double)__lcpp_x);}
+@@ -1091,7 +1140,9 @@ acosh(_A1 __lcpp_x) _NOEXCEPT {return ::acosh((double)__lcpp_x);}
  // asinh
  
  inline _LIBCPP_INLINE_VISIBILITY float       asinh(float __lcpp_x) _NOEXCEPT       {return ::asinhf(__lcpp_x);}
@@ -327,7 +357,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1101,7 +1149,10 @@ asinh(_A1 __lcpp_x) _NOEXCEPT {return ::asinh((double)__lcpp_x);}
+@@ -1101,7 +1152,10 @@ asinh(_A1 __lcpp_x) _NOEXCEPT {return ::asinh((double)__lcpp_x);}
  // atanh
  
  inline _LIBCPP_INLINE_VISIBILITY float       atanh(float __lcpp_x) _NOEXCEPT       {return ::atanhf(__lcpp_x);}
@@ -338,7 +368,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1111,7 +1162,9 @@ atanh(_A1 __lcpp_x) _NOEXCEPT {return ::atanh((double)__lcpp_x);}
+@@ -1111,7 +1165,9 @@ atanh(_A1 __lcpp_x) _NOEXCEPT {return ::atanh((double)__lcpp_x);}
  // cbrt
  
  inline _LIBCPP_INLINE_VISIBILITY float       cbrt(float __lcpp_x) _NOEXCEPT       {return ::cbrtf(__lcpp_x);}
@@ -348,7 +378,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1142,6 +1195,7 @@ inline _LIBCPP_INLINE_VISIBILITY double __libcpp_copysign(double __lcpp_x, doubl
+@@ -1142,6 +1198,7 @@ inline _LIBCPP_INLINE_VISIBILITY double __libcpp_copysign(double __lcpp_x, doubl
  #endif
  }
  
@@ -356,7 +386,7 @@ index 77762d554512..601c43330434 100644
  #if __has_builtin(__builtin_copysignl)
  _LIBCPP_CONSTEXPR
  #endif
-@@ -1152,6 +1206,7 @@ inline _LIBCPP_INLINE_VISIBILITY long double __libcpp_copysign(long double __lcp
+@@ -1152,6 +1209,7 @@ inline _LIBCPP_INLINE_VISIBILITY long double __libcpp_copysign(long double __lcp
    return ::copysignl(__lcpp_x, __lcpp_y);
  #endif
  }
@@ -364,7 +394,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  #if __has_builtin(__builtin_copysign)
-@@ -1179,9 +1234,11 @@ inline _LIBCPP_INLINE_VISIBILITY float copysign(float __lcpp_x, float __lcpp_y)
+@@ -1179,9 +1237,11 @@ inline _LIBCPP_INLINE_VISIBILITY float copysign(float __lcpp_x, float __lcpp_y)
    return ::__libcpp_copysign(__lcpp_x, __lcpp_y);
  }
  
@@ -376,7 +406,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1198,7 +1255,9 @@ typename std::_EnableIf
+@@ -1198,7 +1258,9 @@ typename std::_EnableIf
  // erf
  
  inline _LIBCPP_INLINE_VISIBILITY float       erf(float __lcpp_x) _NOEXCEPT       {return ::erff(__lcpp_x);}
@@ -386,7 +416,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1208,7 +1267,9 @@ erf(_A1 __lcpp_x) _NOEXCEPT {return ::erf((double)__lcpp_x);}
+@@ -1208,7 +1270,9 @@ erf(_A1 __lcpp_x) _NOEXCEPT {return ::erf((double)__lcpp_x);}
  // erfc
  
  inline _LIBCPP_INLINE_VISIBILITY float       erfc(float __lcpp_x) _NOEXCEPT       {return ::erfcf(__lcpp_x);}
@@ -396,7 +426,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1218,7 +1279,9 @@ erfc(_A1 __lcpp_x) _NOEXCEPT {return ::erfc((double)__lcpp_x);}
+@@ -1218,7 +1282,9 @@ erfc(_A1 __lcpp_x) _NOEXCEPT {return ::erfc((double)__lcpp_x);}
  // exp2
  
  inline _LIBCPP_INLINE_VISIBILITY float       exp2(float __lcpp_x) _NOEXCEPT       {return ::exp2f(__lcpp_x);}
@@ -406,7 +436,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1228,7 +1291,9 @@ exp2(_A1 __lcpp_x) _NOEXCEPT {return ::exp2((double)__lcpp_x);}
+@@ -1228,7 +1294,9 @@ exp2(_A1 __lcpp_x) _NOEXCEPT {return ::exp2((double)__lcpp_x);}
  // expm1
  
  inline _LIBCPP_INLINE_VISIBILITY float       expm1(float __lcpp_x) _NOEXCEPT       {return ::expm1f(__lcpp_x);}
@@ -416,7 +446,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1238,7 +1303,9 @@ expm1(_A1 __lcpp_x) _NOEXCEPT {return ::expm1((double)__lcpp_x);}
+@@ -1238,7 +1306,9 @@ expm1(_A1 __lcpp_x) _NOEXCEPT {return ::expm1((double)__lcpp_x);}
  // fdim
  
  inline _LIBCPP_INLINE_VISIBILITY float       fdim(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::fdimf(__lcpp_x, __lcpp_y);}
@@ -426,7 +456,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1266,6 +1333,7 @@ inline _LIBCPP_INLINE_VISIBILITY float       fma(float __lcpp_x, float __lcpp_y,
+@@ -1266,6 +1336,7 @@ inline _LIBCPP_INLINE_VISIBILITY float       fma(float __lcpp_x, float __lcpp_y,
      return ::fmaf(__lcpp_x, __lcpp_y, __lcpp_z);
  #endif
  }
@@ -434,7 +464,7 @@ index 77762d554512..601c43330434 100644
  inline _LIBCPP_INLINE_VISIBILITY long double fma(long double __lcpp_x, long double __lcpp_y, long double __lcpp_z) _NOEXCEPT
  {
  #if __has_builtin(__builtin_fmal)
-@@ -1274,6 +1342,7 @@ inline _LIBCPP_INLINE_VISIBILITY long double fma(long double __lcpp_x, long doub
+@@ -1274,6 +1345,7 @@ inline _LIBCPP_INLINE_VISIBILITY long double fma(long double __lcpp_x, long doub
      return ::fmal(__lcpp_x, __lcpp_y, __lcpp_z);
  #endif
  }
@@ -442,7 +472,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2, class _A3>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1300,7 +1369,9 @@ fma(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) _NOEXCEPT
+@@ -1300,7 +1372,9 @@ fma(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) _NOEXCEPT
  // fmax
  
  inline _LIBCPP_INLINE_VISIBILITY float       fmax(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::fmaxf(__lcpp_x, __lcpp_y);}
@@ -452,7 +482,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1321,7 +1392,9 @@ fmax(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+@@ -1321,7 +1395,9 @@ fmax(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
  // fmin
  
  inline _LIBCPP_INLINE_VISIBILITY float       fmin(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::fminf(__lcpp_x, __lcpp_y);}
@@ -462,7 +492,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1342,7 +1415,9 @@ fmin(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+@@ -1342,7 +1418,9 @@ fmin(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
  // hypot
  
  inline _LIBCPP_INLINE_VISIBILITY float       hypot(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::hypotf(__lcpp_x, __lcpp_y);}
@@ -472,7 +502,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1363,7 +1438,9 @@ hypot(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+@@ -1363,7 +1441,9 @@ hypot(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
  // ilogb
  
  inline _LIBCPP_INLINE_VISIBILITY int ilogb(float __lcpp_x) _NOEXCEPT       {return ::ilogbf(__lcpp_x);}
@@ -482,7 +512,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1373,7 +1450,9 @@ ilogb(_A1 __lcpp_x) _NOEXCEPT {return ::ilogb((double)__lcpp_x);}
+@@ -1373,7 +1453,9 @@ ilogb(_A1 __lcpp_x) _NOEXCEPT {return ::ilogb((double)__lcpp_x);}
  // lgamma
  
  inline _LIBCPP_INLINE_VISIBILITY float       lgamma(float __lcpp_x) _NOEXCEPT       {return ::lgammaf(__lcpp_x);}
@@ -492,7 +522,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1390,6 +1469,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llrint(float __lcpp_x) _NOEXCEPT
+@@ -1390,6 +1472,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llrint(float __lcpp_x) _NOEXCEPT
      return ::llrintf(__lcpp_x);
  #endif
  }
@@ -500,7 +530,7 @@ index 77762d554512..601c43330434 100644
  inline _LIBCPP_INLINE_VISIBILITY long long llrint(long double __lcpp_x) _NOEXCEPT
  {
  #if __has_builtin(__builtin_llrintl)
-@@ -1398,6 +1478,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llrint(long double __lcpp_x) _NOEXCEP
+@@ -1398,6 +1481,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llrint(long double __lcpp_x) _NOEXCEP
      return ::llrintl(__lcpp_x);
  #endif
  }
@@ -508,7 +538,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1421,6 +1502,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llround(float __lcpp_x) _NOEXCEPT
+@@ -1421,6 +1505,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llround(float __lcpp_x) _NOEXCEPT
      return ::llroundf(__lcpp_x);
  #endif
  }
@@ -516,7 +546,7 @@ index 77762d554512..601c43330434 100644
  inline _LIBCPP_INLINE_VISIBILITY long long llround(long double __lcpp_x) _NOEXCEPT
  {
  #if __has_builtin(__builtin_llroundl)
-@@ -1429,6 +1511,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llround(long double __lcpp_x) _NOEXCE
+@@ -1429,6 +1514,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llround(long double __lcpp_x) _NOEXCE
      return ::llroundl(__lcpp_x);
  #endif
  }
@@ -524,7 +554,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1445,7 +1528,9 @@ llround(_A1 __lcpp_x) _NOEXCEPT
+@@ -1445,7 +1531,9 @@ llround(_A1 __lcpp_x) _NOEXCEPT
  // log1p
  
  inline _LIBCPP_INLINE_VISIBILITY float       log1p(float __lcpp_x) _NOEXCEPT       {return ::log1pf(__lcpp_x);}
@@ -534,7 +564,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1455,7 +1540,9 @@ log1p(_A1 __lcpp_x) _NOEXCEPT {return ::log1p((double)__lcpp_x);}
+@@ -1455,7 +1543,9 @@ log1p(_A1 __lcpp_x) _NOEXCEPT {return ::log1p((double)__lcpp_x);}
  // log2
  
  inline _LIBCPP_INLINE_VISIBILITY float       log2(float __lcpp_x) _NOEXCEPT       {return ::log2f(__lcpp_x);}
@@ -544,7 +574,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1465,7 +1552,9 @@ log2(_A1 __lcpp_x) _NOEXCEPT {return ::log2((double)__lcpp_x);}
+@@ -1465,7 +1555,9 @@ log2(_A1 __lcpp_x) _NOEXCEPT {return ::log2((double)__lcpp_x);}
  // logb
  
  inline _LIBCPP_INLINE_VISIBILITY float       logb(float __lcpp_x) _NOEXCEPT       {return ::logbf(__lcpp_x);}
@@ -554,7 +584,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1539,7 +1628,9 @@ lround(_A1 __lcpp_x) _NOEXCEPT
+@@ -1539,7 +1631,9 @@ lround(_A1 __lcpp_x) _NOEXCEPT
  // nearbyint
  
  inline _LIBCPP_INLINE_VISIBILITY float       nearbyint(float __lcpp_x) _NOEXCEPT       {return ::nearbyintf(__lcpp_x);}
@@ -564,7 +594,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1549,7 +1640,9 @@ nearbyint(_A1 __lcpp_x) _NOEXCEPT {return ::nearbyint((double)__lcpp_x);}
+@@ -1549,7 +1643,9 @@ nearbyint(_A1 __lcpp_x) _NOEXCEPT {return ::nearbyint((double)__lcpp_x);}
  // nextafter
  
  inline _LIBCPP_INLINE_VISIBILITY float       nextafter(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::nextafterf(__lcpp_x, __lcpp_y);}
@@ -574,7 +604,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1569,6 +1662,7 @@ nextafter(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+@@ -1569,6 +1665,7 @@ nextafter(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
  
  // nexttoward
  
@@ -582,7 +612,7 @@ index 77762d554512..601c43330434 100644
  inline _LIBCPP_INLINE_VISIBILITY float       nexttoward(float __lcpp_x, long double __lcpp_y) _NOEXCEPT       {return ::nexttowardf(__lcpp_x, __lcpp_y);}
  inline _LIBCPP_INLINE_VISIBILITY long double nexttoward(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::nexttowardl(__lcpp_x, __lcpp_y);}
  
-@@ -1576,11 +1670,14 @@ template <class _A1>
+@@ -1576,11 +1673,14 @@ template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
  typename std::enable_if<std::is_integral<_A1>::value, double>::type
  nexttoward(_A1 __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::nexttoward((double)__lcpp_x, __lcpp_y);}
@@ -597,7 +627,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1601,7 +1698,9 @@ remainder(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+@@ -1601,7 +1701,9 @@ remainder(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
  // remquo
  
  inline _LIBCPP_INLINE_VISIBILITY float       remquo(float __lcpp_x, float __lcpp_y, int* __lcpp_z) _NOEXCEPT             {return ::remquof(__lcpp_x, __lcpp_y, __lcpp_z);}
@@ -607,7 +637,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1684,7 +1783,9 @@ round(_A1 __lcpp_x) _NOEXCEPT
+@@ -1684,7 +1786,9 @@ round(_A1 __lcpp_x) _NOEXCEPT
  // scalbln
  
  inline _LIBCPP_INLINE_VISIBILITY float       scalbln(float __lcpp_x, long __lcpp_y) _NOEXCEPT       {return ::scalblnf(__lcpp_x, __lcpp_y);}
@@ -617,7 +647,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1694,7 +1795,9 @@ scalbln(_A1 __lcpp_x, long __lcpp_y) _NOEXCEPT {return ::scalbln((double)__lcpp_
+@@ -1694,7 +1798,9 @@ scalbln(_A1 __lcpp_x, long __lcpp_y) _NOEXCEPT {return ::scalbln((double)__lcpp_
  // scalbn
  
  inline _LIBCPP_INLINE_VISIBILITY float       scalbn(float __lcpp_x, int __lcpp_y) _NOEXCEPT       {return ::scalbnf(__lcpp_x, __lcpp_y);}
@@ -627,7 +657,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1704,7 +1807,9 @@ scalbn(_A1 __lcpp_x, int __lcpp_y) _NOEXCEPT {return ::scalbn((double)__lcpp_x,
+@@ -1704,7 +1810,9 @@ scalbn(_A1 __lcpp_x, int __lcpp_y) _NOEXCEPT {return ::scalbn((double)__lcpp_x,
  // tgamma
  
  inline _LIBCPP_INLINE_VISIBILITY float       tgamma(float __lcpp_x) _NOEXCEPT       {return ::tgammaf(__lcpp_x);}
@@ -638,10 +668,20 @@ index 77762d554512..601c43330434 100644
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
 diff --git a/llvm/lib/Support/CommandLine.cpp b/llvm/lib/Support/CommandLine.cpp
-index 6c140863b13c..caab14d29020 100644
+index 4ae3ad4c2453..b2b6d93561fd 100644
 --- a/llvm/lib/Support/CommandLine.cpp
 +++ b/llvm/lib/Support/CommandLine.cpp
-@@ -1112,12 +1112,57 @@ static llvm::Error ExpandResponseFile(
+@@ -15,6 +15,9 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// Modifications copyright (C) 2021 Arm Limited (or its affiliates).
++// All rights reserved.
++
+ #include "llvm/Support/CommandLine.h"
+ 
+ #include "DebugOptions.h"
+@@ -1112,12 +1115,57 @@ static llvm::Error ExpandResponseFile(
    if (!RelativeNames)
      return Error::success();
    llvm::StringRef BasePath = llvm::sys::path::parent_path(FName);

--- a/patches/llvm-HEAD.patch
+++ b/patches/llvm-HEAD.patch
@@ -1,8 +1,18 @@
 diff --git a/libcxx/include/cmath b/libcxx/include/cmath
-index adf83c2b0a7b..2089a2555bec 100644
+index 0a7ff083eb62..5644467e5dc9 100644
 --- a/libcxx/include/cmath
 +++ b/libcxx/include/cmath
-@@ -531,7 +531,9 @@ using ::truncl _LIBCPP_USING_IF_EXISTS;
+@@ -7,6 +7,9 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// Modifications copyright (C) 2021 Arm Limited (or its affiliates).
++// All rights reserved.
++
+ #ifndef _LIBCPP_CMATH
+ #define _LIBCPP_CMATH
+ 
+@@ -531,7 +534,9 @@ using ::truncl _LIBCPP_USING_IF_EXISTS;
  #if _LIBCPP_STD_VER > 14
  inline _LIBCPP_INLINE_VISIBILITY float       hypot(       float x,       float y,       float z ) { return sqrt(x*x + y*y + z*z); }
  inline _LIBCPP_INLINE_VISIBILITY double      hypot(      double x,      double y,      double z ) { return sqrt(x*x + y*y + z*z); }
@@ -12,7 +22,7 @@ index adf83c2b0a7b..2089a2555bec 100644
  
  template <class _A1, class _A2, class _A3>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -633,8 +635,10 @@ lerp(float __a, float __b, float __t)                   _NOEXCEPT { return __ler
+@@ -633,8 +638,10 @@ lerp(float __a, float __b, float __t)                   _NOEXCEPT { return __ler
  constexpr double
  lerp(double __a, double __b, double __t)                _NOEXCEPT { return __lerp(__a, __b, __t); }
  
@@ -24,10 +34,20 @@ index adf83c2b0a7b..2089a2555bec 100644
  #endif // _LIBCPP_STD_VER > 17
  
 diff --git a/libcxx/include/math.h b/libcxx/include/math.h
-index 77762d554512..601c43330434 100644
+index 8cbbc54a623f..e65592e076a8 100644
 --- a/libcxx/include/math.h
 +++ b/libcxx/include/math.h
-@@ -790,8 +790,10 @@ isunordered(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+@@ -7,6 +7,9 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// Modifications copyright (C) 2021 Arm Limited (or its affiliates).
++// All rights reserved.
++
+ #ifndef _LIBCPP_MATH_H
+ #define _LIBCPP_MATH_H
+ 
+@@ -790,8 +793,10 @@ isunordered(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       acos(float __lcpp_x) _NOEXCEPT       {return ::acosf(__lcpp_x);}
@@ -38,7 +58,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -802,8 +804,10 @@ acos(_A1 __lcpp_x) _NOEXCEPT {return ::acos((double)__lcpp_x);}
+@@ -802,8 +807,10 @@ acos(_A1 __lcpp_x) _NOEXCEPT {return ::acos((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       asin(float __lcpp_x) _NOEXCEPT       {return ::asinf(__lcpp_x);}
@@ -49,7 +69,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -814,8 +818,10 @@ asin(_A1 __lcpp_x) _NOEXCEPT {return ::asin((double)__lcpp_x);}
+@@ -814,8 +821,10 @@ asin(_A1 __lcpp_x) _NOEXCEPT {return ::asin((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       atan(float __lcpp_x) _NOEXCEPT       {return ::atanf(__lcpp_x);}
@@ -60,7 +80,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -826,8 +832,10 @@ atan(_A1 __lcpp_x) _NOEXCEPT {return ::atan((double)__lcpp_x);}
+@@ -826,8 +835,10 @@ atan(_A1 __lcpp_x) _NOEXCEPT {return ::atan((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       atan2(float __lcpp_y, float __lcpp_x) _NOEXCEPT             {return ::atan2f(__lcpp_y, __lcpp_x);}
@@ -71,7 +91,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -849,8 +857,10 @@ atan2(_A1 __lcpp_y, _A2 __lcpp_x) _NOEXCEPT
+@@ -849,8 +860,10 @@ atan2(_A1 __lcpp_y, _A2 __lcpp_x) _NOEXCEPT
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       ceil(float __lcpp_x) _NOEXCEPT       {return ::ceilf(__lcpp_x);}
@@ -82,7 +102,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -861,8 +871,10 @@ ceil(_A1 __lcpp_x) _NOEXCEPT {return ::ceil((double)__lcpp_x);}
+@@ -861,8 +874,10 @@ ceil(_A1 __lcpp_x) _NOEXCEPT {return ::ceil((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       cos(float __lcpp_x) _NOEXCEPT       {return ::cosf(__lcpp_x);}
@@ -93,7 +113,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -873,8 +885,10 @@ cos(_A1 __lcpp_x) _NOEXCEPT {return ::cos((double)__lcpp_x);}
+@@ -873,8 +888,10 @@ cos(_A1 __lcpp_x) _NOEXCEPT {return ::cos((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       cosh(float __lcpp_x) _NOEXCEPT       {return ::coshf(__lcpp_x);}
@@ -104,7 +124,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -885,8 +899,10 @@ cosh(_A1 __lcpp_x) _NOEXCEPT {return ::cosh((double)__lcpp_x);}
+@@ -885,8 +902,10 @@ cosh(_A1 __lcpp_x) _NOEXCEPT {return ::cosh((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       exp(float __lcpp_x) _NOEXCEPT       {return ::expf(__lcpp_x);}
@@ -115,7 +135,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -897,8 +913,10 @@ exp(_A1 __lcpp_x) _NOEXCEPT {return ::exp((double)__lcpp_x);}
+@@ -897,8 +916,10 @@ exp(_A1 __lcpp_x) _NOEXCEPT {return ::exp((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       fabs(float __lcpp_x) _NOEXCEPT       {return ::fabsf(__lcpp_x);}
@@ -126,7 +146,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -909,8 +927,10 @@ fabs(_A1 __lcpp_x) _NOEXCEPT {return ::fabs((double)__lcpp_x);}
+@@ -909,8 +930,10 @@ fabs(_A1 __lcpp_x) _NOEXCEPT {return ::fabs((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       floor(float __lcpp_x) _NOEXCEPT       {return ::floorf(__lcpp_x);}
@@ -137,7 +157,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -921,8 +941,10 @@ floor(_A1 __lcpp_x) _NOEXCEPT {return ::floor((double)__lcpp_x);}
+@@ -921,8 +944,10 @@ floor(_A1 __lcpp_x) _NOEXCEPT {return ::floor((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       fmod(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::fmodf(__lcpp_x, __lcpp_y);}
@@ -148,7 +168,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -944,8 +966,10 @@ fmod(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+@@ -944,8 +969,10 @@ fmod(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       frexp(float __lcpp_x, int* __lcpp_e) _NOEXCEPT       {return ::frexpf(__lcpp_x, __lcpp_e);}
@@ -159,7 +179,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -956,8 +980,10 @@ frexp(_A1 __lcpp_x, int* __lcpp_e) _NOEXCEPT {return ::frexp((double)__lcpp_x, _
+@@ -956,8 +983,10 @@ frexp(_A1 __lcpp_x, int* __lcpp_e) _NOEXCEPT {return ::frexp((double)__lcpp_x, _
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       ldexp(float __lcpp_x, int __lcpp_e) _NOEXCEPT       {return ::ldexpf(__lcpp_x, __lcpp_e);}
@@ -170,7 +190,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -968,8 +994,10 @@ ldexp(_A1 __lcpp_x, int __lcpp_e) _NOEXCEPT {return ::ldexp((double)__lcpp_x, __
+@@ -968,8 +997,10 @@ ldexp(_A1 __lcpp_x, int __lcpp_e) _NOEXCEPT {return ::ldexp((double)__lcpp_x, __
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       log(float __lcpp_x) _NOEXCEPT       {return ::logf(__lcpp_x);}
@@ -181,7 +201,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -980,8 +1008,10 @@ log(_A1 __lcpp_x) _NOEXCEPT {return ::log((double)__lcpp_x);}
+@@ -980,8 +1011,10 @@ log(_A1 __lcpp_x) _NOEXCEPT {return ::log((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       log10(float __lcpp_x) _NOEXCEPT       {return ::log10f(__lcpp_x);}
@@ -192,7 +212,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -992,15 +1022,19 @@ log10(_A1 __lcpp_x) _NOEXCEPT {return ::log10((double)__lcpp_x);}
+@@ -992,15 +1025,19 @@ log10(_A1 __lcpp_x) _NOEXCEPT {return ::log10((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       modf(float __lcpp_x, float* __lcpp_y) _NOEXCEPT             {return ::modff(__lcpp_x, __lcpp_y);}
@@ -212,7 +232,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1022,8 +1056,10 @@ pow(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+@@ -1022,8 +1059,10 @@ pow(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       sin(float __lcpp_x) _NOEXCEPT       {return ::sinf(__lcpp_x);}
@@ -223,7 +243,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1034,8 +1070,10 @@ sin(_A1 __lcpp_x) _NOEXCEPT {return ::sin((double)__lcpp_x);}
+@@ -1034,8 +1073,10 @@ sin(_A1 __lcpp_x) _NOEXCEPT {return ::sin((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       sinh(float __lcpp_x) _NOEXCEPT       {return ::sinhf(__lcpp_x);}
@@ -234,7 +254,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1046,8 +1084,10 @@ sinh(_A1 __lcpp_x) _NOEXCEPT {return ::sinh((double)__lcpp_x);}
+@@ -1046,8 +1087,10 @@ sinh(_A1 __lcpp_x) _NOEXCEPT {return ::sinh((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       sqrt(float __lcpp_x) _NOEXCEPT       {return ::sqrtf(__lcpp_x);}
@@ -245,7 +265,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1058,8 +1098,10 @@ sqrt(_A1 __lcpp_x) _NOEXCEPT {return ::sqrt((double)__lcpp_x);}
+@@ -1058,8 +1101,10 @@ sqrt(_A1 __lcpp_x) _NOEXCEPT {return ::sqrt((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       tan(float __lcpp_x) _NOEXCEPT       {return ::tanf(__lcpp_x);}
@@ -256,7 +276,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1070,8 +1112,10 @@ tan(_A1 __lcpp_x) _NOEXCEPT {return ::tan((double)__lcpp_x);}
+@@ -1070,8 +1115,10 @@ tan(_A1 __lcpp_x) _NOEXCEPT {return ::tan((double)__lcpp_x);}
  
  #if !(defined(_AIX) || defined(__sun__))
  inline _LIBCPP_INLINE_VISIBILITY float       tanh(float __lcpp_x) _NOEXCEPT       {return ::tanhf(__lcpp_x);}
@@ -267,7 +287,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1081,7 +1125,9 @@ tanh(_A1 __lcpp_x) _NOEXCEPT {return ::tanh((double)__lcpp_x);}
+@@ -1081,7 +1128,9 @@ tanh(_A1 __lcpp_x) _NOEXCEPT {return ::tanh((double)__lcpp_x);}
  // acosh
  
  inline _LIBCPP_INLINE_VISIBILITY float       acosh(float __lcpp_x) _NOEXCEPT       {return ::acoshf(__lcpp_x);}
@@ -277,7 +297,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1091,7 +1137,9 @@ acosh(_A1 __lcpp_x) _NOEXCEPT {return ::acosh((double)__lcpp_x);}
+@@ -1091,7 +1140,9 @@ acosh(_A1 __lcpp_x) _NOEXCEPT {return ::acosh((double)__lcpp_x);}
  // asinh
  
  inline _LIBCPP_INLINE_VISIBILITY float       asinh(float __lcpp_x) _NOEXCEPT       {return ::asinhf(__lcpp_x);}
@@ -287,7 +307,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1101,7 +1149,10 @@ asinh(_A1 __lcpp_x) _NOEXCEPT {return ::asinh((double)__lcpp_x);}
+@@ -1101,7 +1152,10 @@ asinh(_A1 __lcpp_x) _NOEXCEPT {return ::asinh((double)__lcpp_x);}
  // atanh
  
  inline _LIBCPP_INLINE_VISIBILITY float       atanh(float __lcpp_x) _NOEXCEPT       {return ::atanhf(__lcpp_x);}
@@ -298,7 +318,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1111,7 +1162,9 @@ atanh(_A1 __lcpp_x) _NOEXCEPT {return ::atanh((double)__lcpp_x);}
+@@ -1111,7 +1165,9 @@ atanh(_A1 __lcpp_x) _NOEXCEPT {return ::atanh((double)__lcpp_x);}
  // cbrt
  
  inline _LIBCPP_INLINE_VISIBILITY float       cbrt(float __lcpp_x) _NOEXCEPT       {return ::cbrtf(__lcpp_x);}
@@ -308,7 +328,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1142,6 +1195,7 @@ inline _LIBCPP_INLINE_VISIBILITY double __libcpp_copysign(double __lcpp_x, doubl
+@@ -1142,6 +1198,7 @@ inline _LIBCPP_INLINE_VISIBILITY double __libcpp_copysign(double __lcpp_x, doubl
  #endif
  }
  
@@ -316,7 +336,7 @@ index 77762d554512..601c43330434 100644
  #if __has_builtin(__builtin_copysignl)
  _LIBCPP_CONSTEXPR
  #endif
-@@ -1152,6 +1206,7 @@ inline _LIBCPP_INLINE_VISIBILITY long double __libcpp_copysign(long double __lcp
+@@ -1152,6 +1209,7 @@ inline _LIBCPP_INLINE_VISIBILITY long double __libcpp_copysign(long double __lcp
    return ::copysignl(__lcpp_x, __lcpp_y);
  #endif
  }
@@ -324,7 +344,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  #if __has_builtin(__builtin_copysign)
-@@ -1179,9 +1234,11 @@ inline _LIBCPP_INLINE_VISIBILITY float copysign(float __lcpp_x, float __lcpp_y)
+@@ -1179,9 +1237,11 @@ inline _LIBCPP_INLINE_VISIBILITY float copysign(float __lcpp_x, float __lcpp_y)
    return ::__libcpp_copysign(__lcpp_x, __lcpp_y);
  }
  
@@ -336,7 +356,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1198,7 +1255,9 @@ typename std::_EnableIf
+@@ -1198,7 +1258,9 @@ typename std::__enable_if_t
  // erf
  
  inline _LIBCPP_INLINE_VISIBILITY float       erf(float __lcpp_x) _NOEXCEPT       {return ::erff(__lcpp_x);}
@@ -346,7 +366,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1208,7 +1267,9 @@ erf(_A1 __lcpp_x) _NOEXCEPT {return ::erf((double)__lcpp_x);}
+@@ -1208,7 +1270,9 @@ erf(_A1 __lcpp_x) _NOEXCEPT {return ::erf((double)__lcpp_x);}
  // erfc
  
  inline _LIBCPP_INLINE_VISIBILITY float       erfc(float __lcpp_x) _NOEXCEPT       {return ::erfcf(__lcpp_x);}
@@ -356,7 +376,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1218,7 +1279,9 @@ erfc(_A1 __lcpp_x) _NOEXCEPT {return ::erfc((double)__lcpp_x);}
+@@ -1218,7 +1282,9 @@ erfc(_A1 __lcpp_x) _NOEXCEPT {return ::erfc((double)__lcpp_x);}
  // exp2
  
  inline _LIBCPP_INLINE_VISIBILITY float       exp2(float __lcpp_x) _NOEXCEPT       {return ::exp2f(__lcpp_x);}
@@ -366,7 +386,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1228,7 +1291,9 @@ exp2(_A1 __lcpp_x) _NOEXCEPT {return ::exp2((double)__lcpp_x);}
+@@ -1228,7 +1294,9 @@ exp2(_A1 __lcpp_x) _NOEXCEPT {return ::exp2((double)__lcpp_x);}
  // expm1
  
  inline _LIBCPP_INLINE_VISIBILITY float       expm1(float __lcpp_x) _NOEXCEPT       {return ::expm1f(__lcpp_x);}
@@ -376,7 +396,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1238,7 +1303,9 @@ expm1(_A1 __lcpp_x) _NOEXCEPT {return ::expm1((double)__lcpp_x);}
+@@ -1238,7 +1306,9 @@ expm1(_A1 __lcpp_x) _NOEXCEPT {return ::expm1((double)__lcpp_x);}
  // fdim
  
  inline _LIBCPP_INLINE_VISIBILITY float       fdim(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::fdimf(__lcpp_x, __lcpp_y);}
@@ -386,7 +406,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1266,6 +1333,7 @@ inline _LIBCPP_INLINE_VISIBILITY float       fma(float __lcpp_x, float __lcpp_y,
+@@ -1266,6 +1336,7 @@ inline _LIBCPP_INLINE_VISIBILITY float       fma(float __lcpp_x, float __lcpp_y,
      return ::fmaf(__lcpp_x, __lcpp_y, __lcpp_z);
  #endif
  }
@@ -394,7 +414,7 @@ index 77762d554512..601c43330434 100644
  inline _LIBCPP_INLINE_VISIBILITY long double fma(long double __lcpp_x, long double __lcpp_y, long double __lcpp_z) _NOEXCEPT
  {
  #if __has_builtin(__builtin_fmal)
-@@ -1274,6 +1342,7 @@ inline _LIBCPP_INLINE_VISIBILITY long double fma(long double __lcpp_x, long doub
+@@ -1274,6 +1345,7 @@ inline _LIBCPP_INLINE_VISIBILITY long double fma(long double __lcpp_x, long doub
      return ::fmal(__lcpp_x, __lcpp_y, __lcpp_z);
  #endif
  }
@@ -402,7 +422,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2, class _A3>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1300,7 +1369,9 @@ fma(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) _NOEXCEPT
+@@ -1300,7 +1372,9 @@ fma(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) _NOEXCEPT
  // fmax
  
  inline _LIBCPP_INLINE_VISIBILITY float       fmax(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::fmaxf(__lcpp_x, __lcpp_y);}
@@ -412,7 +432,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1321,7 +1392,9 @@ fmax(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+@@ -1321,7 +1395,9 @@ fmax(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
  // fmin
  
  inline _LIBCPP_INLINE_VISIBILITY float       fmin(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::fminf(__lcpp_x, __lcpp_y);}
@@ -422,7 +442,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1342,7 +1415,9 @@ fmin(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+@@ -1342,7 +1418,9 @@ fmin(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
  // hypot
  
  inline _LIBCPP_INLINE_VISIBILITY float       hypot(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::hypotf(__lcpp_x, __lcpp_y);}
@@ -432,7 +452,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1363,7 +1438,9 @@ hypot(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+@@ -1363,7 +1441,9 @@ hypot(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
  // ilogb
  
  inline _LIBCPP_INLINE_VISIBILITY int ilogb(float __lcpp_x) _NOEXCEPT       {return ::ilogbf(__lcpp_x);}
@@ -442,7 +462,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1373,7 +1450,9 @@ ilogb(_A1 __lcpp_x) _NOEXCEPT {return ::ilogb((double)__lcpp_x);}
+@@ -1373,7 +1453,9 @@ ilogb(_A1 __lcpp_x) _NOEXCEPT {return ::ilogb((double)__lcpp_x);}
  // lgamma
  
  inline _LIBCPP_INLINE_VISIBILITY float       lgamma(float __lcpp_x) _NOEXCEPT       {return ::lgammaf(__lcpp_x);}
@@ -452,7 +472,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1390,6 +1469,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llrint(float __lcpp_x) _NOEXCEPT
+@@ -1390,6 +1472,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llrint(float __lcpp_x) _NOEXCEPT
      return ::llrintf(__lcpp_x);
  #endif
  }
@@ -460,7 +480,7 @@ index 77762d554512..601c43330434 100644
  inline _LIBCPP_INLINE_VISIBILITY long long llrint(long double __lcpp_x) _NOEXCEPT
  {
  #if __has_builtin(__builtin_llrintl)
-@@ -1398,6 +1478,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llrint(long double __lcpp_x) _NOEXCEP
+@@ -1398,6 +1481,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llrint(long double __lcpp_x) _NOEXCEP
      return ::llrintl(__lcpp_x);
  #endif
  }
@@ -468,7 +488,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1421,6 +1502,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llround(float __lcpp_x) _NOEXCEPT
+@@ -1421,6 +1505,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llround(float __lcpp_x) _NOEXCEPT
      return ::llroundf(__lcpp_x);
  #endif
  }
@@ -476,7 +496,7 @@ index 77762d554512..601c43330434 100644
  inline _LIBCPP_INLINE_VISIBILITY long long llround(long double __lcpp_x) _NOEXCEPT
  {
  #if __has_builtin(__builtin_llroundl)
-@@ -1429,6 +1511,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llround(long double __lcpp_x) _NOEXCE
+@@ -1429,6 +1514,7 @@ inline _LIBCPP_INLINE_VISIBILITY long long llround(long double __lcpp_x) _NOEXCE
      return ::llroundl(__lcpp_x);
  #endif
  }
@@ -484,7 +504,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1445,7 +1528,9 @@ llround(_A1 __lcpp_x) _NOEXCEPT
+@@ -1445,7 +1531,9 @@ llround(_A1 __lcpp_x) _NOEXCEPT
  // log1p
  
  inline _LIBCPP_INLINE_VISIBILITY float       log1p(float __lcpp_x) _NOEXCEPT       {return ::log1pf(__lcpp_x);}
@@ -494,7 +514,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1455,7 +1540,9 @@ log1p(_A1 __lcpp_x) _NOEXCEPT {return ::log1p((double)__lcpp_x);}
+@@ -1455,7 +1543,9 @@ log1p(_A1 __lcpp_x) _NOEXCEPT {return ::log1p((double)__lcpp_x);}
  // log2
  
  inline _LIBCPP_INLINE_VISIBILITY float       log2(float __lcpp_x) _NOEXCEPT       {return ::log2f(__lcpp_x);}
@@ -504,7 +524,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1465,7 +1552,9 @@ log2(_A1 __lcpp_x) _NOEXCEPT {return ::log2((double)__lcpp_x);}
+@@ -1465,7 +1555,9 @@ log2(_A1 __lcpp_x) _NOEXCEPT {return ::log2((double)__lcpp_x);}
  // logb
  
  inline _LIBCPP_INLINE_VISIBILITY float       logb(float __lcpp_x) _NOEXCEPT       {return ::logbf(__lcpp_x);}
@@ -514,7 +534,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1539,7 +1628,9 @@ lround(_A1 __lcpp_x) _NOEXCEPT
+@@ -1539,7 +1631,9 @@ lround(_A1 __lcpp_x) _NOEXCEPT
  // nearbyint
  
  inline _LIBCPP_INLINE_VISIBILITY float       nearbyint(float __lcpp_x) _NOEXCEPT       {return ::nearbyintf(__lcpp_x);}
@@ -524,7 +544,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1549,7 +1640,9 @@ nearbyint(_A1 __lcpp_x) _NOEXCEPT {return ::nearbyint((double)__lcpp_x);}
+@@ -1549,7 +1643,9 @@ nearbyint(_A1 __lcpp_x) _NOEXCEPT {return ::nearbyint((double)__lcpp_x);}
  // nextafter
  
  inline _LIBCPP_INLINE_VISIBILITY float       nextafter(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::nextafterf(__lcpp_x, __lcpp_y);}
@@ -534,7 +554,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1569,6 +1662,7 @@ nextafter(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+@@ -1569,6 +1665,7 @@ nextafter(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
  
  // nexttoward
  
@@ -542,7 +562,7 @@ index 77762d554512..601c43330434 100644
  inline _LIBCPP_INLINE_VISIBILITY float       nexttoward(float __lcpp_x, long double __lcpp_y) _NOEXCEPT       {return ::nexttowardf(__lcpp_x, __lcpp_y);}
  inline _LIBCPP_INLINE_VISIBILITY long double nexttoward(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::nexttowardl(__lcpp_x, __lcpp_y);}
  
-@@ -1576,11 +1670,14 @@ template <class _A1>
+@@ -1576,11 +1673,14 @@ template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
  typename std::enable_if<std::is_integral<_A1>::value, double>::type
  nexttoward(_A1 __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::nexttoward((double)__lcpp_x, __lcpp_y);}
@@ -557,7 +577,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1601,7 +1698,9 @@ remainder(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+@@ -1601,7 +1701,9 @@ remainder(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
  // remquo
  
  inline _LIBCPP_INLINE_VISIBILITY float       remquo(float __lcpp_x, float __lcpp_y, int* __lcpp_z) _NOEXCEPT             {return ::remquof(__lcpp_x, __lcpp_y, __lcpp_z);}
@@ -567,7 +587,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1, class _A2>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1684,7 +1783,9 @@ round(_A1 __lcpp_x) _NOEXCEPT
+@@ -1684,7 +1786,9 @@ round(_A1 __lcpp_x) _NOEXCEPT
  // scalbln
  
  inline _LIBCPP_INLINE_VISIBILITY float       scalbln(float __lcpp_x, long __lcpp_y) _NOEXCEPT       {return ::scalblnf(__lcpp_x, __lcpp_y);}
@@ -577,7 +597,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1694,7 +1795,9 @@ scalbln(_A1 __lcpp_x, long __lcpp_y) _NOEXCEPT {return ::scalbln((double)__lcpp_
+@@ -1694,7 +1798,9 @@ scalbln(_A1 __lcpp_x, long __lcpp_y) _NOEXCEPT {return ::scalbln((double)__lcpp_
  // scalbn
  
  inline _LIBCPP_INLINE_VISIBILITY float       scalbn(float __lcpp_x, int __lcpp_y) _NOEXCEPT       {return ::scalbnf(__lcpp_x, __lcpp_y);}
@@ -587,7 +607,7 @@ index 77762d554512..601c43330434 100644
  
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
-@@ -1704,7 +1807,9 @@ scalbn(_A1 __lcpp_x, int __lcpp_y) _NOEXCEPT {return ::scalbn((double)__lcpp_x,
+@@ -1704,7 +1810,9 @@ scalbn(_A1 __lcpp_x, int __lcpp_y) _NOEXCEPT {return ::scalbn((double)__lcpp_x,
  // tgamma
  
  inline _LIBCPP_INLINE_VISIBILITY float       tgamma(float __lcpp_x) _NOEXCEPT       {return ::tgammaf(__lcpp_x);}
@@ -598,10 +618,20 @@ index 77762d554512..601c43330434 100644
  template <class _A1>
  inline _LIBCPP_INLINE_VISIBILITY
 diff --git a/llvm/lib/Support/CommandLine.cpp b/llvm/lib/Support/CommandLine.cpp
-index 6c140863b13c..caab14d29020 100644
+index e64934aa90cc..baa10ad66bc0 100644
 --- a/llvm/lib/Support/CommandLine.cpp
 +++ b/llvm/lib/Support/CommandLine.cpp
-@@ -1112,12 +1112,57 @@ static llvm::Error ExpandResponseFile(
+@@ -15,6 +15,9 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// Modifications copyright (C) 2021 Arm Limited (or its affiliates).
++// All rights reserved.
++
+ #include "llvm/Support/CommandLine.h"
+ 
+ #include "DebugOptions.h"
+@@ -1112,12 +1115,57 @@ static llvm::Error ExpandResponseFile(
    if (!RelativeNames)
      return Error::success();
    llvm::StringRef BasePath = llvm::sys::path::parent_path(FName);

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -164,6 +164,7 @@ def parse_args_to_config() -> Config:
                              '  configure - write target configuration files\n'
                              '  package - create binary package\n'
                              '  all - perform all of the above\n'
+                             '  package-src - create source package\n'
                              '  test - run tests\n'
                              'Default: all')
     args = parser.parse_args()
@@ -353,12 +354,17 @@ def main() -> int:
         build_all(cfg)
         run_tests(cfg)
 
-        def do_package():
+        def do_source_package():
             version.poplulate_commits(cfg.repos_dir)
-            package.write_version_file(cfg, version)
-            package.copy_samples(cfg)
-            package.package_toolchain(cfg)
-        run_or_skip(cfg, Action.PACKAGE, do_package, 'packaging')
+            package.create_source_package(cfg, version)
+        run_or_skip(cfg, Action.PACKAGE_SRC, do_source_package,
+                    'source package')
+
+        def do_binary_package():
+            version.poplulate_commits(cfg.repos_dir)
+            package.create_binary_package(cfg, version)
+        run_or_skip(cfg, Action.PACKAGE, do_binary_package, 'binary package')
+
     except util.ToolchainBuildError:
         # By this time the error must have already been logged
         return 1

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -26,9 +26,10 @@ import repos
 import util
 
 
-def write_version_file(cfg: config.Config, version: repos.LLVMBMTC) -> None:
+def _write_version_file(cfg: config.Config, version: repos.LLVMBMTC,
+                        target_dir: str) -> None:
     """Create VERSION.txt in the install directory."""
-    dest = os.path.join(cfg.target_llvm_dir, 'VERSION.txt')
+    dest = os.path.join(target_dir, 'VERSION.txt')
     if cfg.verbose:
         logging.info('Writing "%s" to %s', cfg.version_string, dest)
     lines = [cfg.version_string, '', 'Components:']
@@ -40,7 +41,7 @@ def write_version_file(cfg: config.Config, version: repos.LLVMBMTC) -> None:
     util.write_lines(lines, dest)
 
 
-def copy_samples(cfg: config.Config) -> None:
+def _copy_samples(cfg: config.Config) -> None:
     """Copy code samples, filter out files that are not usable on the target
        platform."""
     src = os.path.join(cfg.source_dir, 'samples')
@@ -76,7 +77,7 @@ def _get_excluded_symlinks(cfg: config.Config) -> FrozenSet[str]:
     return frozenset(excludes)
 
 
-def _create_tarball(cfg: config.Config, dest_pkg: str) -> None:
+def _create_tarball(cfg: config.Config, src_dir: str, dest_pkg: str) -> None:
     """Create a tarball package."""
     def reset_uid(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo:
         tarinfo.uid = tarinfo.gid = 0
@@ -88,7 +89,7 @@ def _create_tarball(cfg: config.Config, dest_pkg: str) -> None:
         exclude_set = _get_excluded_symlinks(cfg)
         dereference = True
     with tarfile.open(dest_pkg, 'w:gz') as dest:
-        for root, _, files in os.walk(cfg.target_llvm_dir):
+        for root, _, files in os.walk(src_dir):
             for fname in sorted(files):
                 if fname in exclude_set:
                     continue
@@ -102,11 +103,11 @@ def _create_tarball(cfg: config.Config, dest_pkg: str) -> None:
                          filter=reset_uid)
 
 
-def _create_zip(cfg: config.Config, dest_pkg: str) -> None:
+def _create_zip(cfg: config.Config, src_dir: str, dest_pkg: str) -> None:
     """Create a zip package."""
     exclude_set = _get_excluded_symlinks(cfg)
     with zipfile.ZipFile(dest_pkg, 'w', zipfile.ZIP_DEFLATED) as dest:
-        for root, _, files in os.walk(cfg.target_llvm_dir):
+        for root, _, files in os.walk(src_dir):
             for fname in files:
                 if fname in exclude_set:
                     continue
@@ -117,8 +118,8 @@ def _create_zip(cfg: config.Config, dest_pkg: str) -> None:
                 dest.write(abs_path, arc_name)
 
 
-def package_toolchain(cfg: config.Config) -> None:
-    """Create a package with a newly built toolchain."""
+def _create_archive(cfg: config.Config, pkg_src_dir, pkg_dest_name) -> None:
+    """Create a package from a given directory."""
     if not os.path.exists(cfg.package_dir):
         os.makedirs(cfg.package_dir)
     format_mapping = {
@@ -126,11 +127,30 @@ def package_toolchain(cfg: config.Config) -> None:
         PackageFormat.ZIP: ('.zip', _create_zip),
     }
     package_ext, package_fn = format_mapping[cfg.package_format]
-    dest_pkg = os.path.join(cfg.package_dir,
-                            cfg.package_base_name + package_ext)
+    dest_pkg = os.path.join(cfg.package_dir, pkg_dest_name + package_ext)
     logging.info('Creating package %s', dest_pkg)
     try:
-        package_fn(cfg, dest_pkg)
+        package_fn(cfg, pkg_src_dir, dest_pkg)
     except RuntimeError as ex:
         logging.error('Failed to create %s', dest_pkg)
         raise util.ToolchainBuildError from ex
+
+
+def create_binary_package(cfg: config.Config, version: repos.LLVMBMTC) -> None:
+    """Create a binary package with a newly built toolchain."""
+    _write_version_file(cfg, version, cfg.target_llvm_dir)
+    _copy_samples(cfg)
+    _create_archive(cfg, cfg.target_llvm_dir, cfg.bin_package_base_name)
+
+
+def create_source_package(cfg: config.Config, version: repos.LLVMBMTC) -> None:
+    """Create a source package with a newly built toolchain."""
+    if os.path.exists(cfg.install_src_subdir):
+        logging.info('Removing existing directory %s', cfg.install_src_subdir)
+        shutil.rmtree(cfg.install_src_subdir)
+    os.makedirs(cfg.install_src_subdir)
+    repos.export_repository(cfg.source_dir, cfg.install_src_subdir, False)
+    repos.export_toolchain_repositories(cfg.repos_dir, version,
+                                        cfg.install_src_subdir)
+    _write_version_file(cfg, version, cfg.install_src_subdir)
+    _create_archive(cfg, cfg.install_src_subdir, cfg.src_package_base_name)

--- a/scripts/repos.py
+++ b/scripts/repos.py
@@ -25,7 +25,6 @@ import sys
 from typing import List, Mapping, Optional, Any
 
 import git  # type: ignore
-import yaml
 
 import util
 
@@ -158,17 +157,13 @@ class LLVMBMTC:
 def get_all_versions(filename: str) -> Mapping[str, LLVMBMTC]:
     """Build the database containing all releases from a YAML file."""
     versions = {}
-    with open(filename, 'r') as stream:
-        try:
-            yml = yaml.load(stream, Loader=yaml.FullLoader)
-            for value in yml:
-                toolchain = LLVMBMTC(value)
-                if toolchain.revision in versions:
-                    die('toolchain revision {} previously defined'.format(
-                        toolchain.revision))
-                versions[toolchain.revision] = toolchain
-        except yaml.YAMLError as ex:
-            logging.error(ex)
+    yml = util.read_yaml(filename)
+    for value in yml['Revisions']:
+        toolchain = LLVMBMTC(value)
+        if toolchain.revision in versions:
+            die('toolchain revision {} previously defined'.format(
+                toolchain.revision))
+        versions[toolchain.revision] = toolchain
 
     return versions
 

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -16,6 +16,8 @@
 import logging
 from typing import Any, Sequence, List
 
+import yaml
+
 
 class ToolchainBuildError(RuntimeError):
     """A single error for all failures related to toolchain build: this
@@ -39,3 +41,13 @@ def configure_logging() -> None:
     """Set logging format and level threshold for the default logger."""
     log_format = '%(levelname)s: %(message)s'
     logging.basicConfig(format=log_format, level=logging.INFO)
+
+
+def read_yaml(path: str) -> Any:
+    """Read a YAML file and return its contents as a Python dict or list."""
+    with open(path, 'rt') as in_f:
+        try:
+            return yaml.load(in_f, Loader=yaml.FullLoader)
+        except yaml.YAMLError as ex:
+            logging.error(ex)
+            raise

--- a/versions.yml
+++ b/versions.yml
@@ -15,44 +15,47 @@
 # limitations under the License.
 #
 
-- Revision: "13.0.0"
-  Modules:
-    - Name: llvm.git
-      FriendlyName: LLVM
-      URL:  https://github.com/llvm/llvm-project.git
-      Revision: llvmorg-13.0.0
-      Patch: llvm-13.patch
-    - Name: newlib.git
-      FriendlyName: Newlib
-      URL:  https://github.com/mirror/newlib-cygwin.git
-      Revision: newlib-4.1.0
-      Patch: newlib-4.1.0-llvm-13.patch
+---
+SourceType: "standalone-build-scripts"
+Revisions:
+  - Revision: "13.0.0"
+    Modules:
+      - Name: llvm.git
+        FriendlyName: LLVM
+        URL:  https://github.com/llvm/llvm-project.git
+        Revision: llvmorg-13.0.0
+        Patch: llvm-13.patch
+      - Name: newlib.git
+        FriendlyName: Newlib
+        URL:  https://github.com/mirror/newlib-cygwin.git
+        Revision: newlib-4.1.0
+        Patch: newlib-4.1.0-llvm-13.patch
 
-- Revision: branch-13
-  Modules:
-    - Name: llvm.git
-      FriendlyName: LLVM
-      URL:  https://github.com/llvm/llvm-project.git
-      Branch: release/13.x
-      Revision: HEAD
-      Patch: llvm-13.patch
-    - Name: newlib.git
-      FriendlyName: Newlib
-      URL:  https://github.com/mirror/newlib-cygwin.git
-      Revision: newlib-4.1.0
-      Patch: newlib-4.1.0-llvm-13.patch
+  - Revision: branch-13
+    Modules:
+      - Name: llvm.git
+        FriendlyName: LLVM
+        URL:  https://github.com/llvm/llvm-project.git
+        Branch: release/13.x
+        Revision: HEAD
+        Patch: llvm-13.patch
+      - Name: newlib.git
+        FriendlyName: Newlib
+        URL:  https://github.com/mirror/newlib-cygwin.git
+        Revision: newlib-4.1.0
+        Patch: newlib-4.1.0-llvm-13.patch
 
-- Revision: HEAD
-  Modules:
-    - Name: llvm.git
-      FriendlyName: LLVM
-      URL:  https://github.com/llvm/llvm-project.git
-      Branch: main
-      Revision: HEAD
-      Patch: llvm-HEAD.patch
-    - Name: newlib.git
-      FriendlyName: Newlib
-      URL:  https://github.com/mirror/newlib-cygwin.git
-      Branch: master
-      Revision: HEAD
-      Patch: newlib-HEAD.patch
+  - Revision: HEAD
+    Modules:
+      - Name: llvm.git
+        FriendlyName: LLVM
+        URL:  https://github.com/llvm/llvm-project.git
+        Branch: main
+        Revision: HEAD
+        Patch: llvm-HEAD.patch
+      - Name: newlib.git
+        FriendlyName: Newlib
+        URL:  https://github.com/mirror/newlib-cygwin.git
+        Branch: master
+        Revision: HEAD
+        Patch: newlib-HEAD.patch


### PR DESCRIPTION
This series of patches implements a new build script action "package-src" which creates a source package containing a copy of the build scripts bundled with LLVM and newlib source code.
It also adds support for building the toolchain from such source packages.