### PR TITLE
[picolibc] minor fixes for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,11 +500,15 @@ function(
             -Dtests-enable-stack-protector=false
             --prefix <INSTALL_DIR>
             --cross-file <BINARY_DIR>/meson-cross-build.txt
-            ${picolibc_SOURCE_DIR}
+            <SOURCE_DIR>
         BUILD_COMMAND ${MESON_EXECUTABLE} configure -Dtests=false
         COMMAND ${MESON_EXECUTABLE} compile
         INSTALL_COMMAND ${MESON_EXECUTABLE} install ${MESON_INSTALL_QUIET}
         TEST_COMMAND ${MESON_EXECUTABLE} configure -Dtests=true
+        # meson<0.64.0 does not properly apply new configuration after
+        # "meson configure -Dtests=false"
+        # use "meson setup --reconfigure" as a workaround
+        COMMAND ${MESON_EXECUTABLE} setup . <SOURCE_DIR> -Dtests=true --reconfigure
         COMMAND ${MESON_EXECUTABLE} test
         COMMAND ${MESON_EXECUTABLE} configure -Dtests=false
         USES_TERMINAL_CONFIGURE FALSE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,15 +632,14 @@ Hard-float library with target triple \"${target_triple}\" must end \"-eabihf\""
         # Always run the build command so that incremental builds are correct.
         BUILD_ALWAYS TRUE
         CONFIGURE_HANDLED_BY_BUILD TRUE
-    )
-    ExternalProject_Get_Property(compiler_rt_${variant} INSTALL_DIR)
-    # Copy compiler-rt lib directory, moving libraries out of their
-    # target-specific subdirectory.
-    add_custom_command(
-        TARGET compiler_rt_${variant}
-        POST_BUILD
-        COMMAND "${CMAKE_COMMAND}" -E copy_directory
-            ${INSTALL_DIR}/lib/${target_triple} "${LLVM_BINARY_DIR}/${directory}/lib"
+        INSTALL_COMMAND ${CMAKE_COMMAND} --install .
+        # Copy compiler-rt lib directory, moving libraries out of their
+        # target-specific subdirectory.
+        COMMAND
+            ${CMAKE_COMMAND}
+            -E copy_directory
+            <INSTALL_DIR>/lib/${target_triple}
+            "${LLVM_BINARY_DIR}/${directory}/lib"
     )
 
     add_dependencies(


### PR DESCRIPTION
Fix dependency problem between picolibc tests and compiler-rt
The compiler libraries are now copied as part of install step, so they
are available for picolibc tests.

 Fix for tests not being run with old meson