### PR TITLE
Set bug report URL

### DIFF
--- a/scripts/make.py
+++ b/scripts/make.py
@@ -217,6 +217,8 @@ class ToolchainBuild:
             'CMAKE_INSTALL_PREFIX:STRING': cfg.target_llvm_dir,
             'LLVM_ENABLE_PROJECTS:STRING': ';'.join(projects),
             'LLVM_DISTRIBUTION_COMPONENTS:STRING': ';'.join(dist_comps),
+            'BUG_REPORT_URL': 'https://github.com/ARM-software/'
+                              'LLVM-embedded-toolchain-for-Arm/issues',
         })
         if cfg.is_cross_compiling:
             native_tools_dir = join(cfg.native_llvm_build_dir, 'bin')


### PR DESCRIPTION
This patch sets the bug report URL to point to the LLVM Embedded
Toolchain for Arm Github issues page rather than that of upstream
LLVM.

The URL is displayed when an internal compiler error occurs.