### PR TITLE
Update picolibc patch

### DIFF
--- a/patches/picolibc.patch
+++ b/patches/picolibc.patch
@@ -1,5 +1,5 @@
 diff --git a/meson.build b/meson.build
-index 9a24b1737..a85a0f9d9 100644
+index 729baeed9..0d905cc85 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -41,7 +41,7 @@ project('picolibc', 'c',
@@ -11,7 +11,7 @@ index 9a24b1737..a85a0f9d9 100644
  	version: '1.8'
         )
  
-@@ -960,6 +960,12 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
+@@ -965,6 +965,12 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
    error('newlib-retargetable-locking and newlib-multithread must be set to the same value')
  endif
  
@@ -24,7 +24,7 @@ index 9a24b1737..a85a0f9d9 100644
  conf_data.set('_HAVE_CC_INHIBIT_LOOP_TO_LIBCALL',
  	      cc.has_argument('-fno-tree-loop-distribute-patterns'),
  	      description: 'Compiler flag to prevent detecting memcpy/memset patterns')
-@@ -1120,7 +1126,14 @@ endif
+@@ -1125,7 +1131,14 @@ endif
  # Dig out the list of available encodings from the encoding.aliases file. Only
  # accept the first entry from each line
  
@@ -40,15 +40,6 @@ index 9a24b1737..a85a0f9d9 100644
  
  # Include all available encodings if none were specified on the command line
  
-@@ -1264,7 +1277,7 @@ endif
- # of meson newer than that.
- 
- test_env = environment({'PICOLIBC_TEST' : '1'})
--test_env.prepend('PATH', meson.source_root() / 'scripts')
-+test_env.prepend('PATH', meson.current_source_dir() / 'scripts')
- 
- # CompCert needs the '-WUl,' prefix to correctly pass the --spec parameters to the linker
- specs_prefix = ''
 diff --git a/picolibc.ld.in b/picolibc.ld.in
 index f7e7fa80c..75d7a9aaf 100644
 --- a/picolibc.ld.in


### PR DESCRIPTION
This change removes a part of picolibc patch that replaces meson.source_root with meson.current_source_dir because upstream has done the same change in commit
ce310201ab403f57874925e4165c66484ff0224d.