### PR TITLE
Revert "Fix the profiling sample runtime"

### DIFF
--- a/samples/src/cpp-baremetal-semihosting-prof/proflib.c
+++ b/samples/src/cpp-baremetal-semihosting-prof/proflib.c
@@ -65,10 +65,11 @@ static const char *NamesLast = NULL;
 static char *CountersFirst = NULL;
 static char *CountersLast = NULL;
 
+#define INSTR_PROF_RAW_VERSION 8
 #define INSTR_PROF_RAW_VERSION_VAR __llvm_profile_raw_version
 #define INSTR_PROF_PROFILE_RUNTIME_VAR __llvm_profile_runtime
 
-extern uint64_t INSTR_PROF_RAW_VERSION_VAR;
+uint64_t INSTR_PROF_RAW_VERSION_VAR = INSTR_PROF_RAW_VERSION;
 int INSTR_PROF_PROFILE_RUNTIME_VAR;
 
 void __llvm_profile_dump(void);


### PR DESCRIPTION
Reverts ARM-software/LLVM-embedded-toolchain-for-Arm#308 since the upstream change was reverted https://github.com/llvm/llvm-project/commit/4d5d9a539058c87b42b472daedfb95377f5e1612