### PR TITLE
picolibc: tests with meson

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -538,8 +538,7 @@ function(
     # To solve this compiler_rt relies on picolibc to be just installed, not on
     # the full target, which would include tests. Picolibc tests, are enabled
     # only in tests step, otherwise, they would be built before install.
-    add_custom_target(compiler_rt_${variant}-available)
-    ExternalProject_Add_StepDependencies(picolibc_${variant} test compiler_rt_${variant}-available)
+    ExternalProject_Add_StepDependencies(picolibc_${variant} test compiler_rt_${variant}-install)
 
     add_dependencies(check-picolibc picolibc_${variant}-test)
     add_dependencies(
@@ -625,7 +624,7 @@ Hard-float library with target triple \"${target_triple}\" must end \"-eabihf\""
         -DLLVM_LIT_ARGS=${LLVM_LIT_ARGS}
         -DLLVM_CMAKE_DIR=${LLVM_BINARY_DIR}/lib/cmake/llvm
         -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON
-        STEP_TARGETS build
+        STEP_TARGETS build install
         USES_TERMINAL_CONFIGURE TRUE
         USES_TERMINAL_BUILD TRUE
         USES_TERMINAL_INSTALL TRUE
@@ -645,7 +644,6 @@ Hard-float library with target triple \"${target_triple}\" must end \"-eabihf\""
             ${INSTALL_DIR}/lib/${target_triple} "${LLVM_BINARY_DIR}/${directory}/lib"
     )
 
-    add_dependencies(compiler_rt_${variant}-available compiler_rt_${variant})
     add_dependencies(
         llvm-toolchain-runtimes
         compiler_rt_${variant}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,7 +435,7 @@ add_custom_target(check-picolibc)
 # by add_subdirectory of llvm project
 set(LLVM_DEFAULT_EXTERNAL_LIT "${LLVM_BINARY_DIR}/bin/llvm-lit")
 
-function(get_test_executor target_triple qemu_machine qemu_cpu qemu_params)
+function(get_test_executor_params target_triple qemu_machine qemu_cpu qemu_params)
     if(target_triple MATCHES "^aarch64")
         set(qemu_command "qemu-system-aarch64")
     else()
@@ -447,18 +447,16 @@ function(get_test_executor target_triple qemu_machine qemu_cpu qemu_params)
     string(REPLACE " " ":" qemu_params_list "${qemu_params}")
 
     set(
-        test_executor
-        ${CMAKE_CURRENT_SOURCE_DIR}/test-support/lit-exec-qemu.py
+        test_executor_params
         --qemu-command ${qemu_command}
         --qemu-machine ${qemu_machine})
     if(qemu_cpu)
-        list(APPEND test_executor "--qemu-cpu" "${qemu_cpu}")
+        list(APPEND test_executor_params --qemu-cpu ${qemu_cpu})
     endif()
     if(qemu_params_list)
-        list(APPEND test_executor "--qemu-params=${qemu_params_list}")
+        list(APPEND test_executor_params "--qemu-params=${qemu_params_list}")
     endif()
-    list(JOIN test_executor " " test_executor)
-    set(test_executor "${test_executor}" PARENT_SCOPE)
+    set(test_executor_params "${test_executor_params}" PARENT_SCOPE)
 endfunction()
 
 function(
@@ -467,7 +465,7 @@ function(
     variant
     target_triple
     flags
-    test_executor
+    test_executor_params
     default_flash_addr
     default_flash_size
     default_ram_addr
@@ -526,9 +524,8 @@ function(
     list(APPEND flags --sysroot "${LLVM_BINARY_DIR}/${directory}")
     to_meson_list("${flags}" meson_c_args)
 
-    separate_arguments(test_executor)
-    list(GET test_executor 0 test_executor_bin)
-    to_meson_list("${test_executor}" test_executor)
+    set(test_executor_bin ${CMAKE_CURRENT_SOURCE_DIR}/test-support/picolibc-test-wrapper.py)
+    to_meson_list("${test_executor_params}" test_executor_params)
 
     ExternalProject_Get_Property(picolibc_${variant} BINARY_DIR)
     configure_file(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/cmake/meson-cross-build.txt.in ${BINARY_DIR}/meson-cross-build.txt @ONLY)
@@ -557,7 +554,7 @@ function(
     variant
     target_triple
     flags
-    test_executor
+    test_executor_params
     libc_target
 )
     # We can't always put the exact target
@@ -586,6 +583,13 @@ Hard-float library with target triple \"${target_triple}\" must end \"-eabihf\""
     if(variant STREQUAL "armv6m_soft_nofp")
         set(compiler_rt_test_flags "${compiler_rt_test_flags} -fomit-frame-pointer")
     endif()
+
+    set(
+        test_executor
+        ${CMAKE_CURRENT_SOURCE_DIR}/test-support/lit-exec-qemu.py
+        ${test_executor_params}
+    )
+    list(JOIN test_executor " " test_executor)
 
     ExternalProject_Add(
         compiler_rt_${variant}
@@ -656,11 +660,18 @@ function(
     variant
     target_triple
     flags
-    test_executor
+    test_executor_params
     libc_target
     extra_cmake_options
 )
     get_runtimes_flags("${directory}" "${flags}")
+
+    set(
+        test_executor
+        ${CMAKE_CURRENT_SOURCE_DIR}/test-support/lit-exec-qemu.py
+        ${test_executor_params}
+    )
+    list(JOIN test_executor " " test_executor)
 
     ExternalProject_Add(
         libcxx_libcxxabi_libunwind_${variant}
@@ -859,14 +870,19 @@ function(add_library_variant target_arch)
     set(directory "${TARGET_LIBRARIES_DIR}/${parent_dir_name}/${variant}")
     set(VARIANT_COMPILE_FLAGS "--target=${target_triple} ${VARIANT_COMPILE_FLAGS}")
     make_config_cfg("${directory}" "${variant}" "${VARIANT_COMPILE_FLAGS}")
-    get_test_executor("${target_triple}" "${VARIANT_QEMU_MACHINE}" "${VARIANT_QEMU_CPU}" "${VARIANT_QEMU_PARAMS}")
+    get_test_executor_params(
+        "${target_triple}"
+        "${VARIANT_QEMU_MACHINE}"
+        "${VARIANT_QEMU_CPU}"
+        "${VARIANT_QEMU_PARAMS}"
+    )
     if(NOT PREBUILT_TARGET_LIBRARIES)
         add_picolibc(
             "${directory}"
             "${variant}"
             "${target_triple}"
             "${VARIANT_COMPILE_FLAGS}"
-            "${test_executor}"
+            "${test_executor_params}"
             "${VARIANT_FLASH_ADDRESS}"
             "${VARIANT_FLASH_SIZE}"
             "${VARIANT_RAM_ADDRESS}"
@@ -878,7 +894,7 @@ function(add_library_variant target_arch)
             "${variant}"
             "${target_triple}"
             "${VARIANT_COMPILE_FLAGS}"
-            "${test_executor}"
+            "${test_executor_params}"
             "picolibc_${variant}-install"
         )
         add_libcxx_libcxxabi_libunwind(
@@ -886,7 +902,7 @@ function(add_library_variant target_arch)
             "${variant}"
             "${target_triple}"
             "${VARIANT_COMPILE_FLAGS}"
-            "${test_executor}"
+            "${test_executor_params}"
             "picolibc_${variant}-install"
             "${picolibc_specific_runtimes_options}"
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,6 +468,11 @@ function(
     target_triple
     flags
     test_executor
+    default_flash_addr
+    default_flash_size
+    default_ram_addr
+    default_ram_size
+    default_stack_size
 )
     if(CMAKE_INSTALL_MESSAGE STREQUAL NEVER)
         set(MESON_INSTALL_QUIET "--quiet")
@@ -485,9 +490,23 @@ function(
         INSTALL_DIR "${LLVM_BINARY_DIR}/${directory}"
         PREFIX picolibc/${variant}
         DEPENDS clang lld llvm-ar llvm-config llvm-nm llvm-ranlib llvm-strip
-        CONFIGURE_COMMAND ${MESON_EXECUTABLE} -Dincludedir=include -Dlibdir=lib -Dspecsdir=none -Dmultilib=false --prefix <INSTALL_DIR> --cross-file <BINARY_DIR>/meson-cross-build.txt ${picolibc_SOURCE_DIR}
-        BUILD_COMMAND ninja
+        CONFIGURE_COMMAND
+            ${MESON_EXECUTABLE}
+            setup
+            -Dincludedir=include
+            -Dlibdir=lib
+            -Dspecsdir=none
+            -Dmultilib=false
+            -Dtests-enable-stack-protector=false
+            --prefix <INSTALL_DIR>
+            --cross-file <BINARY_DIR>/meson-cross-build.txt
+            ${picolibc_SOURCE_DIR}
+        BUILD_COMMAND ${MESON_EXECUTABLE} configure -Dtests=false
+        COMMAND ${MESON_EXECUTABLE} compile
         INSTALL_COMMAND ${MESON_EXECUTABLE} install ${MESON_INSTALL_QUIET}
+        TEST_COMMAND ${MESON_EXECUTABLE} configure -Dtests=true
+        COMMAND ${MESON_EXECUTABLE} test
+        COMMAND ${MESON_EXECUTABLE} configure -Dtests=false
         USES_TERMINAL_CONFIGURE TRUE
         USES_TERMINAL_BUILD TRUE
         USES_TERMINAL_TEST TRUE
@@ -495,6 +514,8 @@ function(
         # Always run the build command so that incremental builds are correct.
         BUILD_ALWAYS TRUE
         CONFIGURE_HANDLED_BY_BUILD TRUE
+        TEST_EXCLUDE_FROM_MAIN
+        STEP_TARGETS install test
     )
 
     # Set meson_c_args to a comma-separated list of the clang path
@@ -504,117 +525,23 @@ function(
     list(PREPEND flags "${LLVM_BINARY_DIR}/bin/clang${CMAKE_EXECUTABLE_SUFFIX}")
     list(APPEND flags --sysroot "${LLVM_BINARY_DIR}/${directory}")
     to_meson_list("${flags}" meson_c_args)
+
+    separate_arguments(test_executor)
+    list(GET test_executor 0 test_executor_bin)
+    to_meson_list("${test_executor}" test_executor)
+
     ExternalProject_Get_Property(picolibc_${variant} BINARY_DIR)
     configure_file(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/cmake/meson-cross-build.txt.in ${BINARY_DIR}/meson-cross-build.txt @ONLY)
 
-    # Full list of picolibc tests
-    set(picolibc_tests
-        abort
-        atexit
-        complex-funcs
-        constructor
-        constructor-skip
-        fenv
-        ffs
-        hosted-exit
-        long_double
-        malloc
-        malloc_stress
-        math_errhandling
-        math-funcs
-        on_exit
-        posix-io
-        printf_scanf
-        printf-tests
-        rand
-        regex
-        setjmp
-        stack-smash
-        test-efcvt
-        test-except
-        test-fopen
-        test-memset
-        test-mktemp
-        test-put
-        test-strchr
-        test-strtod
-        timegm
-        time-sprintf
-        time-tests
-        tls
-        ungetc
-    )
-    # remove tests failing on a given platform
-    if(variant STREQUAL "aarch64")
-        list(REMOVE_ITEM picolibc_tests constructor-skip math_errhandling)
-    endif()
-    if(variant STREQUAL "armv4t")
-        list(REMOVE_ITEM picolibc_tests constructor-skip test-except)
-    endif()
-    if(variant STREQUAL "armv5te")
-        list(REMOVE_ITEM picolibc_tests constructor-skip test-except)
-    endif()
-    if(variant STREQUAL "armv6m_soft_nofp")
-        list(REMOVE_ITEM picolibc_tests constructor-skip)
-    endif()
-    if(variant STREQUAL "armv7m_soft_nofp")
-        list(REMOVE_ITEM picolibc_tests constructor-skip)
-    endif()
-    if(variant STREQUAL "armv7em_soft_nofp")
-        list(REMOVE_ITEM picolibc_tests constructor-skip)
-    endif()
-    if(variant STREQUAL "armv7em_hard_fpv4_sp_d16")
-        list(REMOVE_ITEM picolibc_tests constructor-skip math_errhandling)
-    endif()
-    if(variant STREQUAL "armv7em_hard_fpv5_d16")
-        list(REMOVE_ITEM picolibc_tests constructor-skip math_errhandling)
-    endif()
-    if(variant STREQUAL "armv8m.main_soft_nofp")
-        list(REMOVE_ITEM picolibc_tests constructor-skip long_double math_errhandling malloc_stress timegm)
-    endif()
-    if(variant STREQUAL "armv8m.main_hard_fp")
-        list(REMOVE_ITEM picolibc_tests constructor-skip complex-funcs fenv long_double math_errhandling math-funcs malloc_stress printf_scanf rand test-efcvt test-strtod timegm)
-    endif()
-    if(variant STREQUAL "armv8.1m.main_soft_nofp_nomve")
-        list(REMOVE_ITEM picolibc_tests constructor-skip long_double math_errhandling malloc_stress timegm)
-    endif()
-    if(variant STREQUAL "armv8.1m.main_hard_fp")
-        list(REMOVE_ITEM picolibc_tests constructor-skip long_double math_errhandling malloc_stress timegm)
-    endif()
-    if(variant STREQUAL "armv8.1m.main_hard_nofp_mve")
-        list(REMOVE_ITEM picolibc_tests constructor-skip complex-funcs fenv ffs long_double math_errhandling math-funcs malloc_stress printf_scanf printf-tests rand regex test-efcvt test-strtod timegm time-tests)
-    endif()
+    # Building picolibc tests requires compiler_rt to be installed.
+    # Building compiler_rt tests requires picolibc to be installed.
+    # To solve this compiler_rt relies on picolibc to be just installed, not on
+    # the full target, which would include tests. Picolibc tests, are enabled
+    # only in tests step, otherwise, they would be built before install.
+    add_custom_target(compiler_rt_${variant}-available)
+    ExternalProject_Add_StepDependencies(picolibc_${variant} test compiler_rt_${variant}-available)
 
-    configure_lit_site_cfg(${CMAKE_CURRENT_SOURCE_DIR}/test-support/picolibc-lit.site.cfg.py.in
-                            picolibc_tests_${variant}/lit.cfg.py)
-    add_lit_testsuite(check-picolibc_${variant}
-        "Running picolibc tests: ${variant}"
-        ${CMAKE_CURRENT_BINARY_DIR}/picolibc_tests_${variant}
-        DEPENDS picolibc_${variant} compiler_rt_${variant} llvm-toolchain-runtimes)
-
-    function(picolibc_test test)
-        set(BUILD_PARAMS --config ${variant}_semihost.cfg
-                -T ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/test-support/ldscripts/picolibc_${variant}.ld
-                -nostdlib -lc -lg -lm -lclang_rt.builtins -lsemihost -Oz
-                ${picolibc_SOURCE_DIR}/test/${test}.c ${ARGN} -o ${CMAKE_CURRENT_BINARY_DIR}/picolibc_tests_${variant}/check-picolibc_${variant}_build_${test}.out)
-        string(REPLACE ";" " " BUILD_PARAMS "${BUILD_PARAMS}")
-        set(TEST_COMMAND "${test_executor} check-picolibc_${variant}_build_${test}.out")
-        set(PICOLIBC_LIT_TEST_TEMPLATE ${CMAKE_CURRENT_SOURCE_DIR}/test-support/picolibc-lit-test.template)
-        # Some picolibc tests return non-zero value upon success, then use dedicated test template
-        if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test-support/picolibc-lit-test-${test}.template)
-            set(PICOLIBC_LIT_TEST_TEMPLATE ${CMAKE_CURRENT_SOURCE_DIR}/test-support/picolibc-lit-test-${test}.template)
-        endif()
-        configure_file(${PICOLIBC_LIT_TEST_TEMPLATE} ${CMAKE_CURRENT_BINARY_DIR}/picolibc_tests_${variant}/${test}.test)
-    endfunction()
-
-    foreach(test IN LISTS picolibc_tests)
-        picolibc_test(${test})
-    endforeach()
-    # Test disabled due to duplicated symbol name div in test file and in picolibc
-    # picolibc_test(rounding-mode)
-    # Test disabled due to fail on armv8.1m.main_hard_nofp_mve
-    # picolibc_test(try-ilp32)
-    add_dependencies(check-picolibc check-picolibc_${variant})
+    add_dependencies(check-picolibc picolibc_${variant}-test)
     add_dependencies(
         llvm-toolchain-runtimes
         picolibc_${variant}
@@ -656,7 +583,7 @@ Hard-float library with target triple \"${target_triple}\" must end \"-eabihf\""
 
     get_runtimes_flags("${directory}" "${flags}")
 
-    set(compiler_rt_test_flags "--config ${LLVM_BINARY_DIR}/bin/${variant}_semihost.cfg -T ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/test-support/ldscripts/picolibc_${variant}.ld")
+    set(compiler_rt_test_flags "--config ${LLVM_BINARY_DIR}/bin/${variant}_semihost.cfg -T picolibcpp.ld")
     if(variant STREQUAL "armv6m_soft_nofp")
         set(compiler_rt_test_flags "${compiler_rt_test_flags} -fomit-frame-pointer")
     endif()
@@ -718,6 +645,7 @@ Hard-float library with target triple \"${target_triple}\" must end \"-eabihf\""
             ${INSTALL_DIR}/lib/${target_triple} "${LLVM_BINARY_DIR}/${directory}/lib"
     )
 
+    add_dependencies(compiler_rt_${variant}-available compiler_rt_${variant})
     add_dependencies(
         llvm-toolchain-runtimes
         compiler_rt_${variant}
@@ -759,7 +687,7 @@ function(
         # Let CMake know we're cross-compiling
         -DCMAKE_SYSTEM_NAME=Generic
         -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY
-        -DLIBC_LINKER_SCRIPT=${CMAKE_CURRENT_SOURCE_DIR}/test-support/ldscripts/picolibc_${variant}.ld
+        -DLIBC_LINKER_SCRIPT=picolibcpp.ld
         -DLIBCXXABI_BAREMETAL=ON
         -DLIBCXXABI_ENABLE_ASSERTIONS=OFF
         -DLIBCXXABI_ENABLE_SHARED=OFF
@@ -899,6 +827,11 @@ function(add_library_variant target_arch)
         QEMU_MACHINE
         QEMU_CPU
         QEMU_PARAMS
+        FLASH_ADDRESS
+        FLASH_SIZE
+        RAM_ADDRESS
+        RAM_SIZE
+        STACK_SIZE
     )
     cmake_parse_arguments(VARIANT "" "${one_value_args}" "" ${ARGN})
 
@@ -936,6 +869,11 @@ function(add_library_variant target_arch)
             "${target_triple}"
             "${VARIANT_COMPILE_FLAGS}"
             "${test_executor}"
+            "${VARIANT_FLASH_ADDRESS}"
+            "${VARIANT_FLASH_SIZE}"
+            "${VARIANT_RAM_ADDRESS}"
+            "${VARIANT_RAM_SIZE}"
+            "${VARIANT_STACK_SIZE}"
         )
         add_compiler_rt(
             "${directory}"
@@ -943,7 +881,7 @@ function(add_library_variant target_arch)
             "${target_triple}"
             "${VARIANT_COMPILE_FLAGS}"
             "${test_executor}"
-            "picolibc_${variant}"
+            "picolibc_${variant}-install"
         )
         add_libcxx_libcxxabi_libunwind(
             "${directory}"
@@ -951,7 +889,7 @@ function(add_library_variant target_arch)
             "${target_triple}"
             "${VARIANT_COMPILE_FLAGS}"
             "${test_executor}"
-            "picolibc_${variant}"
+            "picolibc_${variant}-install"
             "${picolibc_specific_runtimes_options}"
         )
         if(VARIANT_COMPILE_FLAGS MATCHES "-march=armv8")
@@ -990,20 +928,37 @@ add_library_variant(
     MULTILIB_FLAGS "--target=aarch64-none-unknown-elf"
     QEMU_MACHINE "virt"
     QEMU_CPU "cortex-a57"
+    FLASH_ADDRESS 0x40000000
+    FLASH_SIZE 4M
+    RAM_ADDRESS 0x40400000
+    RAM_SIZE 2M
+    STACK_SIZE 8K
 )
 add_library_variant(
     armv4t
     COMPILE_FLAGS "-march=armv4t"
     MULTILIB_FLAGS "--target=armv4t-none-unknown-eabi -mfpu=none"
-    QEMU_MACHINE "musicpal"
-    QEMU_CPU "arm926"
+    QEMU_MACHINE "none"
+    QEMU_CPU "ti925t"
+    QEMU_PARAMS "-m 1G"
+    FLASH_ADDRESS 0x00000000
+    FLASH_SIZE 4M
+    RAM_ADDRESS 0x20000000
+    RAM_SIZE 2M
+    STACK_SIZE 4K
 )
 add_library_variant(
     armv5te
     COMPILE_FLAGS "-march=armv5te"
     MULTILIB_FLAGS "--target=armv5e-none-unknown-eabi -mfpu=none"
-    QEMU_MACHINE "musicpal"
+    QEMU_MACHINE "none"
     QEMU_CPU "arm926"
+    QEMU_PARAMS "-m 1G"
+    FLASH_ADDRESS 0x00000000
+    FLASH_SIZE 4M
+    RAM_ADDRESS 0x20000000
+    RAM_SIZE 2M
+    STACK_SIZE 4K
 )
 add_library_variant(
     armv6m
@@ -1011,6 +966,11 @@ add_library_variant(
     COMPILE_FLAGS "-mfloat-abi=soft -march=armv6m"
     MULTILIB_FLAGS "--target=thumbv6m-none-unknown-eabi -mfpu=none"
     QEMU_MACHINE "mps2-an385"
+    FLASH_ADDRESS 0x00000000
+    FLASH_SIZE 4M
+    RAM_ADDRESS 0x20000000
+    RAM_SIZE 2M
+    STACK_SIZE 4K
 )
 add_library_variant(
     armv7m
@@ -1019,6 +979,11 @@ add_library_variant(
     MULTILIB_FLAGS "--target=thumbv7m-none-unknown-eabi -mfpu=none"
     QEMU_MACHINE "mps2-an385"
     QEMU_CPU "cortex-m3"
+    FLASH_ADDRESS 0x00000000
+    FLASH_SIZE 4M
+    RAM_ADDRESS 0x20000000
+    RAM_SIZE 2M
+    STACK_SIZE 4K
 )
 add_library_variant(
     armv7em
@@ -1027,6 +992,11 @@ add_library_variant(
     MULTILIB_FLAGS "--target=thumbv7em-none-unknown-eabi -mfpu=none"
     QEMU_MACHINE "mps2-an386"
     QEMU_CPU "cortex-m4"
+    FLASH_ADDRESS 0x00000000
+    FLASH_SIZE 4M
+    RAM_ADDRESS 0x20000000
+    RAM_SIZE 2M
+    STACK_SIZE 4K
 )
 add_library_variant(
     armv7em
@@ -1035,6 +1005,11 @@ add_library_variant(
     MULTILIB_FLAGS "--target=thumbv7em-none-unknown-eabihf -mfpu=fpv4-sp-d16"
     QEMU_MACHINE "mps2-an386"
     QEMU_CPU "cortex-m4"
+    FLASH_ADDRESS 0x00000000
+    FLASH_SIZE 4M
+    RAM_ADDRESS 0x20000000
+    RAM_SIZE 2M
+    STACK_SIZE 4K
 )
 add_library_variant(
     armv7em
@@ -1043,6 +1018,11 @@ add_library_variant(
     MULTILIB_FLAGS "--target=thumbv7em-none-unknown-eabihf -mfpu=fpv5-d16"
     QEMU_MACHINE "mps2-an500"
     QEMU_CPU "cortex-m7"
+    FLASH_ADDRESS 0x00000000
+    FLASH_SIZE 4M
+    RAM_ADDRESS 0x20000000
+    RAM_SIZE 2M
+    STACK_SIZE 4K
 )
 add_library_variant(
     armv8m.main
@@ -1051,6 +1031,11 @@ add_library_variant(
     MULTILIB_FLAGS "--target=thumbv8m.main-none-unknown-eabi -mfpu=none"
     QEMU_MACHINE "mps2-an505"
     QEMU_CPU "cortex-m33"
+    FLASH_ADDRESS 0x10000000
+    FLASH_SIZE 4M
+    RAM_ADDRESS 0x80000000
+    RAM_SIZE 16M
+    STACK_SIZE 4K
 )
 add_library_variant(
     armv8m.main
@@ -1059,6 +1044,11 @@ add_library_variant(
     MULTILIB_FLAGS "--target=thumbv8m.main-none-unknown-eabihf -mfpu=fpv5-d16"
     QEMU_MACHINE "mps2-an505"
     QEMU_CPU "cortex-m33"
+    FLASH_ADDRESS 0x10000000
+    FLASH_SIZE 4M
+    RAM_ADDRESS 0x80000000
+    RAM_SIZE 16M
+    STACK_SIZE 4K
 )
 add_library_variant(
     armv8.1m.main
@@ -1067,6 +1057,11 @@ add_library_variant(
     MULTILIB_FLAGS "--target=thumbv8.1m.main-none-unknown-eabi -mfpu=none"
     QEMU_MACHINE "mps3-an547"
     QEMU_CPU "cortex-m55"
+    FLASH_ADDRESS 0x10000000
+    FLASH_SIZE 2M
+    RAM_ADDRESS 0x60000000
+    RAM_SIZE 2M
+    STACK_SIZE 4K
 )
 add_library_variant(
     armv8.1m.main
@@ -1075,6 +1070,11 @@ add_library_variant(
     MULTILIB_FLAGS "--target=thumbv8.1m.main-none-unknown-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-sp-d16"
     QEMU_MACHINE "mps3-an547"
     QEMU_CPU "cortex-m55"
+    FLASH_ADDRESS 0x10000000
+    FLASH_SIZE 2M
+    RAM_ADDRESS 0x60000000
+    RAM_SIZE 2M
+    STACK_SIZE 4K
 )
 add_library_variant(
     armv8.1m.main
@@ -1083,6 +1083,11 @@ add_library_variant(
     MULTILIB_FLAGS "--target=thumbv8.1m.main-none-unknown-eabihf -march=thumbv8.1m.main+dsp+mve -mfpu=none"
     QEMU_MACHINE "mps3-an547"
     QEMU_CPU "cortex-m55"
+    FLASH_ADDRESS 0x10000000
+    FLASH_SIZE 2M
+    RAM_ADDRESS 0x60000000
+    RAM_SIZE 2M
+    STACK_SIZE 4K
 )
 
 configure_file(

--- a/cmake/meson-cross-build.txt.in
+++ b/cmake/meson-cross-build.txt.in
@@ -7,7 +7,8 @@ exe_wrapper = [
     'sh',
     '-c',
     'test -z "$PICOLIBC_TEST" || @test_executor_bin@ "$@"',
-    @test_executor@]
+    '@test_executor_bin@',
+    @test_executor_params@]
 
 [host_machine]
 system = 'none'

--- a/cmake/meson-cross-build.txt.in
+++ b/cmake/meson-cross-build.txt.in
@@ -1,9 +1,13 @@
 [binaries]
-c = [@meson_c_args@]
+c = [@meson_c_args@, '-nostdlib']
 ar = '@LLVM_BINARY_DIR@/bin/llvm-ar@CMAKE_EXECUTABLE_SUFFIX@'
 strip = '@LLVM_BINARY_DIR@/bin/llvm-strip@CMAKE_EXECUTABLE_SUFFIX@'
 # only needed to run tests
-exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-@cpu_family@ "$@"', 'run-@cpu_family@']
+exe_wrapper = [
+    'sh',
+    '-c',
+    'test -z "$PICOLIBC_TEST" || @test_executor_bin@ "$@"',
+    @test_executor@]
 
 [host_machine]
 system = 'none'
@@ -13,3 +17,9 @@ endian = 'little'
 
 [properties]
 skip_sanity_check = true
+libgcc ='-lclang_rt.builtins'
+default_flash_addr = '@default_flash_addr@'
+default_flash_size = '@default_flash_size@'
+default_ram_addr   = '@default_ram_addr@'
+default_ram_size   = '@default_ram_size@'
+default_stack_size = '@default_stack_size@'

--- a/test-support/ldscripts/picolibc_aarch64.ld
+++ b/test-support/ldscripts/picolibc_aarch64.ld
@@ -1,7 +1,0 @@
-__flash =      0x40000000;
-__flash_size = 0x00400000;
-__ram =        0x40400000;
-__ram_size   = 0x00200000;
-__stack_size = 8k;
-
-INCLUDE picolibcpp.ld

--- a/test-support/ldscripts/picolibc_armv4t.ld
+++ b/test-support/ldscripts/picolibc_armv4t.ld
@@ -1,7 +1,0 @@
-__flash =      0x00010000;
-__flash_size = 0x00400000;
-__ram =        0x00500000;
-__ram_size   = 0x00200000;
-__stack_size = 4k;
-
-INCLUDE picolibcpp.ld

--- a/test-support/ldscripts/picolibc_armv5te.ld
+++ b/test-support/ldscripts/picolibc_armv5te.ld
@@ -1,7 +1,0 @@
-__flash =      0x00010000;
-__flash_size = 0x00400000;
-__ram =        0x00500000;
-__ram_size   = 0x00200000;
-__stack_size = 4k;
-
-INCLUDE picolibcpp.ld

--- a/test-support/ldscripts/picolibc_armv6m_soft_nofp.ld
+++ b/test-support/ldscripts/picolibc_armv6m_soft_nofp.ld
@@ -1,7 +1,0 @@
-__flash         = 0x00000000; /* starting address of flash */
-__flash_size    = 0x00400000; /* length of flash */
-__ram           = 0x20000000; /* starting address of RAM bank 0 */
-__ram_size      = 0x00200000; /* length of RAM bank 0 */
-__stack_size    = 4k;
-
-INCLUDE picolibcpp.ld

--- a/test-support/ldscripts/picolibc_armv7em_hard_fpv4_sp_d16.ld
+++ b/test-support/ldscripts/picolibc_armv7em_hard_fpv4_sp_d16.ld
@@ -1,7 +1,0 @@
-__flash =      0x00000000;
-__flash_size = 0x00400000;
-__ram =        0x20000000;
-__ram_size   = 0x00200000;
-__stack_size = 4k;
-
-INCLUDE picolibcpp.ld

--- a/test-support/ldscripts/picolibc_armv7em_hard_fpv5_d16.ld
+++ b/test-support/ldscripts/picolibc_armv7em_hard_fpv5_d16.ld
@@ -1,7 +1,0 @@
-__flash =      0x00000000;
-__flash_size = 0x00400000;
-__ram =        0x20000000;
-__ram_size   = 0x00200000;
-__stack_size = 4k;
-
-INCLUDE picolibcpp.ld

--- a/test-support/ldscripts/picolibc_armv7em_soft_nofp.ld
+++ b/test-support/ldscripts/picolibc_armv7em_soft_nofp.ld
@@ -1,7 +1,0 @@
-__flash =      0x00000000;
-__flash_size = 0x00400000;
-__ram =        0x20000000;
-__ram_size   = 0x00200000;
-__stack_size = 4k;
-
-INCLUDE picolibcpp.ld

--- a/test-support/ldscripts/picolibc_armv7m_soft_nofp.ld
+++ b/test-support/ldscripts/picolibc_armv7m_soft_nofp.ld
@@ -1,7 +1,0 @@
-__flash =      0x00000000;
-__flash_size = 0x00400000;
-__ram =        0x20000000;
-__ram_size   = 0x00200000;
-__stack_size = 4k;
-
-INCLUDE picolibcpp.ld

--- a/test-support/ldscripts/picolibc_armv8.1m.main_hard_fp.ld
+++ b/test-support/ldscripts/picolibc_armv8.1m.main_hard_fp.ld
@@ -1,4 +1,0 @@
-__flash_size = 0x00400000; 
-__stack_size = 4k;
-
-INCLUDE picolibcpp.ld

--- a/test-support/ldscripts/picolibc_armv8.1m.main_hard_nofp_mve.ld
+++ b/test-support/ldscripts/picolibc_armv8.1m.main_hard_nofp_mve.ld
@@ -1,4 +1,0 @@
-__flash_size = 0x00400000;
-__stack_size = 4k;
-
-INCLUDE picolibcpp.ld

--- a/test-support/ldscripts/picolibc_armv8.1m.main_soft_nofp_nomve.ld
+++ b/test-support/ldscripts/picolibc_armv8.1m.main_soft_nofp_nomve.ld
@@ -1,4 +1,0 @@
-__flash_size = 0x00400000; 
-__stack_size = 4k;
-
-INCLUDE picolibcpp.ld

--- a/test-support/ldscripts/picolibc_armv8m.main_hard_fp.ld
+++ b/test-support/ldscripts/picolibc_armv8m.main_hard_fp.ld
@@ -1,3 +1,0 @@
-__stack_size = 4k;
-
-INCLUDE picolibcpp.ld

--- a/test-support/ldscripts/picolibc_armv8m.main_soft_nofp.ld
+++ b/test-support/ldscripts/picolibc_armv8m.main_soft_nofp.ld
@@ -1,4 +1,0 @@
-__flash_size = 0x00400000;
-__stack_size = 4k;
-
-INCLUDE picolibcpp.ld

--- a/test-support/lit-exec-qemu.py
+++ b/test-support/lit-exec-qemu.py
@@ -5,15 +5,53 @@
 # This script is a bridge between lit-based tests of LLVM C++ runtime libraries
 # (libc++abi, libunwind, libc++) and QEMU. It must handle the same command-line
 # arguments as llvm-project/libcxx/utils/run.py.
+# This is also a wrapper script to run picolibc tests with QEMU.
 
 import sys
 import argparse
 import subprocess
 import pathlib
 
+# https://mesonbuild.com/Unit-tests.html#skipped-tests-and-hard-errors
+EXIT_CODE_SKIP = 77
+
+disabled_tests = [
+    "picolibc_aarch64-build/test/math_errhandling",
+    "picolibc_armv7em_hard_fpv4_sp_d16-build/test/math_errhandling",
+    "picolibc_armv7em_hard_fpv5_d16-build/test/math_errhandling",
+    "picolibc_armv8m.main_hard_fp-build/test/printf_scanf",
+    "picolibc_armv8m.main_hard_fp-build/test/printff_scanff",
+    "picolibc_armv8m.main_hard_fp-build/test/printff-tests",
+    "picolibc_armv8m.main_hard_fp-build/test/math_errhandling",
+    "picolibc_armv8m.main_hard_fp-build/test/rounding-mode",
+    "picolibc_armv8m.main_hard_fp-build/test/long_double",
+    "picolibc_armv8m.main_hard_fp-build/test/rand",
+    "picolibc_armv8m.main_hard_fp-build/test/fenv",
+    "picolibc_armv8m.main_hard_fp-build/test/math-funcs",
+    "picolibc_armv8m.main_hard_fp-build/test/test-strtod",
+    "picolibc_armv8m.main_hard_fp-build/test/test-efcvt",
+    "picolibc_armv8m.main_hard_fp-build/test/complex-funcs",
+    "picolibc_armv8m.main_hard_fp-build/test/semihost/semihost-times",
+    "picolibc_armv8m.main_hard_fp-build/newlib/libm/test/math_test",
+    "picolibc_armv8m.main_hard_fp-build/test/libc-testsuite/sscanf",
+    "picolibc_armv8m.main_hard_fp-build/test/libc-testsuite/strtod",
+    "picolibc_armv8.1m.main_soft_nofp_nomve-build/newlib/libm/test/math_test",
+    "picolibc_armv8.1m.main_hard_fp-build/test/math_errhandling",
+    "picolibc_armv8.1m.main_hard_fp-build/newlib/libm/test/math_test",
+    "picolibc_armv8.1m.main_hard_nofp_mve-build/test/fenv",
+    "picolibc_armv8.1m.main_hard_nofp_mve-build/newlib/libm/test/math_test",
+    "picolibc_armv8.1m.main_hard_nofp_mve-build/test/math_errhandling",
+]
+
+
+def is_disabled(image):
+    return any([image.endswith(t) for t in disabled_tests])
+
 
 def run(args):
     """Execute the program using QEMU and return the subprocess return code."""
+    if is_disabled(args.image):
+        return EXIT_CODE_SKIP
     qemu_params = ["-M", args.qemu_machine]
     if args.qemu_cpu:
         qemu_params += ["-cpu", args.qemu_cpu]
@@ -42,8 +80,11 @@ def run(args):
         qemu_params += ["-device", f"loader,file={args.image},cpu-num=0"]
 
     qemu_cmd = [args.qemu_command] + qemu_params
+    # setting stdin to devnull prevents qemu from fiddling with the echo bit of
+    # the parent terminal
     result = subprocess.run(
         qemu_cmd,
+        stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         stderr=sys.stderr,
         timeout=args.timeout,

--- a/test-support/lit-exec-qemu.py
+++ b/test-support/lit-exec-qemu.py
@@ -5,94 +5,11 @@
 # This script is a bridge between lit-based tests of LLVM C++ runtime libraries
 # (libc++abi, libunwind, libc++) and QEMU. It must handle the same command-line
 # arguments as llvm-project/libcxx/utils/run.py.
-# This is also a wrapper script to run picolibc tests with QEMU.
 
-import sys
+from run_qemu import run_qemu
 import argparse
-import subprocess
 import pathlib
-
-# https://mesonbuild.com/Unit-tests.html#skipped-tests-and-hard-errors
-EXIT_CODE_SKIP = 77
-
-disabled_tests = [
-    "picolibc_aarch64-build/test/math_errhandling",
-    "picolibc_armv7em_hard_fpv4_sp_d16-build/test/math_errhandling",
-    "picolibc_armv7em_hard_fpv5_d16-build/test/math_errhandling",
-    "picolibc_armv8m.main_hard_fp-build/test/printf_scanf",
-    "picolibc_armv8m.main_hard_fp-build/test/printff_scanff",
-    "picolibc_armv8m.main_hard_fp-build/test/printff-tests",
-    "picolibc_armv8m.main_hard_fp-build/test/math_errhandling",
-    "picolibc_armv8m.main_hard_fp-build/test/rounding-mode",
-    "picolibc_armv8m.main_hard_fp-build/test/long_double",
-    "picolibc_armv8m.main_hard_fp-build/test/rand",
-    "picolibc_armv8m.main_hard_fp-build/test/fenv",
-    "picolibc_armv8m.main_hard_fp-build/test/math-funcs",
-    "picolibc_armv8m.main_hard_fp-build/test/test-strtod",
-    "picolibc_armv8m.main_hard_fp-build/test/test-efcvt",
-    "picolibc_armv8m.main_hard_fp-build/test/complex-funcs",
-    "picolibc_armv8m.main_hard_fp-build/test/semihost/semihost-times",
-    "picolibc_armv8m.main_hard_fp-build/newlib/libm/test/math_test",
-    "picolibc_armv8m.main_hard_fp-build/test/libc-testsuite/sscanf",
-    "picolibc_armv8m.main_hard_fp-build/test/libc-testsuite/strtod",
-    "picolibc_armv8.1m.main_soft_nofp_nomve-build/newlib/libm/test/math_test",
-    "picolibc_armv8.1m.main_hard_fp-build/test/math_errhandling",
-    "picolibc_armv8.1m.main_hard_fp-build/newlib/libm/test/math_test",
-    "picolibc_armv8.1m.main_hard_nofp_mve-build/test/fenv",
-    "picolibc_armv8.1m.main_hard_nofp_mve-build/newlib/libm/test/math_test",
-    "picolibc_armv8.1m.main_hard_nofp_mve-build/test/math_errhandling",
-]
-
-
-def is_disabled(image):
-    return any([image.endswith(t) for t in disabled_tests])
-
-
-def run(args):
-    """Execute the program using QEMU and return the subprocess return code."""
-    if is_disabled(args.image):
-        return EXIT_CODE_SKIP
-    qemu_params = ["-M", args.qemu_machine]
-    if args.qemu_cpu:
-        qemu_params += ["-cpu", args.qemu_cpu]
-    if args.qemu_params:
-        qemu_params += args.qemu_params.split(":")
-
-    # Setup semihosting with chardev bound to stdio.
-    # This is needed to test semihosting functionality in picolibc.
-    qemu_params += ["-chardev", "stdio,mux=on,id=stdio0"]
-    semihosting_config = ["enable=on", "chardev=stdio0"] + [
-        "arg=" + arg.replace(",", ",,") for arg in args.arguments
-    ]
-    qemu_params += ["-semihosting-config", ",".join(semihosting_config)]
-
-    # Disable features we don't need and which could slow down the test or
-    # interfere with semihosting.
-    qemu_params += ["-monitor", "none", "-serial", "none", "-nographic"]
-
-    # Load the image to machine's memory and set the PC.
-    # "virt" machine cannot be used with load, as QEMU will try to put
-    # device tree blob at start of RAM conflicting with our code
-    # https://www.qemu.org/docs/master/system/arm/virt.html#hardware-configuration-information-for-bare-metal-programming
-    if args.qemu_machine == "virt":
-        qemu_params += ["-kernel", args.image]
-    else:
-        qemu_params += ["-device", f"loader,file={args.image},cpu-num=0"]
-
-    qemu_cmd = [args.qemu_command] + qemu_params
-    # setting stdin to devnull prevents qemu from fiddling with the echo bit of
-    # the parent terminal
-    result = subprocess.run(
-        qemu_cmd,
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE,
-        stderr=sys.stderr,
-        timeout=args.timeout,
-        cwd=args.execdir,
-        check=False,
-    )
-    sys.stdout.buffer.write(result.stdout)
-    return result.returncode
+import sys
 
 
 def main():
@@ -124,7 +41,7 @@ def main():
     parser.add_argument(
         "--execdir",
         type=pathlib.Path,
-        default=".",
+        default=pathlib.Path.cwd(),
         help="directory to run the program from",
     )
     parser.add_argument(
@@ -146,7 +63,16 @@ def main():
         help="optional arguments for the image",
     )
     args = parser.parse_args()
-    ret_code = run(args)
+    ret_code = run_qemu(
+        args.qemu_command,
+        args.qemu_machine,
+        args.qemu_cpu,
+        args.qemu_params.split(":") if args.qemu_params else [],
+        args.image,
+        args.arguments,
+        args.timeout,
+        args.execdir,
+    )
     sys.exit(ret_code)
 
 

--- a/test-support/picolibc-test-wrapper.py
+++ b/test-support/picolibc-test-wrapper.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2023, Arm Limited and affiliates.
+
+# This is a wrapper script to run picolibc tests with QEMU.
+
+from run_qemu import run_qemu
+import argparse
+import pathlib
+import sys
+
+# https://mesonbuild.com/Unit-tests.html#skipped-tests-and-hard-errors
+EXIT_CODE_SKIP = 77
+
+disabled_tests = [
+    "picolibc_aarch64-build/test/math_errhandling",
+    "picolibc_armv7em_hard_fpv4_sp_d16-build/test/math_errhandling",
+    "picolibc_armv7em_hard_fpv5_d16-build/test/math_errhandling",
+    "picolibc_armv8m.main_hard_fp-build/test/printf_scanf",
+    "picolibc_armv8m.main_hard_fp-build/test/printff_scanff",
+    "picolibc_armv8m.main_hard_fp-build/test/printff-tests",
+    "picolibc_armv8m.main_hard_fp-build/test/math_errhandling",
+    "picolibc_armv8m.main_hard_fp-build/test/rounding-mode",
+    "picolibc_armv8m.main_hard_fp-build/test/long_double",
+    "picolibc_armv8m.main_hard_fp-build/test/rand",
+    "picolibc_armv8m.main_hard_fp-build/test/fenv",
+    "picolibc_armv8m.main_hard_fp-build/test/math-funcs",
+    "picolibc_armv8m.main_hard_fp-build/test/test-strtod",
+    "picolibc_armv8m.main_hard_fp-build/test/test-efcvt",
+    "picolibc_armv8m.main_hard_fp-build/test/complex-funcs",
+    "picolibc_armv8m.main_hard_fp-build/test/semihost/semihost-times",
+    "picolibc_armv8m.main_hard_fp-build/newlib/libm/test/math_test",
+    "picolibc_armv8m.main_hard_fp-build/test/libc-testsuite/sscanf",
+    "picolibc_armv8m.main_hard_fp-build/test/libc-testsuite/strtod",
+    "picolibc_armv8.1m.main_soft_nofp_nomve-build/newlib/libm/test/math_test",
+    "picolibc_armv8.1m.main_hard_fp-build/test/math_errhandling",
+    "picolibc_armv8.1m.main_hard_fp-build/newlib/libm/test/math_test",
+    "picolibc_armv8.1m.main_hard_nofp_mve-build/test/fenv",
+    "picolibc_armv8.1m.main_hard_nofp_mve-build/newlib/libm/test/math_test",
+    "picolibc_armv8.1m.main_hard_nofp_mve-build/test/math_errhandling",
+]
+
+
+def is_disabled(image):
+    return any([image.endswith(t) for t in disabled_tests])
+
+
+def run(args):
+    if is_disabled(args.image):
+        return EXIT_CODE_SKIP
+    return run_qemu(
+        args.qemu_command,
+        args.qemu_machine,
+        args.qemu_cpu,
+        args.qemu_params.split(":") if args.qemu_params else [],
+        args.image,
+        args.arguments,
+        None,
+        pathlib.Path.cwd(),
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run a single test using qemu"
+    )
+    parser.add_argument(
+        "--qemu-command", required=True, help="qemu-system-<arch> path"
+    )
+    parser.add_argument(
+        "--qemu-machine",
+        required=True,
+        help="name of the machine to pass to QEMU",
+    )
+    parser.add_argument(
+        "--qemu-cpu", required=False, help="name of the cpu to pass to QEMU"
+    )
+    parser.add_argument(
+        "--qemu-params",
+        required=False,
+        help='list of arguments to pass to qemu, separated with ":"',
+    )
+    parser.add_argument("image", help="image file to execute")
+    parser.add_argument(
+        "arguments",
+        nargs=argparse.REMAINDER,
+        default=[],
+        help="optional arguments for the image",
+    )
+    args = parser.parse_args()
+    ret_code = run(args)
+    sys.exit(ret_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/test-support/run_qemu.py
+++ b/test-support/run_qemu.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2023, Arm Limited and affiliates.
+
+import subprocess
+import sys
+
+
+def run_qemu(
+    qemu_command,
+    qemu_machine,
+    qemu_cpu,
+    qemu_extra_params,
+    image,
+    arguments,
+    timeout,
+    working_directory,
+):
+    """Execute the program using QEMU and return the subprocess return code."""
+    qemu_params = ["-M", qemu_machine]
+    if qemu_cpu:
+        qemu_params += ["-cpu", qemu_cpu]
+    qemu_params += qemu_extra_params
+
+    # Setup semihosting with chardev bound to stdio.
+    # This is needed to test semihosting functionality in picolibc.
+    qemu_params += ["-chardev", "stdio,mux=on,id=stdio0"]
+    semihosting_config = ["enable=on", "chardev=stdio0"] + [
+        "arg=" + arg.replace(",", ",,") for arg in arguments
+    ]
+    qemu_params += ["-semihosting-config", ",".join(semihosting_config)]
+
+    # Disable features we don't need and which could slow down the test or
+    # interfere with semihosting.
+    qemu_params += ["-monitor", "none", "-serial", "none", "-nographic"]
+
+    # Load the image to machine's memory and set the PC.
+    # "virt" machine cannot be used with load, as QEMU will try to put
+    # device tree blob at start of RAM conflicting with our code
+    # https://www.qemu.org/docs/master/system/arm/virt.html#hardware-configuration-information-for-bare-metal-programming
+    if qemu_machine == "virt":
+        qemu_params += ["-kernel", image]
+    else:
+        qemu_params += ["-device", f"loader,file={image},cpu-num=0"]
+
+    print(qemu_params)
+    sys.stdout.flush()
+
+    # setting stdin to devnull prevents qemu from fiddling with the echo bit of
+    # the parent terminal
+    result = subprocess.run(
+        [qemu_command] + qemu_params,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=sys.stderr,
+        timeout=timeout,
+        cwd=working_directory,
+        check=False,
+    )
+    sys.stdout.buffer.write(result.stdout)
+    return result.returncode


### PR DESCRIPTION
Switch from manually building picolibc tests to bilding and running them
as part of picolibc build. This enables tests, which were not included
in the manual build.

Several fixes were necessary:

1. Add '-nostdlib' to picolibc c_args
This prevents errors like:
  ld.lld: error: unable to find library -lc
in checks for compiler flags support in picolibs build scripts.
Example of failing check:
  has_link_defsym = meson.get_cross_property('has_link_defsym', cc.has_link_argument('-Wl,--defsym=' + global_prefix + '_start=0'))

2. Make picolibc use compiler_rt in place of libgcc.

3. Change machines used with qemu and adjust memory layouts.
Some of picolibc tests need more memory, than previous machines
provided. Example error:
  ld.lld: error: section '.text' will not fit in region 'flash': overflowed by 34504 bytes

4. Postpone building picolibc tests to the test step. compiler_rt
requires picolibc to be installed. picolibc tests require compiler_rt.
The delayed tests enable picolibc to be installed before compiler_rt is built.