### PR TITLE
Remove paths to crt0 from config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -746,10 +746,10 @@ endfunction()
 function(make_config_cfg directory variant flags)
     # Create clang configuration files
     # https://clang.llvm.org/docs/UsersManual.html#configuration-files
-    set(crt0 "crt0.o")
+    set(crt0 "-lcrt0")
     set(extra_args "")
     configure_file(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/cmake/config.cfg.in ${LLVM_BINARY_DIR}/bin/${variant}.cfg)
-    set(crt0 "crt0-semihost.o")
+    set(crt0 "-lcrt0-semihost")
     set(extra_args "\n-lsemihost")
     configure_file(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/cmake/config.cfg.in ${LLVM_BINARY_DIR}/bin/${variant}_semihost.cfg)
     install(FILES

--- a/README.md
+++ b/README.md
@@ -98,6 +98,29 @@ $ ls <install-dir>/LLVMEmbeddedToolchainForArm-<revision>/bin/*.cfg
 > *Note:* If you are using the toolchain in a shared environment with untrusted input,
 > make sure it is sufficiently sandboxed.
 
+### Using the toolchain without config files
+
+Instead of using a config file you can provide a `--sysroot` option specifying
+the directory containing the`include` and `lib` directories of the libraries
+you want to use, in addition to various other required options:
+* The target triple
+* Disabling exceptions and RTTI
+* The `crt0` library - either `crt0` or `crt0-semihost`
+* The semihosting library, if desired.
+ For example:
+
+```
+$ clang \
+--sysroot=<install-dir>/LLVMEmbeddedToolchainForArm-<revision>/lib/clang-runtimes/arm-none-eabi/armv6m_soft_nofp \
+--target=armv6m-none-eabi \
+-fno-exceptions \
+-fno-rtti \
+-lcrt0-semihost \
+-lsemihost \
+-T picolibc.ld \
+-o example example.c
+```
+
 ## Building from source
 
 LLVM Embedded Toolchain for Arm is an open source project and thus can be built

--- a/cmake/config.cfg.in
+++ b/cmake/config.cfg.in
@@ -2,4 +2,4 @@ ${flags}
 -fno-exceptions
 -fno-rtti
 --sysroot <CFGDIR>/../${directory}
-<CFGDIR>/../${directory}/lib/${crt0}${extra_args}
+${crt0}${extra_args}


### PR DESCRIPTION
These are no longer necessary since a crt0 library can be found in the library search path.