### PR TITLE
Windows compatibility changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,7 +479,7 @@ function(add_picolibc directory variant target_triple flags qemu_params variant_
         # ld.lld: error: undefined symbol: __issignalingl  while building math_errhandling test.
         add_custom_command(
                 OUTPUT picolibc_tests_${variant}/check-picolibc_${variant}_build_${test}.out
-                COMMAND ${LLVM_BINARY_DIR}/bin/clang --config ${LLVM_BINARY_DIR}/bin/${variant}_semihost.cfg
+                COMMAND ${LLVM_BINARY_DIR}/bin/clang${CMAKE_EXECUTABLE_SUFFIX} --config ${LLVM_BINARY_DIR}/bin/${variant}_semihost.cfg
                 -T ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/samples/ldscripts/${variant}.ld
                 -nostdlib -lc -lg -lm -lclang_rt.builtins -lsemihost -Oz
                 ${picolibc_SOURCE_DIR}/test/${test}.c ${ARGN} -o picolibc_tests_${variant}/check-picolibc_${variant}_build_${test}.out
@@ -560,23 +560,21 @@ Hard-float library with target triple \"${target_triple}\" must end \"-eabihf\""
         INSTALL_DIR compiler-rt/${variant}/install
         DEPENDS clang lld llvm-ar llvm-config llvm-nm llvm-ranlib ${libc_target}
         CMAKE_ARGS
-        -DCMAKE_AR=${LLVM_BINARY_DIR}/bin/llvm-ar
+        -DCMAKE_AR=${LLVM_BINARY_DIR}/bin/llvm-ar${CMAKE_EXECUTABLE_SUFFIX}
         -DCMAKE_ASM_COMPILER_TARGET=${target_triple}
         -DCMAKE_ASM_FLAGS=${runtimes_flags}
         -DCMAKE_BUILD_TYPE=Release
-        -DCMAKE_CXX_COMPILER=${LLVM_BINARY_DIR}/bin/clang++
+        -DCMAKE_CXX_COMPILER=${LLVM_BINARY_DIR}/bin/clang++${CMAKE_EXECUTABLE_SUFFIX}
         -DCMAKE_CXX_COMPILER_TARGET=${target_triple}
         -DCMAKE_CXX_FLAGS=${runtimes_flags}
-        -DCMAKE_C_COMPILER=${LLVM_BINARY_DIR}/bin/clang
+        -DCMAKE_C_COMPILER=${LLVM_BINARY_DIR}/bin/clang${CMAKE_EXECUTABLE_SUFFIX}
         -DCMAKE_C_COMPILER_TARGET=${target_triple}
         -DCMAKE_C_FLAGS=${runtimes_flags}
         -DCMAKE_INSTALL_MESSAGE=${CMAKE_INSTALL_MESSAGE}
         -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-        -DCMAKE_NM=${LLVM_BINARY_DIR}/bin/llvm-nm
-        -DCMAKE_RANLIB=${LLVM_BINARY_DIR}/bin/llvm-ranlib
-        # Set the cmake system name to Generic so that no host system
-        # include files are searched. At least on OSX this problem
-        # occurs.
+        -DCMAKE_NM=${LLVM_BINARY_DIR}/bin/llvm-nm${CMAKE_EXECUTABLE_SUFFIX}
+        -DCMAKE_RANLIB=${LLVM_BINARY_DIR}/bin/llvm-ranlib${CMAKE_EXECUTABLE_SUFFIX}
+        # Let CMake know we're cross-compiling
         -DCMAKE_SYSTEM_NAME=Generic
         -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY
         -DCOMPILER_RT_BAREMETAL_BUILD=ON
@@ -587,7 +585,7 @@ Hard-float library with target triple \"${target_triple}\" must end \"-eabihf\""
         -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON
         -DLLVM_LIT_ARGS=${LLVM_LIT_ARGS}
         -DLLVM_CCACHE_BUILD=${LLVM_CCACHE_BUILD}
-        -DLLVM_CONFIG_PATH=${LLVM_BINARY_DIR}/bin/llvm-config
+        -DLLVM_CONFIG_PATH=${LLVM_BINARY_DIR}/bin/llvm-config${CMAKE_EXECUTABLE_SUFFIX}
         -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON
         USES_TERMINAL_CONFIGURE TRUE
         USES_TERMINAL_BUILD TRUE
@@ -624,19 +622,21 @@ function(add_libcxx_libcxxabi_libunwind directory variant target_triple flags li
         PREFIX libcxx_libcxxabi_libunwind/${variant}
         DEPENDS clang compiler_rt_${variant} lld llvm-ar llvm-config llvm-nm llvm-ranlib ${libc_target}
         CMAKE_ARGS
-        -DCMAKE_AR=${LLVM_BINARY_DIR}/bin/llvm-ar
+        -DCMAKE_AR=${LLVM_BINARY_DIR}/bin/llvm-ar${CMAKE_EXECUTABLE_SUFFIX}
         -DCMAKE_ASM_FLAGS=${runtimes_flags}
         -DCMAKE_BUILD_TYPE=MinSizeRel
-        -DCMAKE_CXX_COMPILER=${LLVM_BINARY_DIR}/bin/clang++
+        -DCMAKE_CXX_COMPILER=${LLVM_BINARY_DIR}/bin/clang++${CMAKE_EXECUTABLE_SUFFIX}
         -DCMAKE_CXX_COMPILER_TARGET=${target_triple}
         -DCMAKE_CXX_FLAGS=${runtimes_flags}
-        -DCMAKE_C_COMPILER=${LLVM_BINARY_DIR}/bin/clang
+        -DCMAKE_C_COMPILER=${LLVM_BINARY_DIR}/bin/clang${CMAKE_EXECUTABLE_SUFFIX}
         -DCMAKE_C_COMPILER_TARGET=${target_triple}
         -DCMAKE_C_FLAGS=${runtimes_flags}
         -DCMAKE_INSTALL_MESSAGE=${CMAKE_INSTALL_MESSAGE}
         -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-        -DCMAKE_NM=${LLVM_BINARY_DIR}/bin/llvm-nm
-        -DCMAKE_RANLIB=${LLVM_BINARY_DIR}/bin/llvm-ranlib
+        -DCMAKE_NM=${LLVM_BINARY_DIR}/bin/llvm-nm${CMAKE_EXECUTABLE_SUFFIX}
+        -DCMAKE_RANLIB=${LLVM_BINARY_DIR}/bin/llvm-ranlib${CMAKE_EXECUTABLE_SUFFIX}
+        # Let CMake know we're cross-compiling
+        -DCMAKE_SYSTEM_NAME=Generic
         -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY
         -DLIBCXXABI_BAREMETAL=ON
         -DLIBCXXABI_ENABLE_ASSERTIONS=OFF
@@ -1029,12 +1029,12 @@ if(LLVM_TOOLCHAIN_CROSS_BUILD_MINGW)
         -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY
         -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
         -DCMAKE_SYSTEM_NAME=Windows
-        -DCLANG_TABLEGEN=${LLVM_BINARY_DIR}/bin/clang-tblgen
+        -DCLANG_TABLEGEN=${LLVM_BINARY_DIR}/bin/clang-tblgen${CMAKE_EXECUTABLE_SUFFIX}
         -DLLVM_CCACHE_BUILD=${LLVM_CCACHE_BUILD}
-        -DLLVM_CONFIG_PATH=${LLVM_BINARY_DIR}/bin/llvm-config
+        -DLLVM_CONFIG_PATH=${LLVM_BINARY_DIR}/bin/llvm-config${CMAKE_EXECUTABLE_SUFFIX}
         -DLLVM_DISTRIBUTION_COMPONENTS=${LLVM_DISTRIBUTION_COMPONENTS_comma}
         -DLLVM_ENABLE_PROJECTS=${LLVM_ENABLE_PROJECTS_comma}
-        -DLLVM_TABLEGEN=${LLVM_BINARY_DIR}/bin/llvm-tblgen
+        -DLLVM_TABLEGEN=${LLVM_BINARY_DIR}/bin/llvm-tblgen${CMAKE_EXECUTABLE_SUFFIX}
         -DLLVM_TARGETS_TO_BUILD=${LLVM_TARGETS_TO_BUILD_comma}
         BUILD_COMMAND "" # Let the install command build whatever it needs
         INSTALL_COMMAND "${CMAKE_COMMAND}" --build <BINARY_DIR> --target install-distribution-stripped

--- a/cmake/meson-cross-build.txt.in
+++ b/cmake/meson-cross-build.txt.in
@@ -1,7 +1,6 @@
 [binaries]
 c = [@meson_c_args@]
 ar = '@LLVM_BINARY_DIR@/bin/llvm-ar@CMAKE_EXECUTABLE_SUFFIX@'
-nm = '@LLVM_BINARY_DIR@/bin/llvm-nm@CMAKE_EXECUTABLE_SUFFIX@'
 strip = '@LLVM_BINARY_DIR@/bin/llvm-strip@CMAKE_EXECUTABLE_SUFFIX@'
 # only needed to run tests
 exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-@cpu_family@ "$@"', 'run-@cpu_family@']

--- a/patches/picolibc.patch
+++ b/patches/picolibc.patch
@@ -1,17 +1,8 @@
 diff --git a/meson.build b/meson.build
-index 9a24b1737..a85a0f9d9 100644
+index 729baeed9..a242da5bf 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -41,7 +41,7 @@ project('picolibc', 'c',
-           'warning_level=2',
- 	],
- 	license : 'BSD',
--	meson_version : '>= 0.53',
-+	meson_version : '>= 0.57',
- 	version: '1.8'
-        )
- 
-@@ -960,6 +960,12 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
+@@ -965,6 +965,12 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
    error('newlib-retargetable-locking and newlib-multithread must be set to the same value')
  endif
  
@@ -24,31 +15,26 @@ index 9a24b1737..a85a0f9d9 100644
  conf_data.set('_HAVE_CC_INHIBIT_LOOP_TO_LIBCALL',
  	      cc.has_argument('-fno-tree-loop-distribute-patterns'),
  	      description: 'Compiler flag to prevent detecting memcpy/memset patterns')
-@@ -1120,7 +1126,14 @@ endif
+@@ -1125,7 +1131,18 @@ endif
  # Dig out the list of available encodings from the encoding.aliases file. Only
  # accept the first entry from each line
  
 -available_encodings = run_command(['sed', '-e', '/^#/d', '-e', '/^$/d', '-e', 's/ .*$//', files('newlib/libc/iconv/encoding.aliases')[0]], check : true).stdout().split('\n')
 +available_encodings = []
-+foreach line : fs.read('newlib/libc/iconv/encoding.aliases').split('\n')
-+  line = line.strip()
-+  if line == '' or line.startswith('#')
-+    continue
-+  endif
-+  available_encodings += [line.split()[0]]
-+endforeach
++# fs.read was added in meson version 0.57.0. The sed invocation can be
++# removed once picolibc requires a version of meson newer than that.
++if meson.version().version_compare('>=0.57')
++  foreach line : fs.read('newlib/libc/iconv/encoding.aliases').split('\n')
++    if line != '' and not line.startswith('#')
++      available_encodings += [line.split()[0]]
++    endif
++  endforeach
++else
++  available_encodings = run_command(['sed', '-e', '/^#/d', '-e', '/^$/d', '-e', 's/ .*$//', files('newlib/libc/iconv/encoding.aliases')[0]], check : true).stdout().split('\n')
++endif
  
  # Include all available encodings if none were specified on the command line
  
-@@ -1264,7 +1277,7 @@ endif
- # of meson newer than that.
- 
- test_env = environment({'PICOLIBC_TEST' : '1'})
--test_env.prepend('PATH', meson.source_root() / 'scripts')
-+test_env.prepend('PATH', meson.current_source_dir() / 'scripts')
- 
- # CompCert needs the '-WUl,' prefix to correctly pass the --spec parameters to the linker
- specs_prefix = ''
 diff --git a/picolibc.ld.in b/picolibc.ld.in
 index f7e7fa80c..75d7a9aaf 100644
 --- a/picolibc.ld.in


### PR DESCRIPTION
* Update picolibc patch based on feedback from https://github.com/picolibc/picolibc/pull/435
* Avoid calling shell script when building picolibc
* Enable building runtimes on Windows. Also add CMAKE_EXECUTABLE_SUFFIX exhaustively for all executable paths.