### PR TITLE
Enable localisation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,22 +435,21 @@ while(library_variants)
             -DLIBCXXABI_ENABLE_EXCEPTIONS=OFF
             -DLIBCXXABI_ENABLE_THREADS=OFF
             -DLIBCXX_ENABLE_EXCEPTIONS=OFF
-            -DLIBCXX_ENABLE_LOCALIZATION=OFF
             -DLIBCXX_ENABLE_MONOTONIC_CLOCK=OFF
             -DLIBCXX_ENABLE_RANDOM_DEVICE=OFF
             -DLIBCXX_ENABLE_RTTI=OFF
             -DLIBCXX_ENABLE_THREADS=OFF
             -DLIBCXX_ENABLE_WIDE_CHARACTERS=OFF
+            # _LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE: Avoids a static assert
+            # failing in <__locale>.
+            -DLIBCXX_EXTRA_SITE_DEFINES=_LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE
             -DLIBUNWIND_ENABLE_THREADS=OFF
         )
     endif()
 
     # compiler-rt
 
-    # Defining _DEFAULT_SOURCE means that extensions like posix_memalign
-    # can be used by the C++ runtimes. This is required to implement
-    # C++17's aligned new & delete operators.
-    set(runtimes_flags "${common_flags} -ffunction-sections -fdata-sections -fno-ident --sysroot ${sysroot} -D_DEFAULT_SOURCE")
+    set(runtimes_flags "${common_flags} -ffunction-sections -fdata-sections -fno-ident --sysroot ${sysroot}")
 
     ExternalProject_Add(
         compiler_rt_${variant}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,7 +433,6 @@ while(library_variants)
         set(libc_target picolibc_${variant})
         set(libc_specific_runtimes_options
             -DLIBCXXABI_ENABLE_EXCEPTIONS=OFF
-            -DLIBCXXABI_ENABLE_PIC=OFF
             -DLIBCXXABI_ENABLE_THREADS=OFF
             -DLIBCXX_ENABLE_EXCEPTIONS=OFF
             -DLIBCXX_ENABLE_LOCALIZATION=OFF
@@ -541,16 +540,10 @@ while(library_variants)
         -DLIBCXXABI_USE_LLVM_UNWINDER=ON
         -DLIBCXX_CXX_ABI=libcxxabi
         -DLIBCXX_ENABLE_DEBUG_MODE_SUPPORT=OFF
-        -DLIBCXX_ENABLE_EXPERIMENTAL_LIBRARY=OFF
         -DLIBCXX_ENABLE_FILESYSTEM=OFF
-        -DLIBCXX_ENABLE_PARALLEL_ALGORITHMS=OFF
         -DLIBCXX_ENABLE_SHARED=OFF
         -DLIBCXX_ENABLE_STATIC=ON
         -DLIBCXX_INCLUDE_BENCHMARKS=OFF
-        # libc++ CMake files incorrectly detect that the "-GR-" flag
-        # (the clang-cl analog of -fno-rtti) is supported. Manually mark it
-        # as unsupported to avoid warnings.
-        -DLIBCXX_SUPPORTS_GR_FLAG=OFF
         -DLIBUNWIND_ENABLE_SHARED=OFF
         -DLIBUNWIND_ENABLE_STATIC=ON
         -DLIBUNWIND_IS_BAREMETAL=ON

--- a/patches/picolibc-HEAD.patch
+++ b/patches/picolibc-HEAD.patch
@@ -1,3 +1,46 @@
+diff --git a/meson.build b/meson.build
+index ec55ab4fe..be7924d26 100644
+--- a/meson.build
++++ b/meson.build
+@@ -916,6 +916,12 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
+   error('newlib-retargetable-locking and newlib-multithread must be set to the same value')
+ endif
+ 
++conf_data.set('_GNU_SOURCE', '',
++        description: '''Enable GNU functions like strtof_l.
++It's necessary to set this globally because inline functions in
++libc++ headers call the GNU functions.'''
++)
++
+ conf_data.set('_HAVE_CC_INHIBIT_LOOP_TO_LIBCALL',
+ 	      cc.has_argument('-fno-tree-loop-distribute-patterns'),
+ 	      description: 'Compiler flag to prevent detecting memcpy/memset patterns')
+diff --git a/newlib/libc/tinystdio/strtoi.h b/newlib/libc/tinystdio/strtoi.h
+index 673096940..42195aa06 100644
+--- a/newlib/libc/tinystdio/strtoi.h
++++ b/newlib/libc/tinystdio/strtoi.h
+@@ -30,6 +30,7 @@
+   POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
++#define _DEFAULT_SOURCE
+ #include <ctype.h>
+ #include <limits.h>
+ #include <math.h>
+@@ -167,3 +168,13 @@ strtoi(const char *__restrict nptr, char **__restrict endptr, int ibase)
+ 
+     return val;
+ }
++
++
++#define STRTOI_L1(x) x##_l
++#define STRTOI_L(x) STRTOI_L1(x)
++
++strtoi_type
++STRTOI_L(strtoi)(const char *__restrict nptr, char **__restrict endptr, int ibase, locale_t loc) {
++    (void)loc;
++	return strtoi(nptr, endptr, ibase);
++}
 diff --git a/picolibc.ld.in b/picolibc.ld.in
 index c69ad3c3a..7f4d2fc43 100644
 --- a/picolibc.ld.in

--- a/tests/smoketests/cpp-basic-semihosting/hello.cpp
+++ b/tests/smoketests/cpp-basic-semihosting/hello.cpp
@@ -1,9 +1,96 @@
+// Include as many C++17 headers as possible.
+// Unsupported headers are commented out.
+#include <algorithm>
+#include <any>
+#include <array>
+#include <atomic>
+#include <bitset>
+#include <chrono>
+#include <codecvt>
+#include <complex>
+#include <condition_variable>
+#include <deque>
+#include <exception>
+#include <execution>
+//#include <filesystem>
+#include <forward_list>
+#include <fstream>
+#include <functional>
+//#include <future>
+#include <initializer_list>
+#include <iomanip>
+#include <ios>
+#include <iosfwd>
+#include <iostream>
+#include <istream>
+#include <iterator>
+#include <limits>
+#include <list>
+#include <locale>
+#include <map>
+#include <memory>
+#include <memory_resource>
+//#include <mutex>
+#include <new>
+#include <numeric>
+#include <optional>
+#include <ostream>
+#include <queue>
+#include <random>
+#include <ratio>
+#include <regex>
+#include <scoped_allocator>
+#include <set>
+//#include <shared_mutex>
+#include <sstream>
+#include <stack>
+#include <stdexcept>
+#include <streambuf>
 #include <string>
+#include <string_view>
+#include <strstream>
+#include <system_error>
+//#include <thread>
+#include <tuple>
+#include <type_traits>
+#include <typeindex>
+#include <typeinfo>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <valarray>
+#include <variant>
+#include <vector>
+
+#include <cassert>
+#include <cinttypes>
+#include <csignal>
 #include <cstdio>
+//#include <cwchar>
+#include <ccomplex>
+#include <ciso646>
+//#include <cstdalign> // removed in C++20
+#include <cstdlib>
+//#include <cwctype>
+#include <cctype>
+#include <climits>
+#include <cstdarg>
+#include <cstring>
+#include <cerrno>
+#include <clocale>
+#include <cstdbool>
+#include <ctgmath>
+#include <cfenv>
+#include <cmath>
+#include <cstddef>
+#include <ctime>
+#include <cfloat>
+#include <csetjmp>
+#include <cstdint>
+#include <cuchar>
 
 int main(void) {
-    std::string str = "Hello World!\n";
-    printf("%s", str.c_str());
+    std::string str = "Hello World!";
+    std::cout << str << std::endl;
     return 0;
 }
-


### PR DESCRIPTION
Doing so requires enabling GNU extensions in picolibc since libc++ uses
functions like strtof_l that take a locale argument. These functions are
called from inline functions so we must enable them globally instead of
passing an argument only when building libc++. An alternative option is
to set _GNU_SOURCE in libc++'s __config_site header but that would mean
different sets of functions would be declared depending on the ordering
of includes.

Picolibc's tinystdio doesn't include strtoll_l or strtoull_l so this
change adds those. They behave in the same way as tinystdio's strtof_l
which discards the locale argument.

The C++ smoke test now includes all the C++ headers it can to make it
more obvious what can and cannot be included. As you'd expect,
filesystem, threading and wchar related headers can't be included since
we've explicitly disabled those features.