### PR TITLE
Fix HEAD build, two more patches

### DIFF
--- a/patches/llvm-HEAD.patch
+++ b/patches/llvm-HEAD.patch
@@ -1,5 +1,5 @@
 diff --git a/libcxx/include/atomic b/libcxx/include/atomic
-index cfd0e1d054a8..6e2d464638f3 100644
+index 4b60d4d6802b..38041243c288 100644
 --- a/libcxx/include/atomic
 +++ b/libcxx/include/atomic
 @@ -7,6 +7,9 @@
@@ -27,7 +27,7 @@ index cfd0e1d054a8..6e2d464638f3 100644
  #define ATOMIC_FLAG_INIT {false}
  #define ATOMIC_VAR_INIT(__v) {__v}
 diff --git a/libcxx/include/cmath b/libcxx/include/cmath
-index 3a7985f7d454..0cfaec5693dc 100644
+index d8fb0c0d759a..a36d2f499622 100644
 --- a/libcxx/include/cmath
 +++ b/libcxx/include/cmath
 @@ -7,6 +7,9 @@
@@ -59,8 +59,8 @@ index 3a7985f7d454..0cfaec5693dc 100644
  lerp(long double __a, long double __b, long double __t) _NOEXCEPT { return __lerp(__a, __b, __t); }
 +#endif
  
- #endif // _LIBCPP_STD_VER > 17
- 
+ template <class _A1, class _A2, class _A3>
+ inline _LIBCPP_HIDE_FROM_ABI
 diff --git a/libcxx/include/math.h b/libcxx/include/math.h
 index 850cdcfb32f6..9774196a2da7 100644
 --- a/libcxx/include/math.h

--- a/patches/llvm-HEAD.patch
+++ b/patches/llvm-HEAD.patch
@@ -1,33 +1,5 @@
-diff --git a/libcxx/include/atomic b/libcxx/include/atomic
-index 4b60d4d6802b..38041243c288 100644
---- a/libcxx/include/atomic
-+++ b/libcxx/include/atomic
-@@ -7,6 +7,9 @@
- //
- //===----------------------------------------------------------------------===//
- 
-+// Modifications copyright (C) 2022 Arm Limited (or its affiliates).
-+// All rights reserved.
-+
- #ifndef _LIBCPP_ATOMIC
- #define _LIBCPP_ATOMIC
- 
-@@ -2691,10 +2694,13 @@ typedef conditional<_LIBCPP_CONTENTION_LOCK_FREE, __cxx_contention_t, char>::typ
- typedef conditional<_LIBCPP_CONTENTION_LOCK_FREE, __cxx_contention_t, unsigned char>::type      __libcpp_unsigned_lock_free;
- #else
-     // No signed/unsigned lock-free types
-+#define _LIBCPP_NO_LOCK_FREE_TYPES
- #endif
- 
-+#if !defined(_LIBCPP_NO_LOCK_FREE_TYPES)
- typedef atomic<__libcpp_signed_lock_free> atomic_signed_lock_free;
- typedef atomic<__libcpp_unsigned_lock_free> atomic_unsigned_lock_free;
-+#endif
- 
- #define ATOMIC_FLAG_INIT {false}
- #define ATOMIC_VAR_INIT(__v) {__v}
 diff --git a/libcxx/include/cmath b/libcxx/include/cmath
-index d8fb0c0d759a..a36d2f499622 100644
+index 8bd55542ed92..e49a5b7b8f1a 100644
 --- a/libcxx/include/cmath
 +++ b/libcxx/include/cmath
 @@ -7,6 +7,9 @@
@@ -62,7 +34,7 @@ index d8fb0c0d759a..a36d2f499622 100644
  template <class _A1, class _A2, class _A3>
  inline _LIBCPP_HIDE_FROM_ABI
 diff --git a/libcxx/include/math.h b/libcxx/include/math.h
-index 850cdcfb32f6..9774196a2da7 100644
+index e59ac6be11bf..622fb96472d6 100644
 --- a/libcxx/include/math.h
 +++ b/libcxx/include/math.h
 @@ -7,6 +7,9 @@

--- a/versions.yml
+++ b/versions.yml
@@ -50,7 +50,7 @@ Revisions:
       - Name: llvm.git
         FriendlyName: LLVM
         URL:  https://github.com/llvm/llvm-project.git
-        Revision: 004ebe22f857aedb1cceb3097db95bdab28d3fba
+        Revision: d5ab243c6f79f881121a80487f0879d2ab0acc41
         Patch: llvm-HEAD.patch
       - Name: newlib.git
         FriendlyName: Newlib

--- a/versions.yml
+++ b/versions.yml
@@ -50,7 +50,7 @@ Revisions:
       - Name: llvm.git
         FriendlyName: LLVM
         URL:  https://github.com/llvm/llvm-project.git
-        Revision: 9d37d0ea34858288faf6351b9bdc0a0b91107c82
+        Revision: 004ebe22f857aedb1cceb3097db95bdab28d3fba
         Patch: llvm-HEAD.patch
       - Name: newlib.git
         FriendlyName: Newlib


### PR DESCRIPTION
The patches update llvm-HEAD.patch to accommodate upstream changes in libc++ headers.