### PR TITLE
Also build toolchains for Armv4T, Armv5TE and Armv6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Support for locales and input/output streams
+- Experimental support for Armv4T and Armv5TE architectures
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,6 +409,8 @@ add_library_variants(aarch64-none-elf picolibc
     aarch64         ""                  "-march=armv8-a"                                        "-M raspi3b"
 )
 add_library_variants(arm-none-eabi picolibc
+    armv4t          ""                  "-march=armv4t"                                         "-M musicpal -cpu arm926"
+    armv5te         ""                  "-march=armv5te"                                        "-M musicpal -cpu arm926"
     armv6m          soft_nofp           "-mfloat-abi=soft -march=armv6m"                        "-M microbit"
     armv7em         hard_fpv4_sp_d16    "-mfloat-abi=hard -march=armv7em -mfpu=fpv4-sp-d16"     "-M mps2-an386 -cpu cortex-m4"
     armv7em         hard_fpv5_d16       "-mfloat-abi=hard -march=armv7em -mfpu=fpv5-d16"        "-M mps2-an500 -cpu cortex-m7"
@@ -437,11 +439,11 @@ while(library_variants_copy)
         # system doesn't recognize every possible Arm architecture
         # version. So mostly we just say 'arm' and control the arch
         # version via -march=armv7m (or whatever).
-        if(target_arch STREQUAL "armv6m")
-            # An exception is armv6m, which compiler-rt expects to see
-            # in the triple because that's where it looks to decide
-            # whether to use the v6-M specific assembly sources.
-            set(target "armv6m-none-eabi")
+        # Exceptions are architectures pre-armv7, which compiler-rt expects to
+        # see in the triple because that's where it looks to decide whether to
+        # use specific assembly sources.
+        if(target_arch MATCHES "^armv[4-6]")
+            set(target "${target_arch}-none-eabi")
         elseif(flags MATCHES "-mfloat-abi=hard")
             # Also, compiler-rt looks in the ABI component of the
             # triple to decide whether to use the hard float ABI.
@@ -581,8 +583,7 @@ while(library_variants_copy)
             )
             add_dependencies(check-picolibc_${variant} check-picolibc_${variant}-${test})
         endfunction()
-
-        if(${variant} MATCHES "^armv8" OR ${variant} MATCHES "^aarch")
+        if(target_arch MATCHES "^(armv8|aarch64)")
             message("Picolibc tests disabled for ${variant}")
         else()
             execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory picolibc_tests_${variant})

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ embedded and realtime operating systems.
 - Armv7E-M
 - Armv8-M Mainline
 - Armv8.1-M Mainline
+- Armv4T (experimental)
+- Armv5TE (experimental)
+- Armv6 (experimental, using the Armv5TE library variant)
 - AArch64 armv8.0 (experimental)
 
 ## C++ support

--- a/samples/ldscripts/armv4t.ld
+++ b/samples/ldscripts/armv4t.ld
@@ -1,0 +1,7 @@
+__flash =      0x00010000;
+__flash_size = 0x00400000;
+__ram =        0x00500000;
+__ram_size   = 0x00200000;
+__stack_size = 4k;
+
+INCLUDE picolibc.ld

--- a/samples/ldscripts/armv5te.ld
+++ b/samples/ldscripts/armv5te.ld
@@ -1,0 +1,7 @@
+__flash =      0x00010000;
+__flash_size = 0x00400000;
+__ram =        0x00500000;
+__ram_size   = 0x00200000;
+__stack_size = 4k;
+
+INCLUDE picolibc.ld


### PR DESCRIPTION
LLD and compiler-rt support for these has recently been added to LLVM.