### PR TITLE
Lit testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,7 +456,7 @@ function(add_picolibc directory variant target_triple flags qemu_params variant_
     configure_file(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/cmake/meson-cross-build.txt.in ${BINARY_DIR}/meson-cross-build.txt @ONLY)
 
     # picolibc tests
-    string(REPLACE " " ";" qemu_params_list "${qemu_params}")
+    string(REPLACE " " ":" qemu_params_list "${qemu_params}")
     add_custom_target(check-picolibc_${variant})
     set(qemu_command "qemu-system-${cpu_family}")
     # Full list of picolibc tests
@@ -498,40 +498,40 @@ function(add_picolibc directory variant target_triple flags qemu_params variant_
     )
     # remove tests failing on a given platform
     if(variant STREQUAL "armv4t")
-        list(REMOVE_ITEM picolibc_tests abort constructor-skip)
+        list(REMOVE_ITEM picolibc_tests constructor-skip)
     endif()
     if(variant STREQUAL "armv5te")
-        list(REMOVE_ITEM picolibc_tests abort constructor-skip test-except)
+        list(REMOVE_ITEM picolibc_tests constructor-skip)
     endif()
     if(variant STREQUAL "armv6m_soft_nofp")
-        list(REMOVE_ITEM picolibc_tests abort constructor-skip test-except)
+        list(REMOVE_ITEM picolibc_tests constructor-skip)
     endif()
     if(variant STREQUAL "armv7m_soft_nofp")
-        list(REMOVE_ITEM picolibc_tests abort constructor-skip test-except)
+        list(REMOVE_ITEM picolibc_tests constructor-skip)
     endif()
     if(variant STREQUAL "armv7em_soft_nofp")
-        list(REMOVE_ITEM picolibc_tests abort constructor-skip test-except)
+        list(REMOVE_ITEM picolibc_tests constructor-skip)
     endif()
     if(variant STREQUAL "armv7em_hard_fpv4_sp_d16")
-        list(REMOVE_ITEM picolibc_tests abort constructor-skip math_errhandling test-except)
+        list(REMOVE_ITEM picolibc_tests constructor-skip math_errhandling)
     endif()
     if(variant STREQUAL "armv7em_hard_fpv5_d16")
-        list(REMOVE_ITEM picolibc_tests abort constructor-skip math_errhandling test-except)
+        list(REMOVE_ITEM picolibc_tests constructor-skip math_errhandling)
     endif()
     if(variant STREQUAL "armv8m.main_soft_nofp")
-        list(REMOVE_ITEM picolibc_tests abort constructor-skip long_double math_errhandling malloc_stress test-except timegm)
+        list(REMOVE_ITEM picolibc_tests constructor-skip long_double math_errhandling malloc_stress timegm)
     endif()
     if(variant STREQUAL "armv8m.main_hard_fp")
-        list(REMOVE_ITEM picolibc_tests abort constructor-skip complex-funcs fenv long_double math_errhandling math-funcs malloc_stress printf_scanf rand test-efcvt test-except test-strtod timegm)
+        list(REMOVE_ITEM picolibc_tests constructor-skip complex-funcs fenv long_double math_errhandling math-funcs malloc_stress printf_scanf rand test-efcvt test-strtod timegm)
     endif()
     if(variant STREQUAL "armv8.1m.main_soft_nofp_nomve")
-        list(REMOVE_ITEM picolibc_tests abort constructor-skip long_double math_errhandling malloc_stress test-except timegm)
+        list(REMOVE_ITEM picolibc_tests constructor-skip long_double math_errhandling malloc_stress timegm)
     endif()
     if(variant STREQUAL "armv8.1m.main_hard_fp")
-        list(REMOVE_ITEM picolibc_tests abort constructor-skip long_double math_errhandling malloc_stress test-except timegm)
+        list(REMOVE_ITEM picolibc_tests constructor-skip long_double math_errhandling malloc_stress timegm)
     endif()
     if(variant STREQUAL "armv8.1m.main_hard_nofp_mve")
-        list(REMOVE_ITEM picolibc_tests abort constructor-skip complex-funcs fenv ffs long_double math_errhandling math-funcs malloc_stress printf_scanf printf-tests rand regex test-efcvt test-except test-strtod timegm time-tests)
+        list(REMOVE_ITEM picolibc_tests constructor-skip complex-funcs fenv ffs long_double math_errhandling math-funcs malloc_stress printf_scanf printf-tests rand regex test-efcvt test-strtod timegm time-tests)
     endif()
 
     function(picolibc_test test)
@@ -548,7 +548,7 @@ function(add_picolibc directory variant target_triple flags qemu_params variant_
         )
         add_custom_target(
                 check-picolibc_${variant}-${test}
-                ${qemu_command} ${qemu_params_list} -semihosting -nographic -kernel check-picolibc_${variant}_build_${test}.out
+                ${CMAKE_CURRENT_SOURCE_DIR}/test-support/lit-exec-qemu.py --picolibc-test --qemu-command ${qemu_command} --qemu-params=${qemu_params_list} check-picolibc_${variant}_build_${test}.out
                 DEPENDS picolibc_tests_${variant}/check-picolibc_${variant}_build_${test}.out
                 WORKING_DIRECTORY picolibc_tests_${variant}
                 COMMENT "TEST: ${variant} ${test}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,6 +417,10 @@ set(picolibc_specific_runtimes_options
 )
 
 add_custom_target(check-picolibc)
+# Set LLVM_DEFAULT_EXTERNAL_LIT to the directory of clang
+# which was build in previous step. This path is not exported
+# by add_subdirectory of llvm project
+set(LLVM_DEFAULT_EXTERNAL_LIT "${LLVM_BINARY_DIR}/bin/llvm-lit")
 
 function(add_picolibc directory variant target_triple flags qemu_params variant_runtime_options_var)
     if(CMAKE_INSTALL_MESSAGE STREQUAL NEVER)
@@ -457,7 +461,6 @@ function(add_picolibc directory variant target_triple flags qemu_params variant_
 
     # picolibc tests
     string(REPLACE " " ":" qemu_params_list "${qemu_params}")
-    add_custom_target(check-picolibc_${variant})
     set(qemu_command "qemu-system-${cpu_family}")
     # Full list of picolibc tests
     set(picolibc_tests
@@ -498,10 +501,10 @@ function(add_picolibc directory variant target_triple flags qemu_params variant_
     )
     # remove tests failing on a given platform
     if(variant STREQUAL "armv4t")
-        list(REMOVE_ITEM picolibc_tests constructor-skip)
+        list(REMOVE_ITEM picolibc_tests constructor-skip test-except)
     endif()
     if(variant STREQUAL "armv5te")
-        list(REMOVE_ITEM picolibc_tests constructor-skip)
+        list(REMOVE_ITEM picolibc_tests constructor-skip test-except)
     endif()
     if(variant STREQUAL "armv6m_soft_nofp")
         list(REMOVE_ITEM picolibc_tests constructor-skip)
@@ -534,31 +537,31 @@ function(add_picolibc directory variant target_triple flags qemu_params variant_
         list(REMOVE_ITEM picolibc_tests constructor-skip complex-funcs fenv ffs long_double math_errhandling math-funcs malloc_stress printf_scanf printf-tests rand regex test-efcvt test-strtod timegm time-tests)
     endif()
 
+    configure_lit_site_cfg(${CMAKE_CURRENT_SOURCE_DIR}/test-support/picolibc-lit.site.cfg.py.in
+                            picolibc_tests_${variant}/lit.cfg.py)
+    add_lit_testsuite(check-picolibc_${variant}
+        "Running picolibc tests: ${variant}"
+        ${CMAKE_CURRENT_BINARY_DIR}/picolibc_tests_${variant}
+        DEPENDS picolibc_${variant} compiler_rt_${variant} llvm-toolchain-runtimes)
+
     function(picolibc_test test)
-        # -Oz parameter is added just like picolibc is doing, otherwise there is a build issue
-        # ld.lld: error: undefined symbol: __issignalingl  while building math_errhandling test.
-        add_custom_command(
-                OUTPUT picolibc_tests_${variant}/check-picolibc_${variant}_build_${test}.out
-                COMMAND ${LLVM_BINARY_DIR}/bin/clang${CMAKE_EXECUTABLE_SUFFIX} --config ${LLVM_BINARY_DIR}/bin/${variant}_semihost.cfg
+        set(BUILD_PARAMS --config ${variant}_semihost.cfg
                 -T ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/tests/ldscripts/picolibc_${variant}.ld
                 -nostdlib -lc -lg -lm -lclang_rt.builtins -lsemihost -Oz
-                ${picolibc_SOURCE_DIR}/test/${test}.c ${ARGN} -o picolibc_tests_${variant}/check-picolibc_${variant}_build_${test}.out
-                COMMENT "Building: ${test} for ${variant}"
-                DEPENDS ${picolibc_SOURCE_DIR}/test/${test}.c picolibc_${variant} compiler_rt_${variant}
-        )
-        add_custom_target(
-                check-picolibc_${variant}-${test}
-                ${CMAKE_CURRENT_SOURCE_DIR}/test-support/lit-exec-qemu.py --picolibc-test --qemu-command ${qemu_command} --qemu-params=${qemu_params_list} check-picolibc_${variant}_build_${test}.out
-                DEPENDS picolibc_tests_${variant}/check-picolibc_${variant}_build_${test}.out
-                WORKING_DIRECTORY picolibc_tests_${variant}
-                COMMENT "TEST: ${variant} ${test}"
-        )
-        add_dependencies(check-picolibc_${variant} check-picolibc_${variant}-${test})
+                ${picolibc_SOURCE_DIR}/test/${test}.c ${ARGN} -o ${CMAKE_CURRENT_BINARY_DIR}/picolibc_tests_${variant}/check-picolibc_${variant}_build_${test}.out)
+        string(REPLACE ";" " " BUILD_PARAMS "${BUILD_PARAMS}")
+        set(TEST_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-support/lit-exec-qemu.py --qemu-command ${qemu_command} --qemu-params=${qemu_params_list} check-picolibc_${variant}_build_${test}.out)
+        string(REPLACE ";" " " TEST_COMMAND "${TEST_COMMAND}")
+        set(PICOLIBC_LIT_TEST_TEMPLATE ${CMAKE_CURRENT_SOURCE_DIR}/test-support/picolibc-lit-test.template)
+        # Some picolibc tests return non-zero value upon success, then use dedicated test template
+        if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test-support/picolibc-lit-test-${test}.template)
+            set(PICOLIBC_LIT_TEST_TEMPLATE ${CMAKE_CURRENT_SOURCE_DIR}/test-support/picolibc-lit-test-${test}.template)
+        endif()
+        configure_file(${PICOLIBC_LIT_TEST_TEMPLATE} ${CMAKE_CURRENT_BINARY_DIR}/picolibc_tests_${variant}/${test}.test)
     endfunction()
     if(flags MATCHES "-march=armv8-a")
         message("Picolibc tests disabled for ${variant}")
     else()
-        execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory picolibc_tests_${variant})
         foreach(test IN LISTS picolibc_tests)
             picolibc_test(${test})
         endforeach()

--- a/test-support/lit-exec-qemu.py
+++ b/test-support/lit-exec-qemu.py
@@ -15,27 +15,6 @@ import pathlib
 # This script requires Python 3.6 or later
 assert sys.version_info >= (3, 6)
 
-picolibc_binary_name = "check-picolibc"
-picolibc_non_zero_tests = {'abort': 134, "test-except": 1}
-
-def picolibc_alt_retcode(test_name, test_ret_code):
-    """ Some picolibc tests return non-zero retcode on succes
-        all of them will be altered to zero in here
-    """
-    if test_name in picolibc_non_zero_tests:
-        if test_ret_code == picolibc_non_zero_tests[test_name]:
-            return 0
-    return test_ret_code
-
-def picolibc_test_name(binary_name):
-    """ Extract test name from picolibc test binary name
-    """
-    if picolibc_binary_name in binary_name:
-        picolibc_test_name = binary_name[binary_name.rfind("_")+1:]
-        picolibc_test_name = picolibc_test_name[:picolibc_test_name.rfind(".out")]
-        return picolibc_test_name
-    return ""
-
 
 def run(args):
     """Execute the program using QEMU and return the subprocess return code."""
@@ -58,10 +37,7 @@ def run(args):
                             cwd=args.execdir,
                             check=False)
     sys.stdout.buffer.write(result.stdout)
-    ret_code = result.returncode
-    if args.picolibc_test and ret_code != 0:
-        ret_code = picolibc_alt_retcode( picolibc_test_name(image), ret_code)
-    return ret_code
+    return result.returncode
 
 
 def main():
@@ -79,8 +55,6 @@ def main():
                         help='ignored, used for compatibility with libc++ tests')
     parser.add_argument('command', nargs=argparse.REMAINDER,
                         help='image file to execute with optional arguments')
-    parser.add_argument('--picolibc-test', nargs='?', default=False, const=True,
-                        help="Enable return code fix for picolibc tests")
     args = parser.parse_args()
     ret_code = run(args)
     sys.exit(ret_code)

--- a/test-support/lit-exec-qemu.py
+++ b/test-support/lit-exec-qemu.py
@@ -15,6 +15,27 @@ import pathlib
 # This script requires Python 3.6 or later
 assert sys.version_info >= (3, 6)
 
+picolibc_binary_name = "check-picolibc"
+picolibc_non_zero_tests = {'abort': 134, "test-except": 1}
+
+def picolibc_alt_retcode(test_name, test_ret_code):
+    """ Some picolibc tests return non-zero retcode on succes
+        all of them will be altered to zero in here
+    """
+    if test_name in picolibc_non_zero_tests:
+        if test_ret_code == picolibc_non_zero_tests[test_name]:
+            return 0
+    return test_ret_code
+
+def picolibc_test_name(binary_name):
+    """ Extract test name from picolibc test binary name
+    """
+    if picolibc_binary_name in binary_name:
+        picolibc_test_name = binary_name[binary_name.rfind("_")+1:]
+        picolibc_test_name = picolibc_test_name[:picolibc_test_name.rfind(".out")]
+        return picolibc_test_name
+    return ""
+
 
 def run(args):
     """Execute the program using QEMU and return the subprocess return code."""
@@ -37,7 +58,10 @@ def run(args):
                             cwd=args.execdir,
                             check=False)
     sys.stdout.buffer.write(result.stdout)
-    return result.returncode
+    ret_code = result.returncode
+    if args.picolibc_test and ret_code != 0:
+        ret_code = picolibc_alt_retcode( picolibc_test_name(image), ret_code)
+    return ret_code
 
 
 def main():
@@ -55,6 +79,8 @@ def main():
                         help='ignored, used for compatibility with libc++ tests')
     parser.add_argument('command', nargs=argparse.REMAINDER,
                         help='image file to execute with optional arguments')
+    parser.add_argument('--picolibc-test', nargs='?', default=False, const=True,
+                        help="Enable return code fix for picolibc tests")
     args = parser.parse_args()
     ret_code = run(args)
     sys.exit(ret_code)

--- a/test-support/picolibc-lit-test-abort.template
+++ b/test-support/picolibc-lit-test-abort.template
@@ -1,0 +1,4 @@
+# Generated Picolibc lit for @variant@ @picolibc_SOURCE_DIR@/test/@test@.c
+# RUN: %clang @BUILD_PARAMS@
+# RUN: not @TEST_COMMAND@
+# CHECK-OUTPUT: errorcode=0

--- a/test-support/picolibc-lit-test-test-except.template
+++ b/test-support/picolibc-lit-test-test-except.template
@@ -1,0 +1,4 @@
+# Generated Picolibc lit for @variant@ @picolibc_SOURCE_DIR@/test/@test@.c
+# RUN: %clang @BUILD_PARAMS@
+# RUN: not @TEST_COMMAND@
+# CHECK-OUTPUT: errorcode=0

--- a/test-support/picolibc-lit-test.template
+++ b/test-support/picolibc-lit-test.template
@@ -1,0 +1,4 @@
+# Generated Picolibc lit for @variant@ @picolibc_SOURCE_DIR@/test/@test@.c
+# RUN: %clang @BUILD_PARAMS@
+# RUN: @TEST_COMMAND@
+# CHECK-OUTPUT: errorcode=0

--- a/test-support/picolibc-lit.site.cfg.py.in
+++ b/test-support/picolibc-lit.site.cfg.py.in
@@ -1,0 +1,16 @@
+import lit
+
+# Test suite name, displayed in lit's reports of failed tests, e.g.
+#
+config.name = 'Picolibc @variant@'
+
+
+# Python class instance defining how tests are discovered and
+# executed. ShTest is the standard one, which uses RUN: comments in
+# the source files.
+config.test_format = lit.formats.ShTest()
+config.substitutions.append(("%clang", "@LLVM_BINARY_DIR@/bin/clang"))
+
+# Directory where the actual tests live, and filename extensions
+# within that directory that will be regarded as tests.
+config.suffixes = ['.test']


### PR DESCRIPTION
General concept of enabling lit testing for picolibc.

Do not forget to use external lit for example:
-DLLVM_DEFAULT_EXTERNAL_LIT=$PWD/llvm/bin/llvm-lit