### PR TITLE
Pass -march/-mfloat-abi flags to C++ runtime tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -657,6 +657,7 @@ function(add_libcxx_libcxxabi_libunwind directory variant target_triple flags li
         -DLIBUNWIND_USE_COMPILER_RT=ON
         -DLLVM_CCACHE_BUILD=${LLVM_CCACHE_BUILD}
         -DLLVM_ENABLE_RUNTIMES=libcxxabi,libcxx,libunwind
+        -DRUNTIME_TEST_ARCH_FLAGS=${flags}
         ${extra_cmake_options}
         STEP_TARGETS build
         USES_TERMINAL_CONFIGURE TRUE

--- a/test-support/llvm-libc++-picolibc.cfg.in
+++ b/test-support/llvm-libc++-picolibc.cfg.in
@@ -7,9 +7,7 @@ config.substitutions.append(('%{libc-include}', '@CMAKE_INSTALL_PREFIX@/include'
 config.substitutions.append(('%{libc-lib}', '@CMAKE_INSTALL_PREFIX@/lib'))
 config.substitutions.append(('%{libc-linker-script}', '@LIBC_LINKER_SCRIPT@'))
 
-config.substitutions.append(('%{flags}',
-    '-isysroot {}'.format('@CMAKE_OSX_SYSROOT@') if '@CMAKE_OSX_SYSROOT@' else ''
-))
+config.substitutions.append(('%{flags}', '@RUNTIME_TEST_ARCH_FLAGS@'))
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{include} -I %{target-include} -I %{libcxx}/test/support'
     ' -isystem %{libc-include}'

--- a/test-support/llvm-libc++abi-picolibc.cfg.in
+++ b/test-support/llvm-libc++abi-picolibc.cfg.in
@@ -7,9 +7,7 @@ config.substitutions.append(('%{libc-include}', '@CMAKE_INSTALL_PREFIX@/include'
 config.substitutions.append(('%{libc-lib}', '@CMAKE_INSTALL_PREFIX@/lib'))
 config.substitutions.append(('%{libc-linker-script}', '@LIBC_LINKER_SCRIPT@'))
 
-config.substitutions.append(('%{flags}',
-    '-isysroot {}'.format('@CMAKE_OSX_SYSROOT@') if '@CMAKE_OSX_SYSROOT@' else ''
-))
+config.substitutions.append(('%{flags}', '@RUNTIME_TEST_ARCH_FLAGS@'))
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{include} -I %{cxx-include} -I %{cxx-target-include} %{maybe-include-libunwind} '
     ' -I %{libcxx}/test/support -I %{libcxx}/src -D_LIBCPP_ENABLE_CXX17_REMOVED_UNEXPECTED_FUNCTIONS '

--- a/test-support/llvm-libunwind-picolibc.cfg.in
+++ b/test-support/llvm-libunwind-picolibc.cfg.in
@@ -21,7 +21,8 @@ compile_flags.append('-funwind-tables')
 
 local_sysroot = '@CMAKE_OSX_SYSROOT@' or '@CMAKE_SYSROOT@'
 config.substitutions.append(('%{flags}',
-    '-isysroot {}'.format(local_sysroot) if local_sysroot else ''
+    '@RUNTIME_TEST_ARCH_FLAGS@' +
+    (' -isysroot {}'.format(local_sysroot) if local_sysroot else '')
 ))
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{{include}} {}'.format(' '.join(compile_flags))


### PR DESCRIPTION
When building libc++, libc++abi and libunwind tests we need to manually add -march= and -mfloat-abi to the compiler command line, merely setting CMAKE_CXX_FLAGS is not enough.

This patch fixes the issue by adding a new CMake variable RUNTIME_TEST_ARCH_FLAGS and using it in test config files.