### PR TITLE
Restore trailing whitespaces in patch

### DIFF
--- a/patches/llvm-project.patch
+++ b/patches/llvm-project.patch
@@ -17,14 +17,14 @@ index 556854023dff..b1a87faebfe0 100644
 +// RUN: %clang -fsyntax-only  -ffreestanding              --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c89 --sysroot=%S/Inputs -xc %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c99 --sysroot=%S/Inputs -xc %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c11 --sysroot=%S/Inputs -xc %s
-
+ 
 -// RUN: %clang -fsyntax-only -ffreestanding               --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c89 -xc %s
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c99 -xc %s
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c11 -xc %s
 +// RUN: %clang -fsyntax-only -ffreestanding               --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c89 --sysroot=%S/Inputs -xc %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c99 --sysroot=%S/Inputs -xc %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c11 --sysroot=%S/Inputs -xc %s
-
+ 
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c++98 -xc++ %s
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c++11 -xc++ %s
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c++14 -xc++ %s
@@ -33,7 +33,7 @@ index 556854023dff..b1a87faebfe0 100644
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c++11 --sysroot=%S/Inputs -xc++ %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c++14 --sysroot=%S/Inputs -xc++ %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c++17 --sysroot=%S/Inputs -xc++ %s
-
+ 
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c++98 -xc++ %s
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c++11 -xc++ %s
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c++14 -xc++ %s
@@ -42,9 +42,9 @@ index 556854023dff..b1a87faebfe0 100644
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c++11 --sysroot=%S/Inputs -xc++ %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c++14 --sysroot=%S/Inputs -xc++ %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c++17 --sysroot=%S/Inputs -xc++ %s
-
+ 
  // REQUIRES: aarch64-registered-target || arm-registered-target
-
+ 
  #include <arm_fp16.h>
 diff --git a/clang/test/Headers/arm-neon-header.c b/clang/test/Headers/arm-neon-header.c
 index 703424f17bde..7e98d03dfc19 100644
@@ -54,21 +54,21 @@ index 703424f17bde..7e98d03dfc19 100644
  // RUN: %clang_cc1 -triple thumbv7-apple-darwin10 -target-cpu cortex-a8 -fsyntax-only -Wvector-conversions -ffreestanding %s
  // RUN: %clang_cc1 -triple thumbv7-apple-darwin10 -target-cpu cortex-a8 -fsyntax-only -flax-vector-conversions=none -ffreestanding %s
  // RUN: %clang_cc1 -x c++ -triple thumbv7-apple-darwin10 -target-cpu cortex-a8 -fsyntax-only -Wvector-conversions -ffreestanding %s
-
+ 
 -// RUN: %clang -fsyntax-only               -ffreestanding --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c89 -xc %s
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c99 -xc %s
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c11 -xc %s
 +// RUN: %clang -fsyntax-only               -ffreestanding --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c89 --sysroot=%S/Inputs -xc %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c99 --sysroot=%S/Inputs -xc %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c11 --sysroot=%S/Inputs -xc %s
-
+ 
 -// RUN: %clang -fsyntax-only               -ffreestanding --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c89 -xc %s
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c99 -xc %s
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c11 -xc %s
 +// RUN: %clang -fsyntax-only               -ffreestanding --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c89 -xc --sysroot=%S/Inputs %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c99 -xc --sysroot=%S/Inputs %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c11 -xc --sysroot=%S/Inputs %s
-
+ 
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c++98 -xc++ %s
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c++11 -xc++ %s
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c++14 -xc++ %s
@@ -77,7 +77,7 @@ index 703424f17bde..7e98d03dfc19 100644
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c++11 -xc++ --sysroot=%S/Inputs %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c++14 -xc++ --sysroot=%S/Inputs %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64-none-elf -march=armv8.2-a+fp16 -std=c++17 -xc++ --sysroot=%S/Inputs %s
-
+ 
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c++98 -xc++ %s
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c++11 -xc++ %s
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c++14 -xc++ %s
@@ -86,14 +86,14 @@ index 703424f17bde..7e98d03dfc19 100644
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c++11 -xc++ --sysroot=%S/Inputs %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c++14 -xc++ --sysroot=%S/Inputs %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding -nostdinc++ --target=aarch64_be-none-elf -march=armv8.2-a+fp16 -std=c++17 -xc++ --sysroot=%S/Inputs %s
-
+ 
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=aarch64-none-elf -march=armv8.2-a+fp16fml+crypto+dotprod -std=c11 -xc -flax-vector-conversions=none %s
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=aarch64_be-none-elf -march=armv8.2-a+fp16fml+crypto+dotprod -std=c11 -xc -flax-vector-conversions=none %s
 -// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=arm64-linux-gnu -arch +neon -std=c11 -xc -flax-vector-conversions=none %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=aarch64-none-elf -march=armv8.2-a+fp16fml+crypto+dotprod -std=c11 -xc --sysroot=%S/Inputs -flax-vector-conversions=none %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=aarch64_be-none-elf -march=armv8.2-a+fp16fml+crypto+dotprod -std=c11 -xc --sysroot=%S/Inputs -flax-vector-conversions=none %s
 +// RUN: %clang -fsyntax-only -Wall -Werror -ffreestanding --target=arm64-linux-gnu -arch +neon -std=c11 -xc --sysroot=%S/Inputs -flax-vector-conversions=none %s
-
+ 
  // REQUIRES: aarch64-registered-target || arm-registered-target
-
+ 
  #include <arm_neon.h>


### PR DESCRIPTION
Without these the patch is detected as corrupted and the Windows build fails.