### PR TITLE
be more sophisticated about deriving configs from macOS variables 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,23 +323,37 @@ set(CPACK_COMPONENT_INCLUDE_TOPLEVEL_DIRECTORY TRUE)
 # Compress package in parallel.
 set(CPACK_THREADS 0 CACHE STRING "")
 
+# set processor_name
+string(TOLOWER ${CMAKE_SYSTEM_PROCESSOR} processor_name)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    # If we're compiling on OSX we need to understand what targets we're
+    #  building for.
+    string(FIND "${CMAKE_OSX_ARCHITECTURES}" "x86_64" x86_result)
+    string(FIND "${CMAKE_OSX_ARCHITECTURES}" "arm64" arm64_result)
 
-if(CMAKE_OSX_ARCHITECTURES)
-    # For universal binaries don't include architecture in the package name.
-    set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}")
+    if((NOT ${x86_result} EQUAL -1) AND (NOT ${arm64_result} EQUAL -1))
+        set(processor_name "universal")
+    elseif(NOT ${x86_result} EQUAL -1)
+        set(processor_name "x86_64")
+    elseif(NOT ${arm64_result} EQUAL -1)
+        set(processor_name "arm64")
+    # CMAKE_OSX_ARCHITECTURES wasn't set or malformed
+    # if it was malformed, we'll catch that later in the process
+    # otherwise processor_name is already the system processor name
+    endif()
 else()
-    string(TOLOWER ${CMAKE_SYSTEM_PROCESSOR} processor_name)
     string(REGEX MATCH "amd64|x64|x86" x86_match ${processor_name})
     if(x86_match)
         set(processor_name "x86_64")
     else()
         set(processor_name "AArch64")
     endif()
-    if(LLVM_TOOLCHAIN_CROSS_BUILD_MINGW)
-        set(CPACK_SYSTEM_NAME "Windows-${processor_name}")
-    else()
-        set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}-${processor_name}")
-    endif()
+endif()
+
+if(LLVM_TOOLCHAIN_CROSS_BUILD_MINGW)
+    set(CPACK_SYSTEM_NAME "Windows-${processor_name}")
+else()
+    set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}-${processor_name}")
 endif()
 
 add_subdirectory(
@@ -1372,7 +1386,7 @@ endif()
 if(LLVM_TOOLCHAIN_CROSS_BUILD_MINGW OR WIN32)
     set(cpack_generator ZIP)
     set(package_filename_extension ".zip")
-elseif(CMAKE_OSX_ARCHITECTURES)
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(cpack_generator DragNDrop)
     set(package_filename_extension ".dmg")
 else()


### PR DESCRIPTION
edit:
 current commit message:
```
this patch is fixing two issues:

Currently when figuring out the toolchain package name, we make some wrong
assumptions like the presence of CMAKE_OSX_ARCHITECTURES means a unified
build. Also when CMAKE_OSX_ARCHITECTURES is not present and we are building on
macOS silicon, the package name will be `AArch64`.

Should do some parsing of the CMAKE_OSX_ARCHITECTURES and look at the
CMAKE_SYSTEM_PROCESSOR var, to deduce the right system name.

Basically when CMAKE_OSX_ARCHITECTURES is set and non-empty, this overrides the
system architecture, and we need to figure out if we do a unified build (both
x86_64 and arm64 are specified), or either.

If it's a unified build, use `unified` to make this clear, instead of the
current behaviour of omitting the arch string.

Another issue is that we use the presence of the CMAKE_OSX_ARCHITECTURES string
to infer if we should build a `.dmg` or not. Seeing the complexity around
CMAKE_OSX_ARCHITECTURES, it's better to just use CMAKE_SYSTEM_NAME, which would
always point to `Darwin`"
```
