### PR TITLE
Remove use of *.cfg files from samples.

### DIFF
--- a/samples/Makefile.conf
+++ b/samples/Makefile.conf
@@ -19,7 +19,7 @@ ifndef BIN_PATH
 BIN_PATH=../../../bin
 endif
 
-MB_TARGET=--target=armv6m-none-eabi -march=armv6m -mfloat-abi=soft 
+MICROBIT_TARGET=--target=armv6m-none-eabi -march=armv6m -mfloat-abi=soft 
 AARCH64_TARGET=--target=aarch64-none-elf -march=armv8-a
 
 CRT=-lcrt0

--- a/samples/Makefile.conf
+++ b/samples/Makefile.conf
@@ -20,7 +20,7 @@ BIN_PATH=../../../bin
 endif
 
 MICROBIT_TARGET=--target=armv6m-none-eabi -march=armv6m -mfloat-abi=soft 
-AARCH64_TARGET=--target=aarch64-none-elf -march=armv8-a
+AARCH64_TARGET=--target=aarch64-none-elf
 
 CRT=-lcrt0
 CRT_SEMIHOST=-lcrt0-semihost -lsemihost

--- a/samples/Makefile.conf
+++ b/samples/Makefile.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, Arm Limited and affiliates.
+# Copyright (c) 2020-2023, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,3 +18,11 @@
 ifndef BIN_PATH
 BIN_PATH=../../../bin
 endif
+
+MB_TARGET=--target=armv6m-none-eabi -march=armv6m -mfloat-abi=soft 
+AARCH64_TARGET=--target=aarch64-none-elf -march=armv8-a
+
+CRT=-lcrt0
+CRT_SEMIHOST=-lcrt0-semihost -lsemihost
+
+CPP_FLAGS=-fno-exceptions -fno-rtti

--- a/samples/src/baremetal-semihosting-aarch64/Makefile
+++ b/samples/src/baremetal-semihosting-aarch64/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, Arm Limited and affiliates.
+# Copyright (c) 2020-2023, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	$(BIN_PATH)/clang --config aarch64_semihost.cfg -g -T ../../ldscripts/raspi3b.ld -o hello.elf $^
+	$(BIN_PATH)/clang $(AARCH64_TARGET) $(CRT_SEMIHOST) -g -T ../../ldscripts/raspi3b.ld -o hello.elf $^
 
 %.img: %.elf
 	$(BIN_PATH)/llvm-objcopy -O binary $< $@

--- a/samples/src/baremetal-semihosting-aarch64/make.bat
+++ b/samples/src/baremetal-semihosting-aarch64/make.bat
@@ -49,6 +49,6 @@ if exist hello.img del /q hello.img
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang.exe --target=aarch64-none-elf -march=armv8-a -lcrt0-semihost -lsemihost -g -T ..\..\ldscripts\raspi3b.ld -o hello.elf hello.c
+%BIN_PATH%\clang.exe --target=aarch64-none-elf -lcrt0-semihost -lsemihost -g -T ..\..\ldscripts\raspi3b.ld -o hello.elf hello.c
 %BIN_PATH%\llvm-objcopy.exe -O binary hello.elf hello.img
 @exit /B

--- a/samples/src/baremetal-semihosting-aarch64/make.bat
+++ b/samples/src/baremetal-semihosting-aarch64/make.bat
@@ -49,6 +49,6 @@ if exist hello.img del /q hello.img
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang.exe --config aarch64_semihost.cfg -g -T ..\..\ldscripts\raspi3b.ld -o hello.elf hello.c
+%BIN_PATH%\clang.exe --target=aarch64-none-elf -march=armv8-a -lcrt0-semihost -lsemihost -g -T ..\..\ldscripts\raspi3b.ld -o hello.elf hello.c
 %BIN_PATH%\llvm-objcopy.exe -O binary hello.elf hello.img
 @exit /B

--- a/samples/src/baremetal-semihosting/Makefile
+++ b/samples/src/baremetal-semihosting/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, Arm Limited and affiliates.
+# Copyright (c) 2020-2023, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	$(BIN_PATH)/clang --config armv6m_soft_nofp_semihost.cfg -g -T ../../ldscripts/microbit.ld -o hello.elf $^
+	$(BIN_PATH)/clang $(MB_TARGET) $(CRT_SEMIHOST) -g -T ../../ldscripts/microbit.ld -o hello.elf $^
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/baremetal-semihosting/Makefile
+++ b/samples/src/baremetal-semihosting/Makefile
@@ -20,7 +20,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	$(BIN_PATH)/clang $(MB_TARGET) $(CRT_SEMIHOST) -g -T ../../ldscripts/microbit.ld -o hello.elf $^
+	$(BIN_PATH)/clang $(MICROBIT_TARGET) $(CRT_SEMIHOST) -g -T ../../ldscripts/microbit.ld -o hello.elf $^
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/baremetal-semihosting/make.bat
+++ b/samples/src/baremetal-semihosting/make.bat
@@ -1,4 +1,4 @@
-@REM Copyright (c) 2021, Arm Limited and affiliates.
+@REM Copyright (c) 2021-2023, Arm Limited and affiliates.
 @REM SPDX-License-Identifier: Apache-2.0
 @REM
 @REM Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,6 +49,6 @@ if exist hello.hex del /q hello.hex
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang.exe --config armv6m_soft_nofp_semihost.cfg -g -T ..\..\ldscripts\microbit.ld -o hello.elf hello.c
+%BIN_PATH%\clang.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -lcrt0-semihost -lsemihost -g -T ..\..\ldscripts\microbit.ld -o hello.elf hello.c
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B

--- a/samples/src/baremetal-uart/Makefile
+++ b/samples/src/baremetal-uart/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, Arm Limited and affiliates.
+# Copyright (c) 2020-2023, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	$(BIN_PATH)/clang --config armv6m_soft_nofp.cfg -g -T ../../ldscripts/microbit.ld -o hello.elf $^
+	$(BIN_PATH)/clang $(MB_TARGET) $(CRT) -g -T ../../ldscripts/microbit.ld -o hello.elf $^
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/baremetal-uart/Makefile
+++ b/samples/src/baremetal-uart/Makefile
@@ -20,7 +20,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	$(BIN_PATH)/clang $(MB_TARGET) $(CRT) -g -T ../../ldscripts/microbit.ld -o hello.elf $^
+	$(BIN_PATH)/clang $(MICROBIT_TARGET) $(CRT) -g -T ../../ldscripts/microbit.ld -o hello.elf $^
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/baremetal-uart/make.bat
+++ b/samples/src/baremetal-uart/make.bat
@@ -1,4 +1,4 @@
-@REM Copyright (c) 2021, Arm Limited and affiliates.
+@REM Copyright (c) 2021-2023, Arm Limited and affiliates.
 @REM SPDX-License-Identifier: Apache-2.0
 @REM
 @REM Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,6 +49,6 @@ if exist hello.hex del /q hello.hex
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang.exe --config armv6m_soft_nofp.cfg -g -T ..\..\ldscripts\microbit.ld -o hello.elf hello.c
+%BIN_PATH%\clang.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -lcrt0 -g -T ..\..\ldscripts\microbit.ld -o hello.elf hello.c
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B

--- a/samples/src/cpp-baremetal-semihosting-cfi/Makefile
+++ b/samples/src/cpp-baremetal-semihosting-cfi/Makefile
@@ -21,12 +21,12 @@ build: hello.elf
 build-no-cfi: hello-no-cfi.elf
 
 hello.elf: *.cpp
-	$(BIN_PATH)/clang++ --config armv6m_soft_nofp_semihost.cfg -flto -fsanitize=cfi -fvisibility=hidden -fno-sanitize-ignorelist -g -c $^
-	$(BIN_PATH)/clang++ --config armv6m_soft_nofp_semihost.cfg -flto -T ../../ldscripts/microbit.ld -g -o hello.elf hello.o
+	$(BIN_PATH)/clang++ $(MB_TARGET) $(CPP_FLAGS) -flto -fsanitize=cfi -fvisibility=hidden -fno-sanitize-ignorelist -g -c $^
+	$(BIN_PATH)/clang++ $(MB_TARGET) $(CRT_SEMIHOST) $(CPP_FLAGS) -flto -T ../../ldscripts/microbit.ld -g -o hello.elf hello.o
 
 hello-no-cfi.elf: *.cpp
-	$(BIN_PATH)/clang++ --config armv6m_soft_nofp_semihost.cfg -flto -g -c $^
-	$(BIN_PATH)/clang++ --config armv6m_soft_nofp_semihost.cfg -flto -T ../../ldscripts/microbit.ld -g -o hello.elf hello.o
+	$(BIN_PATH)/clang++ $(MB_TARGET) $(CPP_FLAGS) -flto -g -c $^
+	$(BIN_PATH)/clang++ $(MB_TARGET) $(CRT_SEMIHOST) $(CPP_FLAGS) -flto -T ../../ldscripts/microbit.ld -g -o hello.elf hello.o
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/cpp-baremetal-semihosting-cfi/Makefile
+++ b/samples/src/cpp-baremetal-semihosting-cfi/Makefile
@@ -21,12 +21,12 @@ build: hello.elf
 build-no-cfi: hello-no-cfi.elf
 
 hello.elf: *.cpp
-	$(BIN_PATH)/clang++ $(MB_TARGET) $(CPP_FLAGS) -flto -fsanitize=cfi -fvisibility=hidden -fno-sanitize-ignorelist -g -c $^
-	$(BIN_PATH)/clang++ $(MB_TARGET) $(CRT_SEMIHOST) $(CPP_FLAGS) -flto -T ../../ldscripts/microbit.ld -g -o hello.elf hello.o
+	$(BIN_PATH)/clang++ $(MICROBIT_TARGET) $(CPP_FLAGS) -flto -fsanitize=cfi -fvisibility=hidden -fno-sanitize-ignorelist -g -c $^
+	$(BIN_PATH)/clang++ $(MICROBIT_TARGET) $(CRT_SEMIHOST) $(CPP_FLAGS) -flto -T ../../ldscripts/microbit.ld -g -o hello.elf hello.o
 
 hello-no-cfi.elf: *.cpp
-	$(BIN_PATH)/clang++ $(MB_TARGET) $(CPP_FLAGS) -flto -g -c $^
-	$(BIN_PATH)/clang++ $(MB_TARGET) $(CRT_SEMIHOST) $(CPP_FLAGS) -flto -T ../../ldscripts/microbit.ld -g -o hello.elf hello.o
+	$(BIN_PATH)/clang++ $(MICROBIT_TARGET) $(CPP_FLAGS) -flto -g -c $^
+	$(BIN_PATH)/clang++ $(MICROBIT_TARGET) $(CRT_SEMIHOST) $(CPP_FLAGS) -flto -T ../../ldscripts/microbit.ld -g -o hello.elf hello.o
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/cpp-baremetal-semihosting-cfi/make.bat
+++ b/samples/src/cpp-baremetal-semihosting-cfi/make.bat
@@ -56,13 +56,13 @@ if exist hello.hex del /q hello.hex
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang++.exe --config armv6m_soft_nofp_semihost.cfg -flto -fsanitize=cfi -fvisibility=hidden -fno-sanitize-ignorelist -g -c hello.cpp
-%BIN_PATH%\clang++.exe --config armv6m_soft_nofp_semihost.cfg -flto -T ..\..\ldscripts\microbit.ld -g -o hello.elf hello.o
+%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -fno-exceptions -fno-rtti -flto -fsanitize=cfi -fvisibility=hidden -fno-sanitize-ignorelist -g -c hello.cpp
+%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti -flto -T ..\..\ldscripts\microbit.ld -g -o hello.elf hello.o
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B
 
 :build_no_cfi_fn
-%BIN_PATH%\clang++.exe --config armv6m_soft_nofp_semihost.cfg -flto -g -c hello.cpp
-%BIN_PATH%\clang++.exe --config armv6m_soft_nofp_semihost.cfg -flto -T ..\..\ldscripts\microbit.ld -g -o hello.elf hello.o
+%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -fno-exceptions -fno-rtti -flto -g -c hello.cpp
+%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti -flto -T ..\..\ldscripts\microbit.ld -g -o hello.elf hello.o
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B

--- a/samples/src/cpp-baremetal-semihosting-prof/Makefile
+++ b/samples/src/cpp-baremetal-semihosting-prof/Makefile
@@ -20,8 +20,8 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.cpp
-	$(BIN_PATH)/clang --config armv6m_soft_nofp_semihost.cfg -g -c proflib.c
-	$(BIN_PATH)/clang++ --config armv6m_soft_nofp_semihost.cfg -g -T ../../ldscripts/microbit.ld -fprofile-instr-generate -fcoverage-mapping -o hello.elf hello.cpp proflib.o
+	$(BIN_PATH)/clang $(MB_TARGET) -g -c proflib.c
+	$(BIN_PATH)/clang++ $(MB_TARGET) $(CRT_SEMIHOST) $(CPP_FLAGS) -g -T ../../ldscripts/microbit.ld -fprofile-instr-generate -fcoverage-mapping -o hello.elf hello.cpp proflib.o
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/cpp-baremetal-semihosting-prof/Makefile
+++ b/samples/src/cpp-baremetal-semihosting-prof/Makefile
@@ -20,8 +20,8 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.cpp
-	$(BIN_PATH)/clang $(MB_TARGET) -g -c proflib.c
-	$(BIN_PATH)/clang++ $(MB_TARGET) $(CRT_SEMIHOST) $(CPP_FLAGS) -g -T ../../ldscripts/microbit.ld -fprofile-instr-generate -fcoverage-mapping -o hello.elf hello.cpp proflib.o
+	$(BIN_PATH)/clang $(MICROBIT_TARGET) -g -c proflib.c
+	$(BIN_PATH)/clang++ $(MICROBIT_TARGET) $(CRT_SEMIHOST) $(CPP_FLAGS) -g -T ../../ldscripts/microbit.ld -fprofile-instr-generate -fcoverage-mapping -o hello.elf hello.cpp proflib.o
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/cpp-baremetal-semihosting-prof/make.bat
+++ b/samples/src/cpp-baremetal-semihosting-prof/make.bat
@@ -58,7 +58,7 @@ if exist proflib.o del /q proflib.o
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang.exe --config armv6m_soft_nofp_semihost.cfg -g -c proflib.c
-%BIN_PATH%\clang++.exe --config armv6m_soft_nofp_semihost.cfg -g -T ..\..\ldscripts\microbit.ld -fprofile-instr-generate -fcoverage-mapping -o hello.elf hello.cpp proflib.o
+%BIN_PATH%\clang.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -g -c proflib.c
+%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti -g -T ..\..\ldscripts\microbit.ld -fprofile-instr-generate -fcoverage-mapping -o hello.elf hello.cpp proflib.o
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B

--- a/samples/src/cpp-baremetal-semihosting-ubsan/Makefile
+++ b/samples/src/cpp-baremetal-semihosting-ubsan/Makefile
@@ -21,10 +21,10 @@ build: hello.elf
 build-trap: hello-trap.elf
 
 hello.elf: *.cpp		# build with minimal runtime mode
-	$(BIN_PATH)/clang++ $(MB_TARGET) $(CRT_SEMIHOST) $(CPP_FLAGS) --std=c++17 -fsanitize=undefined -fsanitize-minimal-runtime -g -T ../../ldscripts/microbit.ld -o hello.elf $^
+	$(BIN_PATH)/clang++ $(MICROBIT_TARGET) $(CRT_SEMIHOST) $(CPP_FLAGS) --std=c++17 -fsanitize=undefined -fsanitize-minimal-runtime -g -T ../../ldscripts/microbit.ld -o hello.elf $^
 
 hello-trap.elf: *.cpp 	# build with trap mode
-	$(BIN_PATH)/clang++ $(MB_TARGET) $(CRT_SEMIHOST) $(CPP_FLAGS) --std=c++17 -fsanitize=undefined -fsanitize-trap=all -g -T ../../ldscripts/microbit.ld -o hello.elf $^
+	$(BIN_PATH)/clang++ $(MICROBIT_TARGET) $(CRT_SEMIHOST) $(CPP_FLAGS) --std=c++17 -fsanitize=undefined -fsanitize-trap=all -g -T ../../ldscripts/microbit.ld -o hello.elf $^
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/cpp-baremetal-semihosting-ubsan/Makefile
+++ b/samples/src/cpp-baremetal-semihosting-ubsan/Makefile
@@ -21,10 +21,10 @@ build: hello.elf
 build-trap: hello-trap.elf
 
 hello.elf: *.cpp		# build with minimal runtime mode
-	$(BIN_PATH)/clang++ --config armv6m_soft_nofp_semihost.cfg --std=c++17 -fsanitize=undefined -fsanitize-minimal-runtime -g -T ../../ldscripts/microbit.ld -o hello.elf $^
+	$(BIN_PATH)/clang++ $(MB_TARGET) $(CRT_SEMIHOST) $(CPP_FLAGS) --std=c++17 -fsanitize=undefined -fsanitize-minimal-runtime -g -T ../../ldscripts/microbit.ld -o hello.elf $^
 
 hello-trap.elf: *.cpp 	# build with trap mode
-	$(BIN_PATH)/clang++ --config armv6m_soft_nofp_semihost.cfg --std=c++17 -fsanitize=undefined -fsanitize-trap=all -g -T ../../ldscripts/microbit.ld -o hello.elf $^
+	$(BIN_PATH)/clang++ $(MB_TARGET) $(CRT_SEMIHOST) $(CPP_FLAGS) --std=c++17 -fsanitize=undefined -fsanitize-trap=all -g -T ../../ldscripts/microbit.ld -o hello.elf $^
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/cpp-baremetal-semihosting-ubsan/make.bat
+++ b/samples/src/cpp-baremetal-semihosting-ubsan/make.bat
@@ -55,11 +55,11 @@ if exist hello.hex del /q hello.hex
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang++.exe --config armv6m_soft_nofp_semihost.cfg --std=c++17 -fsanitize=undefined -fsanitize-minimal-runtime -g -T ../../ldscripts/microbit.ld -o hello.elf *.cpp
+%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti --std=c++17 -fsanitize=undefined -fsanitize-minimal-runtime -g -T ../../ldscripts/microbit.ld -o hello.elf *.cpp
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B
 
 :build_trap_fn
-%BIN_PATH%\clang++.exe --config armv6m_soft_nofp_semihost.cfg --std=c++17 -fsanitize=undefined -fsanitize-trap=all -g -T ../../ldscripts/microbit.ld -o hello.elf *.cpp
+%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti --std=c++17 -fsanitize=undefined -fsanitize-trap=all -g -T ../../ldscripts/microbit.ld -o hello.elf *.cpp
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B

--- a/samples/src/cpp-baremetal-semihosting/Makefile
+++ b/samples/src/cpp-baremetal-semihosting/Makefile
@@ -20,7 +20,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.cpp
-	$(BIN_PATH)/clang++ $(MB_TARGET) $(CRT_SEMIHOST) $(CPP_FLAGS) -g -T ../../ldscripts/microbit.ld -o hello.elf $^
+	$(BIN_PATH)/clang++ $(MICROBIT_TARGET) $(CRT_SEMIHOST) $(CPP_FLAGS) -g -T ../../ldscripts/microbit.ld -o hello.elf $^
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/cpp-baremetal-semihosting/Makefile
+++ b/samples/src/cpp-baremetal-semihosting/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, Arm Limited and affiliates.
+# Copyright (c) 2021-2023, Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.cpp
-	$(BIN_PATH)/clang++ --config armv6m_soft_nofp_semihost.cfg -g -T ../../ldscripts/microbit.ld -o hello.elf $^
+	$(BIN_PATH)/clang++ $(MB_TARGET) $(CRT_SEMIHOST) $(CPP_FLAGS) -g -T ../../ldscripts/microbit.ld -o hello.elf $^
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/cpp-baremetal-semihosting/make.bat
+++ b/samples/src/cpp-baremetal-semihosting/make.bat
@@ -1,4 +1,4 @@
-@REM Copyright (c) 2021, Arm Limited and affiliates.
+@REM Copyright (c) 2021-2023, Arm Limited and affiliates.
 @REM SPDX-License-Identifier: Apache-2.0
 @REM
 @REM Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,6 +49,6 @@ if exist hello.hex del /q hello.hex
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang++.exe --config armv6m_soft_nofp_semihost.cfg -g -T ..\..\ldscripts\microbit.ld -o hello.elf hello.cpp
+%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti -g -T ..\..\ldscripts\microbit.ld -o hello.elf hello.cpp
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B


### PR DESCRIPTION
Rely on the automatic multilib selection instead.