### PR TITLE
.cfg suffix is no longer automatically added to --config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Replaced newlib with [picolibc](https://github.com/picolibc/picolibc) (GitHub issue #61)
 - Renamed and updated configuration files
+- Configuration files must now be specified including the file name suffix e.g. `--config armv6m_soft_nofp.cfg`
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For example:
 
 ```
 $ PATH=<install-dir>/LLVMEmbeddedToolchainForArm-<revision>/bin:$PATH
-$ clang --config armv6m_soft_nofp_semihost -T picolibc.ld -o example example.c
+$ clang --config armv6m_soft_nofp_semihost.cfg -T picolibc.ld -o example example.c
 ```
 
 The available configuration files can be listed using:

--- a/samples/src/baremetal-semihosting/Makefile
+++ b/samples/src/baremetal-semihosting/Makefile
@@ -20,7 +20,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	$(BIN_PATH)/clang --config armv6m_soft_nofp_semihost -g -T ../../ldscripts/microbit.ld -o hello.elf $^
+	$(BIN_PATH)/clang --config armv6m_soft_nofp_semihost.cfg -g -T ../../ldscripts/microbit.ld -o hello.elf $^
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/baremetal-semihosting/make.bat
+++ b/samples/src/baremetal-semihosting/make.bat
@@ -49,6 +49,6 @@ if exist hello.hex del /q hello.hex
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang.exe --config armv6m_soft_nofp_semihost -g -T ..\..\ldscripts\microbit.ld -o hello.elf hello.c
+%BIN_PATH%\clang.exe --config armv6m_soft_nofp_semihost.cfg -g -T ..\..\ldscripts\microbit.ld -o hello.elf hello.c
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B

--- a/samples/src/baremetal-uart/Makefile
+++ b/samples/src/baremetal-uart/Makefile
@@ -20,7 +20,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	$(BIN_PATH)/clang --config armv6m_soft_nofp -g -T ../../ldscripts/microbit.ld -o hello.elf $^
+	$(BIN_PATH)/clang --config armv6m_soft_nofp.cfg -g -T ../../ldscripts/microbit.ld -o hello.elf $^
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/baremetal-uart/make.bat
+++ b/samples/src/baremetal-uart/make.bat
@@ -49,6 +49,6 @@ if exist hello.hex del /q hello.hex
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang.exe --config armv6m_soft_nofp -g -T ..\..\ldscripts\microbit.ld -o hello.elf hello.c
+%BIN_PATH%\clang.exe --config armv6m_soft_nofp.cfg -g -T ..\..\ldscripts\microbit.ld -o hello.elf hello.c
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B

--- a/samples/src/cpp-baremetal-semihosting/Makefile
+++ b/samples/src/cpp-baremetal-semihosting/Makefile
@@ -20,7 +20,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.cpp
-	$(BIN_PATH)/clang++ --config armv6m_soft_nofp_semihost -g -T ../../ldscripts/microbit.ld -o hello.elf $^
+	$(BIN_PATH)/clang++ --config armv6m_soft_nofp_semihost.cfg -g -T ../../ldscripts/microbit.ld -o hello.elf $^
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/cpp-baremetal-semihosting/make.bat
+++ b/samples/src/cpp-baremetal-semihosting/make.bat
@@ -49,6 +49,6 @@ if exist hello.hex del /q hello.hex
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang++.exe --config armv6m_soft_nofp_semihost -g -T ..\..\ldscripts\microbit.ld -o hello.elf hello.cpp
+%BIN_PATH%\clang++.exe --config armv6m_soft_nofp_semihost.cfg -g -T ..\..\ldscripts\microbit.ld -o hello.elf hello.cpp
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B

--- a/tests/smoketests/basic-semihosting/Makefile
+++ b/tests/smoketests/basic-semihosting/Makefile
@@ -19,7 +19,7 @@ build: hello.elf
 
 hello.elf: *.c
 	@$(BIN_PATH)/clang \
-	--config armv6m_soft_nofp_semihost \
+	--config armv6m_soft_nofp_semihost.cfg \
 	-T ../../../samples/ldscripts/microbit.ld \
 	-g \
 	-o hello.elf \

--- a/tests/smoketests/cpp-basic-semihosting/Makefile
+++ b/tests/smoketests/cpp-basic-semihosting/Makefile
@@ -19,7 +19,7 @@ build: hello.elf
 
 hello.elf: *.cpp
 	@$(BIN_PATH)/clang++ \
-	--config armv6m_soft_nofp_semihost \
+	--config armv6m_soft_nofp_semihost.cfg \
 	-T ../../../samples/ldscripts/microbit.ld \
 	-g \
 	-o hello.elf \


### PR DESCRIPTION
Since https://reviews.llvm.org/D134208 --config armv6m_soft_nofp_semihost no longer works because the feature to automatically append .cfg was removed. This breaks the smoke tests and the documented behaviour of BMT. Fix by added .cfg suffix to every --config option in documentation and examples.