### PR TITLE
don't add "origin/" when checking out a tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,11 +200,13 @@ function(read_repo_version output_variable_prefix repo)
     if(tagType STREQUAL "commithash")
         # GIT_SHALLOW doesn't work with commit hashes.
         set(shallow OFF)
-    elseif(tagType STREQUAL "tag" OR tagType STREQUAL "branch")
+    elseif(tagType STREQUAL "branch")
         set(shallow ON)
         # CMake docs recommend that "branch names and tags should
         # generally be specified as remote names"
         set(tag "origin/${tag}")
+    elseif(tagType STREQUAL "tag")
+        set(shallow ON)
     else()
         message(FATAL_ERROR "Unrecognised tagType ${tagType}")
     endif()


### PR DESCRIPTION
In read_repo_version in CMakeLists.txt we look at versions.json to know what version of a repo we should check out. We can specify the version type be either commithash, branch or tag. Currently we add "origin/" to the version string if the type is either branch or tag. However for tag this isn't the right syntax. Removing origin will properly check out the repo by tag.