### PR TITLE
Remove hard-coded commit hashes from versions.yml HEAD config

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2021, Arm Limited and affiliates.
+# Copyright (c) 2020-2022, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,10 +50,12 @@ Revisions:
       - Name: llvm.git
         FriendlyName: LLVM
         URL:  https://github.com/llvm/llvm-project.git
-        Revision: f642436cc213f99a90e3a4258666dd693b29d79d
+        Branch: main
+        Revision: HEAD
         Patch: llvm-HEAD.patch
       - Name: newlib.git
         FriendlyName: Newlib
         URL:  https://github.com/mirror/newlib-cygwin.git
-        Revision: d5a20f0b70c73c72ec2bc4b639815bb821859255
+        Branch: master
+        Revision: HEAD
         Patch: newlib-HEAD.patch


### PR DESCRIPTION
A prior commit b4aa4b716dc3c1b4923b57c048b5e0e79c13ca5c changed the
HEAD build configuration in versions.yml to use hard-coded commits of
LLVM and newlib, so that build breakages could be fixed one by one.

Now that all breaking changes have been addressed, we can restore the
HEAD configuration to track the tips of upstream branches as before.