### PR TITLE
Use newlib commit that does not require autotools

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -55,5 +55,5 @@ Revisions:
       - Name: newlib.git
         FriendlyName: Newlib
         URL:  https://github.com/mirror/newlib-cygwin.git
-        Revision: 492e5fe8b0863e15ffd5a269e42b60fabfc5f5db
+        Revision: 4ed502ba02270adee7c46bb738374cab867baee1
         Patch: newlib-HEAD.patch


### PR DESCRIPTION
The newlib commit we are currently using has stale
libgloss/aclocal.m4 file, and because of this build fails on machines
that don't have autotools installed.

This patch fixes the issue by changing newlib commit to point to a
commit in which files generated by autotools have been been updated.