### PR TITLE
Default to silent install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,10 @@ if(CCACHE_EXECUTABLE)
     set(LLVM_CCACHE_BUILD ON CACHE BOOL "")
 endif()
 
+# A lot of files get installed which makes the install messages too
+# noisy to be useful so default to disabling them.
+set(CMAKE_INSTALL_MESSAGE NEVER CACHE STRING "")
+
 
 # Define which library variants to build and which flags to use
 # The order is <arch> <name suffix> <flags>
@@ -391,6 +395,10 @@ while(library_variants)
 
     set(sysroot ${LLVM_BINARY_DIR}/lib/clang-runtimes/${variant})
 
+    if (CMAKE_INSTALL_MESSAGE STREQUAL NEVER)
+        set(MESON_INSTALL_QUIET "--quiet")
+    endif()
+
     # picolibc
     ExternalProject_Add(
         picolibc_${variant}
@@ -400,7 +408,7 @@ while(library_variants)
         DEPENDS clang lld llvm-ar llvm-config llvm-nm llvm-ranlib llvm-strip
         CONFIGURE_COMMAND ${MESON_EXECUTABLE} -Dincludedir=include -Dlibdir=lib --prefix <INSTALL_DIR> --cross-file <BINARY_DIR>/meson-cross-build.txt ${picolibc_SOURCE_DIR}
         BUILD_COMMAND ninja
-        INSTALL_COMMAND ninja install
+        INSTALL_COMMAND meson install ${MESON_INSTALL_QUIET}
         USES_TERMINAL_CONFIGURE TRUE
         USES_TERMINAL_BUILD TRUE
         USES_TERMINAL_TEST TRUE
@@ -442,6 +450,7 @@ while(library_variants)
         -DCMAKE_C_COMPILER_TARGET=${target}
         -DCMAKE_C_FLAGS=${runtimes_flags}
         -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld
+        -DCMAKE_INSTALL_MESSAGE=${CMAKE_INSTALL_MESSAGE}
         -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
         -DCMAKE_NM=${llvm_bin}/llvm-nm
         -DCMAKE_RANLIB=${llvm_bin}/llvm-ranlib
@@ -497,6 +506,7 @@ while(library_variants)
         -DCMAKE_C_COMPILER_TARGET=${target}
         -DCMAKE_C_FLAGS=${runtimes_flags}
         -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld
+        -DCMAKE_INSTALL_MESSAGE=${CMAKE_INSTALL_MESSAGE}
         -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
         -DCMAKE_NM=${llvm_bin}/llvm-nm
         -DCMAKE_RANLIB=${llvm_bin}/llvm-ranlib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,8 @@ set(CPACK_ARCHIVE_COMPONENT_INSTALL TRUE)
 set(CPACK_COMPONENTS_GROUPING ALL_COMPONENTS_IN_ONE)
 # Strip debug info from files before packaging them
 set(CPACK_STRIP_FILES TRUE)
+# When extracting the files put them in an ArmCompiler-.../ directory.
+set(CPACK_COMPONENT_INCLUDE_TOPLEVEL_DIRECTORY TRUE)
 
 string(TOLOWER ${CMAKE_SYSTEM_PROCESSOR} processor_name)
 string(REGEX MATCH "amd64|x64|x86" x86_match ${processor_name})


### PR DESCRIPTION
In an incremental build the install messages were drowning out the useful output so default to disabling them.

Second commit: Store files in tar.gz in	ArmCompiler-.../ directory