### PR TITLE
baremetal-uart sample: turn off QEMU semihosting.

### DIFF
--- a/samples/src/baremetal-uart/Makefile
+++ b/samples/src/baremetal-uart/Makefile
@@ -26,10 +26,10 @@ hello.elf: *.c
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@
 
 run: hello.hex
-	qemu-system-arm -M microbit -semihosting -nographic -device loader,file=$<
+	qemu-system-arm -M microbit -nographic -device loader,file=$<
 
 debug: hello.hex
-	qemu-system-arm -M microbit -semihosting -nographic -device loader,file=$< -s -S
+	qemu-system-arm -M microbit -nographic -device loader,file=$< -s -S
 
 clean:
 	rm -f *.elf *.hex

--- a/samples/src/baremetal-uart/hello.c
+++ b/samples/src/baremetal-uart/hello.c
@@ -47,11 +47,11 @@ int uart_putc(char ch, FILE* file)
 
 /* Redirect sdtio as per https://github.com/picolibc/picolibc/blob/main/doc/os.md */
 static FILE __stdio = FDEV_SETUP_STREAM(uart_putc, NULL, NULL, _FDEV_SETUP_WRITE);
-FILE *const stdin = &__stdio; 
-__strong_reference(stdin, stdout); 
+FILE *const stdin = &__stdio;
+__strong_reference(stdin, stdout);
 __strong_reference(stdin, stderr);
 
-int main(void) 
+int main(void)
 {
   uart_init();
   printf("Hello World!");

--- a/samples/src/baremetal-uart/make.bat
+++ b/samples/src/baremetal-uart/make.bat
@@ -36,7 +36,7 @@
 @if [%BIN_PATH%]==[] goto :bin_path_empty
 @call :build_fn
 :do_run
-qemu-system-arm.exe -M microbit -semihosting -nographic -device loader,file=hello.hex
+qemu-system-arm.exe -M microbit -nographic -device loader,file=hello.hex
 @exit /B
 
 :clean

--- a/samples/src/cpp-baremetal-semihosting-cfi/hello.cpp
+++ b/samples/src/cpp-baremetal-semihosting-cfi/hello.cpp
@@ -26,7 +26,7 @@ class Bad { // not derived from Base
 int main(void) {
   Base* base_ptr = reinterpret_cast<Good*>(new Bad());
   base_ptr->print_type();
-  
+
   std::cout << "C++ CFI sample" << std::endl;
 
   return 0;


### PR DESCRIPTION
The whole point of this sample is that it runs without semihosting, so it's at least pointless to enable semihosting in the emulator, and perhaps it's also a testing hazard (in that if semihosting were accidentally included in the image, we'd prefer it to fail, so that we notice).