### PR TITLE
Fix newlib build failure

### DIFF
--- a/patches/newlib-HEAD.patch
+++ b/patches/newlib-HEAD.patch
@@ -25,7 +25,7 @@ index 6b2d62a9b..000a2c728 100644
  #endif
  {
 diff --git a/libgloss/arm/syscalls.c b/libgloss/arm/syscalls.c
-index fc394f94b..0b3287df4 100644
+index 710a741ee..9e710b09a 100644
 --- a/libgloss/arm/syscalls.c
 +++ b/libgloss/arm/syscalls.c
 @@ -180,7 +180,7 @@ initialise_monitor_handles (void)
@@ -67,6 +67,13 @@ index 845ad0173..2056c2adf 100644
          .global __rt_stkovf_split_big
          .global __rt_stkovf_split_small
  
+diff --git a/libgloss/doc/porting.info b/libgloss/doc/porting.info
+new file mode 100644
+index 000000000..8b1378917
+--- /dev/null
++++ b/libgloss/doc/porting.info
+@@ -0,0 +1 @@
++
 diff --git a/newlib/libc/machine/aarch64/memchr.S b/newlib/libc/machine/aarch64/memchr.S
 index 53f5d6bc0..81fcecccd 100644
 --- a/newlib/libc/machine/aarch64/memchr.S

--- a/versions.yml
+++ b/versions.yml
@@ -55,5 +55,5 @@ Revisions:
       - Name: newlib.git
         FriendlyName: Newlib
         URL:  https://github.com/mirror/newlib-cygwin.git
-        Revision: d5a20f0b70c73c72ec2bc4b639815bb821859255
+        Revision: 492e5fe8b0863e15ffd5a269e42b60fabfc5f5db
         Patch: newlib-HEAD.patch


### PR DESCRIPTION
Starting with upstream newlib commit
492e5fe8b0863e15ffd5a269e42b60fabfc5f5db newlib build started failing
on machine that don't have makeinfo (part of texinfo package)
installed when trying to build the file libgloss/doc/porting.info.

We don't provide newlib docs as part of our distribution, so makeinfo
should not be required. This patch fixes the issue by creating an
empty libgloss/doc/porting.info file.