### PR TITLE
Enable more Picolibc tests on aarch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,8 +502,10 @@ function(
 
     if(target_triple MATCHES "^aarch64")
         set(cpu_family aarch64)
+        set(enable_long_double_test false)
     else()
         set(cpu_family arm)
+        set(enable_long_double_test true)
     endif()
 
     ExternalProject_Add(
@@ -520,6 +522,7 @@ function(
             -Dspecsdir=none
             -Dmultilib=false
             -Dtests-enable-stack-protector=false
+            -Dtest-long-double=${enable_long_double_test}
             --prefix <INSTALL_DIR>
             --cross-file <BINARY_DIR>/meson-cross-build.txt
             <SOURCE_DIR>

--- a/test-support/picolibc-test-wrapper.py
+++ b/test-support/picolibc-test-wrapper.py
@@ -16,14 +16,12 @@ disabled_tests = [
     # compiler-rt does not properly set floating point exceptions for
     # computations on types implemented in software
     # https://github.com/picolibc/picolibc/pull/500
-    "picolibc_aarch64-build/test/math_errhandling",
     "picolibc_armv7m_soft_fpv4_sp_d16-build/test/math_errhandling",
     "picolibc_armv7em_hard_fpv4_sp_d16-build/test/math_errhandling",
     "picolibc_armv8.1m.main_hard_fp_nomve-build/test/math_errhandling",
+    "picolibc_armv8.1m.main_hard_nofp_mve-build/test/fenv",
     "picolibc_armv8.1m.main_hard_nofp_mve-build/test/math_errhandling",
     "picolibc_armv8m.main_hard_fp-build/test/math_errhandling",
-
-    "picolibc_aarch64-build/test/test-fma"
 ]
 
 


### PR DESCRIPTION
Disable long double tests for aarch64
so more tests execute without failure.