### PR TITLE
Fix building from sources created by git archive

### DIFF
--- a/cmake/.gitattributes
+++ b/cmake/.gitattributes
@@ -1,0 +1,2 @@
+# During git archive, replace $Format:%H$ with the commit hash.
+generate_version_txt.cmake export-subst

--- a/cmake/generate_version_txt.cmake
+++ b/cmake/generate_version_txt.cmake
@@ -1,9 +1,22 @@
-execute_process(
-    COMMAND git -C ${LLVMEmbeddedToolchainForArm_SOURCE_DIR} rev-parse HEAD
-    OUTPUT_VARIABLE LLVMEmbeddedToolchainForArm_COMMIT
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    COMMAND_ERROR_IS_FATAL ANY
-)
+# The following line will look different depending on how you got this
+# source file. If you got it from a Git repository then it will contain
+# a string in the git pretty format with dollar symbols. If you got it
+# from a source archive then the `git archive` command should have
+# replaced the format string with the Git revision at the time the
+# archive was created. This is configured in the .gitattributes file.
+# In the former case, this script will run a Git command to find out the
+# current revision. In the latter case the revision will be used as is.
+set(LLVMEmbeddedToolchainForArm_COMMIT "$Format:%H$")
+
+if(NOT ${LLVMEmbeddedToolchainForArm_COMMIT} MATCHES "^[a-f0-9]+$")
+    execute_process(
+        COMMAND git -C ${LLVMEmbeddedToolchainForArm_SOURCE_DIR} rev-parse HEAD
+        OUTPUT_VARIABLE LLVMEmbeddedToolchainForArm_COMMIT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+endif()
+
 execute_process(
     COMMAND git -C ${llvmproject_SOURCE_DIR} rev-parse HEAD
     OUTPUT_VARIABLE llvmproject_COMMIT


### PR DESCRIPTION
This fixes the source packages that GitHub automatically creates for each release.

Previously building from a source package would fail with:

`fatal: not a git repository (or any parent up to mount point /)`