### PR TITLE
LLVM_CCACHE_BUILD is deprecated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,10 +161,13 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release CACHE BOOL "" FORCE)
 endif()
 
-# If ccache is available then use it by default.
-find_program(CCACHE_EXECUTABLE ccache)
-if(CCACHE_EXECUTABLE)
-    set(LLVM_CCACHE_BUILD ON CACHE BOOL "")
+if(NOT CMAKE_C_COMPILER_LAUNCHER AND NOT CMAKE_CXX_COMPILER_LAUNCHER)
+    # If ccache is available then use it by default.
+    find_program(CCACHE_EXECUTABLE ccache)
+    if(CCACHE_EXECUTABLE)
+        set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}" CACHE FILEPATH "" FORCE)
+        set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}" CACHE FILEPATH "" FORCE)
+    endif()
 endif()
 
 # If lld is available then use it by default.


### PR DESCRIPTION
Replace it with some code to set CMAKE_C_COMPILER_LAUNCHER and CMAKE_CXX_COMPILER_LAUNCHER if ccache is found and the variables aren't already set.