### PR TITLE
Enable building on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,7 +412,7 @@ function(add_picolibc directory variant target_triple flags qemu_params variant_
         INSTALL_DIR "${LLVM_BINARY_DIR}/${directory}"
         PREFIX picolibc/${variant}
         DEPENDS clang lld llvm-ar llvm-config llvm-nm llvm-ranlib llvm-strip
-        CONFIGURE_COMMAND ${MESON_EXECUTABLE} -Dincludedir=include -Dlibdir=lib --prefix <INSTALL_DIR> --cross-file <BINARY_DIR>/meson-cross-build.txt ${picolibc_SOURCE_DIR}
+        CONFIGURE_COMMAND ${MESON_EXECUTABLE} -Dincludedir=include -Dlibdir=lib -Dspecsdir=none --prefix <INSTALL_DIR> --cross-file <BINARY_DIR>/meson-cross-build.txt ${picolibc_SOURCE_DIR}
         BUILD_COMMAND ninja
         INSTALL_COMMAND ${MESON_EXECUTABLE} install ${MESON_INSTALL_QUIET}
         USES_TERMINAL_CONFIGURE TRUE
@@ -428,7 +428,7 @@ function(add_picolibc directory variant target_triple flags qemu_params variant_
     # '-march=armv6m'
     set(meson_c_args "${flags}")
     string(REPLACE " " "', '" meson_c_args "${meson_c_args}")
-    set(meson_c_args "'${LLVM_BINARY_DIR}/bin/clang', '${meson_c_args}'")
+    set(meson_c_args "'${LLVM_BINARY_DIR}/bin/clang${CMAKE_EXECUTABLE_SUFFIX}', '${meson_c_args}'")
     ExternalProject_Get_Property(picolibc_${variant} BINARY_DIR)
     configure_file(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/cmake/meson-cross-build.txt.in ${BINARY_DIR}/meson-cross-build.txt @ONLY)
 

--- a/cmake/meson-cross-build.txt.in
+++ b/cmake/meson-cross-build.txt.in
@@ -1,8 +1,8 @@
 [binaries]
 c = [@meson_c_args@]
-ar = '@LLVM_BINARY_DIR@/bin/llvm-ar'
-nm = '@LLVM_BINARY_DIR@/bin/llvm-nm'
-strip = '@LLVM_BINARY_DIR@/bin/llvm-strip'
+ar = '@LLVM_BINARY_DIR@/bin/llvm-ar@CMAKE_EXECUTABLE_SUFFIX@'
+nm = '@LLVM_BINARY_DIR@/bin/llvm-nm@CMAKE_EXECUTABLE_SUFFIX@'
+strip = '@LLVM_BINARY_DIR@/bin/llvm-strip@CMAKE_EXECUTABLE_SUFFIX@'
 # only needed to run tests
 exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-@cpu_family@ "$@"', 'run-@cpu_family@']
 

--- a/patches/picolibc.patch
+++ b/patches/picolibc.patch
@@ -1,8 +1,17 @@
 diff --git a/meson.build b/meson.build
-index 10465b666..d748fb95f 100644
+index 9a24b1737..a85a0f9d9 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -945,6 +945,12 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
+@@ -41,7 +41,7 @@ project('picolibc', 'c',
+           'warning_level=2',
+ 	],
+ 	license : 'BSD',
+-	meson_version : '>= 0.53',
++	meson_version : '>= 0.57',
+ 	version: '1.8'
+        )
+ 
+@@ -960,6 +960,12 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
    error('newlib-retargetable-locking and newlib-multithread must be set to the same value')
  endif
  
@@ -15,8 +24,33 @@ index 10465b666..d748fb95f 100644
  conf_data.set('_HAVE_CC_INHIBIT_LOOP_TO_LIBCALL',
  	      cc.has_argument('-fno-tree-loop-distribute-patterns'),
  	      description: 'Compiler flag to prevent detecting memcpy/memset patterns')
+@@ -1120,7 +1126,14 @@ endif
+ # Dig out the list of available encodings from the encoding.aliases file. Only
+ # accept the first entry from each line
+ 
+-available_encodings = run_command(['sed', '-e', '/^#/d', '-e', '/^$/d', '-e', 's/ .*$//', files('newlib/libc/iconv/encoding.aliases')[0]], check : true).stdout().split('\n')
++available_encodings = []
++foreach line : fs.read('newlib/libc/iconv/encoding.aliases').split('\n')
++  line = line.strip()
++  if line == '' or line.startswith('#')
++    continue
++  endif
++  available_encodings += [line.split()[0]]
++endforeach
+ 
+ # Include all available encodings if none were specified on the command line
+ 
+@@ -1264,7 +1277,7 @@ endif
+ # of meson newer than that.
+ 
+ test_env = environment({'PICOLIBC_TEST' : '1'})
+-test_env.prepend('PATH', meson.source_root() / 'scripts')
++test_env.prepend('PATH', meson.current_source_dir() / 'scripts')
+ 
+ # CompCert needs the '-WUl,' prefix to correctly pass the --spec parameters to the linker
+ specs_prefix = ''
 diff --git a/picolibc.ld.in b/picolibc.ld.in
-index c757f7665..e262e1c21 100644
+index f7e7fa80c..75d7a9aaf 100644
 --- a/picolibc.ld.in
 +++ b/picolibc.ld.in
 @@ -207,10 +207,12 @@ SECTIONS


### PR DESCRIPTION
* Add .exe extension to executable paths.
* Remove a unix command from picolibc meson.build.
* Work around other issues by skipping the creation of specs files.