### PR TITLE
Update newlib-HEAD.patch, remove libgloss/libnosys/configure

### DIFF
--- a/patches/newlib-HEAD.patch
+++ b/patches/newlib-HEAD.patch
@@ -67,19 +67,6 @@ index 845ad0173..2056c2adf 100644
          .global __rt_stkovf_split_big
          .global __rt_stkovf_split_small
  
-diff --git a/libgloss/libnosys/configure b/libgloss/libnosys/configure
-index 72c65a68c..474b486f9 100755
---- a/libgloss/libnosys/configure
-+++ b/libgloss/libnosys/configure
-@@ -2071,7 +2071,7 @@ $as_echo "#define MISSING_SYSCALL_NAMES 1" >>confdefs.h
- esac
- 
- case "${target}" in
--  *-*-elf)
-+  *-*-elf|*-*-eabi*)
- 
- $as_echo "#define HAVE_ELF 1" >>confdefs.h
- 
 diff --git a/newlib/libc/machine/aarch64/memchr.S b/newlib/libc/machine/aarch64/memchr.S
 index 53f5d6bc0..81fcecccd 100644
 --- a/newlib/libc/machine/aarch64/memchr.S

--- a/versions.yml
+++ b/versions.yml
@@ -55,5 +55,5 @@ Revisions:
       - Name: newlib.git
         FriendlyName: Newlib
         URL:  https://github.com/mirror/newlib-cygwin.git
-        Revision: 063d67faf0266e5ba169bc5cfde8aed011b1d41b
+        Revision: d5a20f0b70c73c72ec2bc4b639815bb821859255
         Patch: newlib-HEAD.patch


### PR DESCRIPTION
Upstream newlib commit d5a20f0b70c73c72ec2bc4b639815bb821859255
merges libgloss/libnosys/configure into libgloss/configure. The new
configure script uses a proper check for ELF support rather than
checking that the target triple ends with "-elf" (which gives
incorrect result for "arm-*-eabi").

Because of the change we no longer need a downstream patch for the
configure script.