### PR TITLE
Remove paths to sysroot & crt0 from config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -711,10 +711,10 @@ endfunction()
 function(make_config_cfg directory variant flags)
     # Create clang configuration files
     # https://clang.llvm.org/docs/UsersManual.html#configuration-files
-    set(crt0 "crt0.o")
+    set(crt0 "-lcrt0")
     set(extra_args "")
     configure_file(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/cmake/config.cfg.in ${LLVM_BINARY_DIR}/bin/${variant}.cfg)
-    set(crt0 "crt0-semihost.o")
+    set(crt0 "-lcrt0-semihost")
     set(extra_args "\n-lsemihost")
     configure_file(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/cmake/config.cfg.in ${LLVM_BINARY_DIR}/bin/${variant}_semihost.cfg)
     install(FILES

--- a/cmake/config.cfg.in
+++ b/cmake/config.cfg.in
@@ -1,5 +1,4 @@
 ${flags}
 -fno-exceptions
 -fno-rtti
---sysroot <CFGDIR>/../${directory}
-<CFGDIR>/../${directory}/lib/${crt0}${extra_args}
+${crt0}${extra_args}


### PR DESCRIPTION
These are not necessary since the multilib system will find the correct paths automatically.

This necessitates switching from using crt0.o and crt0-semihost.o to instead using libcrt0.a and libcrt0-semihost.a. This is because .o files cannot be found in the linker search directories, whereas .a files can.