### PR TITLE
Revert "Remove hard-coded commit hashes from versions.yml HEAD config"

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, Arm Limited and affiliates.
+# Copyright (c) 2020-2021, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,12 +50,10 @@ Revisions:
       - Name: llvm.git
         FriendlyName: LLVM
         URL:  https://github.com/llvm/llvm-project.git
-        Branch: main
-        Revision: HEAD
+        Revision: f642436cc213f99a90e3a4258666dd693b29d79d
         Patch: llvm-HEAD.patch
       - Name: newlib.git
         FriendlyName: Newlib
         URL:  https://github.com/mirror/newlib-cygwin.git
-        Branch: master
-        Revision: HEAD
+        Revision: d5a20f0b70c73c72ec2bc4b639815bb821859255
         Patch: newlib-HEAD.patch


### PR DESCRIPTION
This reverts commit 798361a321e7aa13cdc0d867548cf582d0037a12.

The commit causes build failure on machines that don't have 'makeinfo'
(part of 'texinfo' package) installed.