### PR TITLE
Clarify docs referring to sources.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,7 @@ add_custom_target(
     COMMAND
     "${CMAKE_COMMAND}"
     -DLLVMEmbeddedToolchainForArm_VERSION=${LLVMEmbeddedToolchainForArm_VERSION}
+    -DLLVMEmbeddedToolchainForArm_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
     -Dllvmproject_SOURCE_DIR=${llvmproject_SOURCE_DIR}
     -Dpicolibc_SOURCE_DIR=${picolibc_SOURCE_DIR}
     -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/generate_version_txt.cmake

--- a/cmake/THIRD-PARTY-LICENSES.txt.in
+++ b/cmake/THIRD-PARTY-LICENSES.txt.in
@@ -8,7 +8,4 @@ additional or alternate licenses:
  - libc++abi: third-party-licenses/LIBCXXABI-LICENSE.txt
  - Picolibc: third-party-licenses/COPYING.NEWLIB, third-party-licenses/COPYING.picolibc${mingw_runtime_dlls}
 
-Newlib and picolibc licenses refer to the source files of the corresponding
-libraries. To examine the source code please download the source package of
-the LLVM Embedded Toolchain for Arm from
-https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases.
+Picolibc licenses refer to its source files. Sources are identified in VERSION.txt.

--- a/cmake/VERSION.txt.in
+++ b/cmake/VERSION.txt.in
@@ -1,5 +1,6 @@
 LLVM Embedded Toolchain for Arm ${LLVMEmbeddedToolchainForArm_VERSION}
 
-Components:
+Sources:
+* LLVM Embedded Toolchain for Arm: https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm (commit ${LLVMEmbeddedToolchainForArm_COMMIT})
 * LLVM: https://github.com/llvm/llvm-project.git (commit ${llvmproject_COMMIT})
 * Picolibc: https://github.com/picolibc/picolibc.git (commit ${picolibc_COMMIT})

--- a/cmake/generate_version_txt.cmake
+++ b/cmake/generate_version_txt.cmake
@@ -1,4 +1,10 @@
 execute_process(
+    COMMAND git -C ${LLVMEmbeddedToolchainForArm_SOURCE_DIR} rev-parse HEAD
+    OUTPUT_VARIABLE LLVMEmbeddedToolchainForArm_COMMIT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+)
+execute_process(
     COMMAND git -C ${llvmproject_SOURCE_DIR} rev-parse HEAD
     OUTPUT_VARIABLE llvmproject_COMMIT
     OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -45,7 +45,9 @@ ninja llvm-toolchain
 ```
 
 To make it easy to get started, the above command checks out and patches llvm-project & picolibc Git repos automatically.
-If you prefer you can check out and patch the repos manually and use those:
+If you prefer you can check out and patch the repos manually and use those.
+If you check out repos manually then it is your responsibility to ensure that the correct revisions are checked out - see `versions.json` to identify these.
+
 ```
 mkdir repos
 git -C repos clone https://github.com/llvm/llvm-project.git


### PR DESCRIPTION
Previously separate source packages were published which is no longer the case, instead we just refer to the GitHub repos and their revisions.