### PR TITLE
Use LLVM_USE_LINKER instead of LLVM_ENABLE_LLD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,7 @@ endif()
 # If lld is available then use it by default.
 find_program(LLD_EXECUTABLE lld)
 if(LLD_EXECUTABLE)
-    set(LLVM_ENABLE_LLD ON CACHE BOOL "")
+    set(LLVM_USE_LINKER lld CACHE STRING "")
 endif()
 
 # A lot of files get installed which makes the install messages too


### PR DESCRIPTION
This makes it easier to set LLVM_USE_LINKER to a linker other than lld. Without this change, to use a linker other than lld cmake would need to be run with -DLLVM_ENABLE_LLD=OFF -DLLVM_USE_LINKER=...