### PR TITLE
 Fix "undefined symbol: operator new"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,7 +418,10 @@ while(library_variants)
 
     # compiler-rt
 
-    set(runtimes_flags "${common_flags} -ffunction-sections -fdata-sections -fno-ident --sysroot ${sysroot}")
+    # Defining _DEFAULT_SOURCE means that extensions like posix_memalign
+    # can be used by the C++ runtimes. This is required to implement
+    # C++17's aligned new & delete operators.
+    set(runtimes_flags "${common_flags} -ffunction-sections -fdata-sections -fno-ident --sysroot ${sysroot} -D_DEFAULT_SOURCE")
 
     ExternalProject_Add(
         compiler_rt_${variant}
@@ -476,7 +479,6 @@ while(library_variants)
 
     # Other LLVM runtimes
 
-    set(runtimes_cxx_flags "${runtimes_flags} -D_LIBCPP_HAS_NO_LIBRARY_ALIGNED_ALLOCATION")
     ExternalProject_Add(
         runtimes_${variant}
         SOURCE_DIR ${llvmproject_SOURCE_DIR}/runtimes
@@ -489,7 +491,7 @@ while(library_variants)
         -DCMAKE_BUILD_TYPE=MinSizeRel
         -DCMAKE_CXX_COMPILER=${llvm_bin}/clang++
         -DCMAKE_CXX_COMPILER_TARGET=${target}
-        -DCMAKE_CXX_FLAGS=${runtimes_cxx_flags}
+        -DCMAKE_CXX_FLAGS=${runtimes_flags}
         -DCMAKE_C_COMPILER=${llvm_bin}/clang
         -DCMAKE_C_COMPILER_TARGET=${target}
         -DCMAKE_C_FLAGS=${runtimes_flags}

--- a/scripts/make.py
+++ b/scripts/make.py
@@ -372,11 +372,11 @@ class ToolchainBuild:
         Build and install a single variant of lib++abi, libc++ & libunwind
         """
         cmake_defs = self._get_common_cmake_defs_for_libs(lib_spec)
-        # Disable C++17 aligned allocation feature because its implementation
-        # in libc++ relies on posix_memalign() which is not available in our
-        # picolibc build
+        # Defining _DEFAULT_SOURCE means that extensions like
+        # posix_memalign can be used by the C++ runtimes. This is
+        # required to implement C++17's aligned new & delete operators.
         cxx_flags = (cmake_defs.get('CMAKE_CXX_FLAGS', '')
-                     + ' -D_LIBCPP_HAS_NO_LIBRARY_ALIGNED_ALLOCATION')
+                     + ' -D_DEFAULT_SOURCE')
         install_dir = os.path.join(self.cfg.target_llvm_rt_dir,
                                    lib_spec.name)
         cmake_defs.update({


### PR DESCRIPTION
Clang's default C++ standard is now gnu++17 instead of gnu++14.
Supporting C++17 requires aligned new & delete. Implementing this
requires posix_memalign. Picolibc only provides posix_memalign if the
correct feature test macros are set.
https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html