### PR TITLE
Fix typo in find command to remove com.apple.quarantine

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ run the executables change directory to bin and run the following command to
 remove the com.apple.quarantine:
 
 ```
-find . -type f -perm +0111 | xargs xattr -d com.apple.com.quarantine
+find . -type f -perm +0111 | xargs xattr -d com.apple.quarantine
 ```
 
 ### Using the toolchain


### PR DESCRIPTION
Command incorrectly spelled as com.apple.com.quarantine.