### PR TITLE
Rename libcxx.test.newconfig -> config

### DIFF
--- a/test-support/llvm-libc++-picolibc.cfg.in
+++ b/test-support/llvm-libc++-picolibc.cfg.in
@@ -27,8 +27,8 @@ config.substitutions.append(('%{exec}',
 
 import os, site
 site.addsitedir(os.path.join('@LIBCXX_SOURCE_DIR@', 'utils'))
-import libcxx.test.params, libcxx.test.newconfig
-libcxx.test.newconfig.configure(
+import libcxx.test.params, libcxx.test.config
+libcxx.test.config.configure(
     libcxx.test.params.DEFAULT_PARAMETERS,
     libcxx.test.features.DEFAULT_FEATURES,
     config,

--- a/test-support/llvm-libc++abi-picolibc.cfg.in
+++ b/test-support/llvm-libc++abi-picolibc.cfg.in
@@ -28,8 +28,8 @@ config.substitutions.append(('%{exec}',
 
 import os, site
 site.addsitedir(os.path.join('@LIBCXXABI_LIBCXX_PATH@', 'utils'))
-import libcxx.test.params, libcxx.test.newconfig
-libcxx.test.newconfig.configure(
+import libcxx.test.params, libcxx.test.config
+libcxx.test.config.configure(
     libcxx.test.params.DEFAULT_PARAMETERS,
     libcxx.test.features.DEFAULT_FEATURES,
     config,

--- a/test-support/llvm-libunwind-picolibc.cfg.in
+++ b/test-support/llvm-libunwind-picolibc.cfg.in
@@ -35,8 +35,8 @@ config.substitutions.append(('%{exec}',
 
 import os, site
 site.addsitedir(os.path.join('@LIBUNWIND_LIBCXX_PATH@', 'utils'))
-import libcxx.test.params, libcxx.test.newconfig, libcxx.test.newconfig
-libcxx.test.newconfig.configure(
+import libcxx.test.params, libcxx.test.config
+libcxx.test.config.configure(
     libcxx.test.params.DEFAULT_PARAMETERS,
     libcxx.test.features.DEFAULT_FEATURES,
     config,


### PR DESCRIPTION
This patch updates picolibc-specic libc++, libc++abi and libunwind lit.cfg.py files to match upstream change
https://reviews.llvm.org/D144031.