### PR TITLE
Revert "Introduce -resource-dir flag to config files"

### DIFF
--- a/scripts/cfg_files.py
+++ b/scripts/cfg_files.py
@@ -35,7 +35,6 @@ def write_cfg_files(cfg: config.Config, lib_spec: config.LibrarySpec) -> None:
         # libc++ is built with LIBCXX_ENABLE_RTTI=OFF
         '-fno-rtti',
         f'--sysroot {sysroot}',
-        f'-resource-dir {sysroot}',
     ]
 
     no_semihost_lines = base_cfg_lines + [


### PR DESCRIPTION
This reverts commit 316c635e48b53f3ba8e3ee00444d0cfb467aff6d.

The change caused this error while running `build.py test`:

```
  In file included from hello.c:1:
  In file included from /work/LLVM-embedded-toolchain-for-Arm/build-HEAD/install/LLVMEmbeddedToolchainForArm-HEAD/bin/../lib/clang-runtimes/armv6m_soft_nofp/include/stdio.h:44:
  In file included from /work/LLVM-embedded-toolchain-for-Arm/build-HEAD/install/LLVMEmbeddedToolchainForArm-HEAD/bin/../lib/clang-runtimes/armv6m_soft_nofp/include/inttypes.h:17:
  /work/LLVM-embedded-toolchain-for-Arm/build-HEAD/install/LLVMEmbeddedToolchainForArm-HEAD/bin/../lib/clang-runtimes/armv6m_soft_nofp/include/sys/config.h:34:10: fatal error: 'float.h' file not found
  #include <float.h>
          ^~~~~~~~~
  1 error generated.
  Makefile:21: recipe for target 'hello.elf' failed
```