### PR TITLE
Disambiguate variants of tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -783,6 +783,7 @@ function(
         -DLLVM_LIT_ARGS=${LLVM_LIT_ARGS}
         -DLLVM_ENABLE_RUNTIMES=libcxxabi,libcxx,libunwind
         -DRUNTIME_TEST_ARCH_FLAGS=${flags}
+        -DRUNTIME_VARIANT_NAME=${variant}
         ${extra_cmake_options}
         STEP_TARGETS build
         USES_TERMINAL_CONFIGURE TRUE

--- a/test-support/llvm-libc++-picolibc.cfg.in
+++ b/test-support/llvm-libc++-picolibc.cfg.in
@@ -3,6 +3,8 @@
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
+config.name = 'libc++-@RUNTIME_VARIANT_NAME@'
+
 config.substitutions.append(('%{libc-include}', '@CMAKE_INSTALL_PREFIX@/include'))
 config.substitutions.append(('%{libc-lib}', '@CMAKE_INSTALL_PREFIX@/lib'))
 config.substitutions.append(('%{libc-linker-script}', '@LIBC_LINKER_SCRIPT@'))

--- a/test-support/llvm-libc++abi-picolibc.cfg.in
+++ b/test-support/llvm-libc++abi-picolibc.cfg.in
@@ -3,6 +3,8 @@
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
+config.name = 'libc++abi-@RUNTIME_VARIANT_NAME@'
+
 config.substitutions.append(('%{libc-include}', '@CMAKE_INSTALL_PREFIX@/include'))
 config.substitutions.append(('%{libc-lib}', '@CMAKE_INSTALL_PREFIX@/lib'))
 config.substitutions.append(('%{libc-linker-script}', '@LIBC_LINKER_SCRIPT@'))

--- a/test-support/llvm-libunwind-picolibc.cfg.in
+++ b/test-support/llvm-libunwind-picolibc.cfg.in
@@ -4,6 +4,8 @@
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
+config.name = 'libunwind-@RUNTIME_VARIANT_NAME@'
+
 config.substitutions.append(('%{libc-include}', '@CMAKE_INSTALL_PREFIX@/include'))
 config.substitutions.append(('%{libc-lib}', '@CMAKE_INSTALL_PREFIX@/lib'))
 config.substitutions.append(('%{libc-linker-script}', '@LIBC_LINKER_SCRIPT@'))


### PR DESCRIPTION
Previously there would be multiple tests with names like llvm-libc++-picolibc-cfg-in.std/numerics/c_math.cmath.pass.cpp

Now the names will be, for example:
libc++-aarch64.std/numerics/c_math.cmath.pass.cpp
libc++-armv6m_soft_nofp.std/numerics/c_math.cmath.pass.cpp