### PR TITLE
Build newlib with -Wno-implicit-function-declaration

### DIFF
--- a/scripts/make.py
+++ b/scripts/make.py
@@ -505,8 +505,12 @@ class ToolchainBuild:
             bin_path = join(cfg.native_llvm_bin_dir, bin_name)
             if cfg.use_ccache:
                 bin_path = 'ccache ' + bin_path
-            return '{} -target {} -ffreestanding'.format(bin_path,
-                                                         lib_spec.target)
+            return ' '.join([
+                bin_path,
+                '-target', lib_spec.target,
+                '-ffreestanding',
+                '-Wno-implicit-function-declaration',
+            ])
 
         # __USES_INITFINI__ and HAVE_INIT_FINI are related to the .init_array
         # mechanism implementation: __USES_INITFINI__ enables the call to


### PR DESCRIPTION
Newlib only declares long double functions like cosl if long double is
equivalent to double. On AArch64 long double is twice the size of double
so the declarations are missing. However Newlib's build system still
tries to compile the long double code.

The LLVM change https://reviews.llvm.org/D122983 means that clang no
longer implicitly declares functions by default. Therefore use
-Wno-implicit-function-declaration to work around the problem.

Ideally Newlib's build system would be fixed, but since we plan on
switching to picolibc (which doesn't have this problem) just use this
workaround instead of fixing it properly.