### PR TITLE
Update newlib-HEAD.patch, libgloss/libnosys/configure

### DIFF
--- a/patches/newlib-HEAD.patch
+++ b/patches/newlib-HEAD.patch
@@ -68,17 +68,17 @@ index 845ad0173..2056c2adf 100644
          .global __rt_stkovf_split_small
  
 diff --git a/libgloss/libnosys/configure b/libgloss/libnosys/configure
-index 7c23c7a0a..2fc584169 100755
+index fe8244703..53585e19b 100755
 --- a/libgloss/libnosys/configure
 +++ b/libgloss/libnosys/configure
-@@ -2058,7 +2058,7 @@ case "${target}" in
+@@ -2081,7 +2081,7 @@ $as_echo "#define MISSING_SYSCALL_NAMES 1" >>confdefs.h
  esac
  
  case "${target}" in
 -  *-*-elf)
 +  *-*-elf|*-*-eabi*)
-         $as_echo "#define HAVE_ELF 1" >>confdefs.h
  
+ $as_echo "#define HAVE_ELF 1" >>confdefs.h
  
 diff --git a/newlib/libc/machine/aarch64/memchr.S b/newlib/libc/machine/aarch64/memchr.S
 index 53f5d6bc0..81fcecccd 100644

--- a/versions.yml
+++ b/versions.yml
@@ -55,5 +55,5 @@ Revisions:
       - Name: newlib.git
         FriendlyName: Newlib
         URL:  https://github.com/mirror/newlib-cygwin.git
-        Revision: 5badb8aa0a6a1a79504dc0cd4ee40df1f173060c
+        Revision: 8c57b8b2b4c4f82e8cca6c4c6d8ac8a1c05fe8a9
         Patch: newlib-HEAD.patch


### PR DESCRIPTION
Upstream newlib commit 8c57b8b2b4c4f82e8cca6c4c6d8ac8a1c05fe8a9
regenerated the 'configure' file causing slight changes in
whitespaces. newlib-HEAD.patch needs to be updated to apply cleanly.

There are no functional changes in the patch, just a change in the
diff context.