### PR TITLE
Fix re-patching picolibc

### DIFF
--- a/scripts/repos.py
+++ b/scripts/repos.py
@@ -239,8 +239,8 @@ def patch_repositories(checkout_path: str, tc_version: LLVMBMTC,
         repo = git.Repo(repo_path)
         try:
             repo.head.reset(index=True, working_tree=True)
-            # Remove ignored files
-            repo.git.clean(['-fX'])
+            # Remove untracked files and directories
+            repo.git.clean(['-fdx'])
             repo.git.apply(['-p1', patch_file])
         except git.exc.GitCommandError as ex:  # pylint: disable=no-member
             die('could not patch "{}" with "{}".\n'


### PR DESCRIPTION
Applying the picolibc patch creates new files.
If those files exist when applying the patch a second time then patching will fail because Git refuses to overwrite existing files.