### PR TITLE
Provide Armv7-M softfp library variant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1082,6 +1082,21 @@ add_library_variant(
     STACK_SIZE 4K
 )
 add_library_variant(
+    armv7m
+    SUFFIX soft_fpv4_sp_d16
+    COMPILE_FLAGS "-mfloat-abi=softfp -march=armv7m -mfpu=fpv4-sp-d16"
+    MULTILIB_FLAGS "--target=thumbv7m-none-unknown-eabi -mfpu=fpv4-sp-d16"
+    QEMU_MACHINE "mps2-an386"
+    QEMU_CPU "cortex-m4"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x00001000
+    FLASH_SIZE 0x3ff000
+    RAM_ADDRESS 0x20000000
+    RAM_SIZE 2M
+    STACK_SIZE 4K
+)
+add_library_variant(
     armv7em
     SUFFIX soft_nofp
     COMPILE_FLAGS "-mfloat-abi=soft -march=armv7em -mfpu=none"

--- a/cmake/multilib.yaml.in
+++ b/cmake/multilib.yaml.in
@@ -111,3 +111,8 @@ Mappings:
 - Match: -march=thumbv8\.[1-9]m\.main.*\+mve\.fp.*\+fp16.*\+lob.*
   Flags:
   - -march=thumbv8.1m.main+fp16+lob+mve.fp
+
+# -mfloat-abi settings
+- Match: -mfloat-abi=softfp
+  Flags:
+  - -mfpu=fpv4-sp-d16

--- a/test-support/picolibc-test-wrapper.py
+++ b/test-support/picolibc-test-wrapper.py
@@ -19,6 +19,7 @@ disabled_tests = [
     "picolibc_aarch64-build/test/math_errhandling",
     "picolibc_aarch64-build/test/test-fma",
     "picolibc_armv7em_hard_fpv4_sp_d16-build/test/math_errhandling",
+    "picolibc_armv7m_soft_fpv4_sp_d16-build/test/math_errhandling",
     "picolibc_armv8.1m.main_hard_fp-build/test/math_errhandling",
     "picolibc_armv8.1m.main_hard_nofp_mve-build/test/fenv",
     "picolibc_armv8.1m.main_hard_nofp_mve-build/test/math_errhandling",


### PR DESCRIPTION
The optional FP Unit for ArmV7-M could be one of FPv4-SP and FPv5, FPv4-SP being the lowest common denominator.
So provide the armv7m_soft_fpv4_sp_d16 variant for -mfpu=fpv4-sp-d16.

The math_errhandling test fails as it does for the armv7em_hard_fpv4_sp_d16 variant. So disable it for now.

Make the new armv7m_soft_fpv4_sp_d16 variant the default when -mfloat-abi=softfp is specified.