### PR TITLE
When BMT build LLVM_DEFAULT_TARGET_TRIPLE set to aarch64-none-elf gen…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ set(LLVM_DISTRIBUTION_COMPONENTS
 )
 set(LLVM_ENABLE_PROJECTS clang;lld CACHE STRING "")
 set(LLVM_TARGETS_TO_BUILD AArch64;ARM CACHE STRING "")
-set(LLVM_DEFAULT_TARGET_TRIPLE aarch64-none-elf CACHE STRING "")
+set(LLVM_DEFAULT_TARGET_TRIPLE aarch64-linux-gnu CACHE STRING "")
 
 # Default to a release build
 # (CMAKE_BUILD_TYPE is a special CMake variable so if you want to set


### PR DESCRIPTION
…erate problems with '-fno-integrated-as' option when build assembler files.

Reason is beause we are using BareMetal driver and don't supply another assembler. Fix set LLVM_DEFAULT_TARGET_TRIPLE to aarch64-linux-gnu in CMakeLists.txt.