### PR TITLE
Update newlib-HEAD.patch, startup code

### DIFF
--- a/patches/newlib-HEAD.patch
+++ b/patches/newlib-HEAD.patch
@@ -1,29 +1,7 @@
-diff --git a/libgloss/aarch64/crt0.S b/libgloss/aarch64/crt0.S
-index f831be12e..e3f45c95e 100644
---- a/libgloss/aarch64/crt0.S
-+++ b/libgloss/aarch64/crt0.S
-@@ -36,7 +36,7 @@
- #error __USER_LABEL_PREFIX is not defined
- #endif
- 
--#ifdef HAVE_INITFINI_ARRAY
-+#ifdef _HAVE_INITFINI_ARRAY
- #define _init	__libc_init_array
- #define _fini	__libc_fini_array
- #endif
 diff --git a/libgloss/arm/crt0.S b/libgloss/arm/crt0.S
-index 8490bde2f..8826d4916 100644
+index 78515180b..8826d4916 100644
 --- a/libgloss/arm/crt0.S
 +++ b/libgloss/arm/crt0.S
-@@ -12,7 +12,7 @@
- #error __USER_LABEL_PREFIX is not defined
- #endif
- 
--#ifdef HAVE_INITFINI_ARRAY
-+#ifdef _HAVE_INITFINI_ARRAY
- #define _init	__libc_init_array
- #define _fini	__libc_fini_array
- #endif
 @@ -565,7 +565,7 @@ change_back:
  
  	/* For Thumb, constants must be after the code since only 

--- a/versions.yml
+++ b/versions.yml
@@ -55,5 +55,5 @@ Revisions:
       - Name: newlib.git
         FriendlyName: Newlib
         URL:  https://github.com/mirror/newlib-cygwin.git
-        Revision: 437c5c5085ff30b4a4960b2b53d06728c788361d
+        Revision: 063d67faf0266e5ba169bc5cfde8aed011b1d41b
         Patch: newlib-HEAD.patch


### PR DESCRIPTION
Upstream newlib commit 063d67faf0266e5ba169bc5cfde8aed011b1d41b fixes
the issue with HAVE_INITFINI_ARRAY (the macro had been renamed in
configure scripts and C source code, but not in startup code written
in assembly), so we no longer need a downstream fix for it.