### PR TITLE
Update C++ support info in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Support for locales and input/output streams
+
 ### Changed
 
 - Packages now extract into a LVMEmbeddedToolchainForArm-VERSION-PLATFORM subdirectory.
@@ -20,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - A changelog
 - Support for building with CMake directly
+- Support for C++17's aligned operator new
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ that are not supported include:
  - Exceptions
  - RTTI
  - Multithreading
- - Locales and input/output streams
- - C++17's aligned operator new
 
 ## Components
 


### PR DESCRIPTION
Also update the change log. Support for C++17's aligned operator new was added with the switch to picolibc.