### PR TITLE
Fix patch for LLVM HEAD

### DIFF
--- a/patches/llvm-HEAD.patch
+++ b/patches/llvm-HEAD.patch
@@ -14,10 +14,10 @@ index be5cbe362666..520d54e6bb90 100644
  
 @@ -531,7 +534,9 @@ using ::truncl _LIBCPP_USING_IF_EXISTS;
  #if _LIBCPP_STD_VER > 14
- inline _LIBCPP_INLINE_VISIBILITY float       hypot(       float x,       float y,       float z ) { return sqrt(x*x + y*y + z*z); }
- inline _LIBCPP_INLINE_VISIBILITY double      hypot(      double x,      double y,      double z ) { return sqrt(x*x + y*y + z*z); }
+ inline _LIBCPP_INLINE_VISIBILITY float       hypot(       float __x,       float __y,       float __z ) { return sqrt(__x*__x + __y*__y + __z*__z); }
+ inline _LIBCPP_INLINE_VISIBILITY double      hypot(      double __x,      double __y,      double __z ) { return sqrt(__x*__x + __y*__y + __z*__z); }
 +#if !(defined(__NEWLIB__) && (defined(_LDBLD_EQ_DBL) || !defined(__CYGWIN__)))
- inline _LIBCPP_INLINE_VISIBILITY long double hypot( long double x, long double y, long double z ) { return sqrt(x*x + y*y + z*z); }
+ inline _LIBCPP_INLINE_VISIBILITY long double hypot( long double __x, long double __y, long double __z ) { return sqrt(__x*__x + __y*__y + __z*__z); }
 +#endif
  
  template <class _A1, class _A2, class _A3>


### PR DESCRIPTION
Required because of a change in libcxx to uglify parameter names.
https://reviews.llvm.org/D129051