### PR TITLE
Add experimental support for OSX host

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ see component links above.
 The LLVM Embedded Toolchain for Arm has been built and tested on Linux/Ubuntu
 18.04.5 LTS, including cross-building for Windows.
 
+Building on macOS is functional but experimental. Currently it is only lightly tested on
+a Macbook Pro with M1 on macOS 12.3.1. Cross-building for Windows from Mac is untested.
+
 [Binary packages](https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases) 
 are provided for major LLVM releases for Linux and Windows.
 

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -5,25 +5,31 @@
 The LLVM Embedded Toolchain for Arm has been built and tested on Linux/Ubuntu
 18.04.5 LTS.
 
+Building and testing on macOS is functional but experimental.
+
 ## Installing prerequisites
 
 The build requires the following software to be installed, in addition
-to the [LLVM requirements|https://llvm.org/docs/GettingStarted.html#software]:
+to the [LLVM requirements](https://llvm.org/docs/GettingStarted.html#software):
 * CMake 3.20 or above
 * Meson
 * Git
 * Ninja
 * Python
+* QEMU (for running the test suite, so optional)
 
 On a Ubuntu 18.04.5 LTS machine you can use the following commands to install
 the software mentioned above:
 ```
+$ apt-get install python3 git make ninja-build qemu
 $ apt-get install clang # If the Clang version installed by the package manager is older than 6.0.0, download a recent version from https://releases.llvm.org or build from source
-$ apt-get install python3
-$ apt-get install git
-$ apt-get install make
-$ apt-get install ninja-build
 $ apt-get install cmake # If the CMake version installed by the package manager is too old, download a recent version from https://cmake.org/download and add it to PATH
+$ pip install meson
+```
+
+On macOS, you can use homebrew:
+```
+$ brew install llvm python3 git make ninja qemu cmake
 $ pip install meson
 ```
 


### PR DESCRIPTION
Just a tiny tweak was needed to get building the toolchain for OSX work: For the runtimes component, which builds libcXX*, including libunwind, we need to disable the APPLE CMake variable that will configure various bits for an assumed Apple target. It doesn't seem possible to disable this without directly editing the source.

Testing has been restricted to building the variants, running the `ninja check-llvm-toolchain' script (qemu runs produce the expected results) and doing some ad-hoc compiling for the targets.

Preferably we should handle this properly in LLVM proper, but accounting for the APPLE variable in a non-hacky way seems like a hairy affair, which will take more effort. Patching the source here seems like an acceptable band-aid for supporting a platform that we have had multiple requests for.

For a bit more detail, see the added comment in the CMakeLists.txt diff.