### PR TITLE
Move default install location into build dir

### DIFF
--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -62,8 +62,10 @@ Some notable options include:
     [Cross-compiling the toolchain for Windows](#cross-compiling-the-toolchain-for-windows))
 * ``--host-toolchain-dir`` the directory from Step 0 that the toolchain resides
   in. Default is ``/usr/bin``.
+* ``--build-dir`` the directory to use for build output.
+  Default is ``./build-<revision>``.
 * ``--install-dir`` the LLVM Embedded Toolchain for Arm installation directory.
-  Default is ``./install-<revision>``.
+  Default is ``<build-dir>/install``.
 
 The build script can optionally take advantage of some tools to speed up the
 build. Currently, these tools are ``ccache``, and ``ninja``.

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -64,11 +64,10 @@ def parse_args_to_config() -> Config:
                              '(default: ./build-<revision>)')
     parser.add_argument('--install-dir', type=str, metavar='PATH',
                         help='directory to install the toolchain to '
-                             '(default: ./install-<revision>)')
+                             '(default: <build-dir>/install)')
     parser.add_argument('--package-dir', type=str, metavar='PATH',
-                        default=cwd,
                         help='directory to store the packaged toolchain in '
-                             '(default: .)')
+                             '(default: <build-dir>)')
     parser.add_argument('--repositories-dir', type=str, metavar='PATH',
                         help='path to directory containing LLVM and picolibc '
                              'repositories (default: ./repos-<revision>)')

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -358,8 +358,16 @@ class Config:  # pylint: disable=too-many-instance-attributes
             self.repos_dir = _assign_dir(args.repositories_dir, 'repos', rev)
 
         self.build_dir = _assign_dir(args.build_dir, 'build', rev)
-        self.install_dir = _assign_dir(args.install_dir, 'install', rev)
-        self.package_dir = os.path.abspath(args.package_dir)
+        self.install_dir = (
+            os.path.abspath(args.install_dir)
+            if args.install_dir
+            else os.path.join(self.build_dir, 'install')
+        )
+        self.package_dir = (
+            os.path.abspath(args.package_dir)
+            if args.package_dir
+            else self.build_dir
+        )
         self.checkout_mode = CheckoutMode(args.checkout_mode)
         self.build_mode = BuildMode(args.build_mode)
 


### PR DESCRIPTION
The smoke tests use the install dir, which meant that deleting the build
dir didn't assure a valid test result.
When compared to other build systems this is surprising.
By moving the install dir into the build dir the expectation that
deleting the build dir will cause tests to use fresh build output is
upheld.

For consistency, also default to putting the package tar.gz in the build
directory.