### PR TITLE
add ExclusiveGroup feature to multilib.yaml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -946,6 +946,7 @@ function(add_library_variant target_arch)
     foreach(flag ${multilib_flags_list})
         string(APPEND multilib_yaml_content "  - ${flag}\n")
     endforeach()
+    string(APPEND multilib_yaml_content "  ExclusiveGroup: stdlibs\n")
 
     install(
         DIRECTORY "${LLVM_BINARY_DIR}/${directory}/"
@@ -1085,21 +1086,6 @@ add_library_variant(
 )
 add_library_variant(
     armv7m
-    SUFFIX soft_nofp
-    COMPILE_FLAGS "-mfloat-abi=soft -march=armv7m -mfpu=none"
-    MULTILIB_FLAGS "--target=thumbv7m-none-unknown-eabi -mfpu=none"
-    QEMU_MACHINE "mps2-an385"
-    QEMU_CPU "cortex-m3"
-    BOOT_FLASH_ADDRESS 0x00000000
-    BOOT_FLASH_SIZE 0x1000
-    FLASH_ADDRESS 0x00001000
-    FLASH_SIZE 0x3ff000
-    RAM_ADDRESS 0x20000000
-    RAM_SIZE 2M
-    STACK_SIZE 4K
-)
-add_library_variant(
-    armv7m
     SUFFIX soft_fpv4_sp_d16
     COMPILE_FLAGS "-mfloat-abi=softfp -march=armv7m -mfpu=fpv4-sp-d16"
     MULTILIB_FLAGS "--target=thumbv7m-none-unknown-eabi -mfpu=fpv4-sp-d16"
@@ -1113,13 +1099,19 @@ add_library_variant(
     RAM_SIZE 2M
     STACK_SIZE 4K
 )
+# When no -mfpu=none is specified, the compiler internally adds all other
+# possible fpu settings before searching for matching variants. So for the
+# no-fpu variant to win, it has to be in multilab.yaml after all other
+# fpu variants. The order of variants in multilab.yaml depends on the order
+# of the add_library_variant calls. So the add_library_variant that adds
+# the soft_nofp for armv7m is placed after all other armv7m variants.
 add_library_variant(
-    armv7em
+    armv7m
     SUFFIX soft_nofp
-    COMPILE_FLAGS "-mfloat-abi=soft -march=armv7em -mfpu=none"
-    MULTILIB_FLAGS "--target=thumbv7em-none-unknown-eabi -mfpu=none"
-    QEMU_MACHINE "mps2-an386"
-    QEMU_CPU "cortex-m4"
+    COMPILE_FLAGS "-mfloat-abi=soft -march=armv7m -mfpu=none"
+    MULTILIB_FLAGS "--target=thumbv7m-none-unknown-eabi -mfpu=none"
+    QEMU_MACHINE "mps2-an385"
+    QEMU_CPU "cortex-m3"
     BOOT_FLASH_ADDRESS 0x00000000
     BOOT_FLASH_SIZE 0x1000
     FLASH_ADDRESS 0x00001000
@@ -1150,6 +1142,27 @@ add_library_variant(
     MULTILIB_FLAGS "--target=thumbv7em-none-unknown-eabihf -mfpu=fpv5-d16"
     QEMU_MACHINE "mps2-an500"
     QEMU_CPU "cortex-m7"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x00001000
+    FLASH_SIZE 0x3ff000
+    RAM_ADDRESS 0x20000000
+    RAM_SIZE 2M
+    STACK_SIZE 4K
+)
+# When no -mfpu=none is specified, the compiler internally adds all other
+# possible fpu settings before searching for matching variants. So for the
+# no-fpu variant to win, it has to be in multilab.yaml after all other
+# fpu variants. The order of variants in multilab.yaml depends on the order
+# of the add_library_variant calls. So the add_library_variant that adds
+# the soft_nofp for armv7em is placed after all other armv7em variants.
+add_library_variant(
+    armv7em
+    SUFFIX soft_nofp
+    COMPILE_FLAGS "-mfloat-abi=soft -march=armv7em -mfpu=none"
+    MULTILIB_FLAGS "--target=thumbv7em-none-unknown-eabi -mfpu=none"
+    QEMU_MACHINE "mps2-an386"
+    QEMU_CPU "cortex-m4"
     BOOT_FLASH_ADDRESS 0x00000000
     BOOT_FLASH_SIZE 0x1000
     FLASH_ADDRESS 0x00001000

--- a/patches/llvm-project.patch
+++ b/patches/llvm-project.patch
@@ -6,3 +6,259 @@ index 20c4f52cd378..eefdedbcb4f4 100644
 -#==============================================================================#
 +#==============================================================================#
  # This file specifies intentionally untracked files that git should ignore.
+diff --git a/clang/include/clang/Driver/Multilib.h b/clang/include/clang/Driver/Multilib.h
+index 1416559..6a9533e 100644
+--- a/clang/include/clang/Driver/Multilib.h
++++ b/clang/include/clang/Driver/Multilib.h
+@@ -39,13 +39,22 @@
+   std::string IncludeSuffix;
+   flags_list Flags;
+ 
++  // Optionally, a multilib can be assigned a string tag indicating that it's
++  // part of a group of mutually exclusive possibilities. If two or more
++  // multilibs have the same non-empty value of ExclusiveGroup, then only the
++  // last matching one of them will be selected.
++  //
++  // Setting this to the empty string is a special case, indicating that the
++  // directory is not mutually exclusive with anything else.
++  std::string ExclusiveGroup;
++
+ public:
+   /// GCCSuffix, OSSuffix & IncludeSuffix will be appended directly to the
+   /// sysroot string so they must either be empty or begin with a '/' character.
+   /// This is enforced with an assert in the constructor.
+   Multilib(StringRef GCCSuffix = {}, StringRef OSSuffix = {},
+-           StringRef IncludeSuffix = {},
+-           const flags_list &Flags = flags_list());
++           StringRef IncludeSuffix = {}, const flags_list &Flags = flags_list(),
++           StringRef ExclusiveGroup = {});
+ 
+   /// Get the detected GCC installation path suffix for the multi-arch
+   /// target variant. Always starts with a '/', unless empty
+@@ -63,6 +72,9 @@
+   /// All elements begin with either '-' or '!'
+   const flags_list &flags() const { return Flags; }
+ 
++  /// Get the exclusive group label.
++  const std::string &exclusiveGroup() const { return ExclusiveGroup; }
++
+   LLVM_DUMP_METHOD void dump() const;
+   /// print summary of the Multilib
+   void print(raw_ostream &OS) const;
+diff --git a/clang/lib/Driver/Multilib.cpp b/clang/lib/Driver/Multilib.cpp
+index a37dffc..33b5db7 100644
+--- a/clang/lib/Driver/Multilib.cpp
++++ b/clang/lib/Driver/Multilib.cpp
+@@ -30,9 +30,10 @@
+ using namespace llvm::sys;
+ 
+ Multilib::Multilib(StringRef GCCSuffix, StringRef OSSuffix,
+-                   StringRef IncludeSuffix, const flags_list &Flags)
++                   StringRef IncludeSuffix, const flags_list &Flags,
++                   StringRef ExclusiveGroup)
+     : GCCSuffix(GCCSuffix), OSSuffix(OSSuffix), IncludeSuffix(IncludeSuffix),
+-      Flags(Flags) {
++      Flags(Flags), ExclusiveGroup(ExclusiveGroup) {
+   assert(GCCSuffix.empty() ||
+          (StringRef(GCCSuffix).front() == '/' && GCCSuffix.size() > 1));
+   assert(OSSuffix.empty() ||
+@@ -97,13 +98,39 @@
+                          llvm::SmallVector<Multilib> &Selected) const {
+   llvm::StringSet<> FlagSet(expandFlags(Flags));
+   Selected.clear();
+-  llvm::copy_if(Multilibs, std::back_inserter(Selected),
+-                [&FlagSet](const Multilib &M) {
+-                  for (const std::string &F : M.flags())
+-                    if (!FlagSet.contains(F))
+-                      return false;
+-                  return true;
+-                });
++
++  // Decide which multilibs we're going to select at all
++  std::vector<bool> IsSelected(Multilibs.size(), false);
++  std::map<std::string, size_t> ExclusiveGroupMembers;
++  for (size_t i = 0, e = Multilibs.size(); i < e; ++i) {
++    const Multilib &M = Multilibs[i];
++
++    // If this multilib doesn't match all our flags, don't select it
++    if (!llvm::all_of(M.flags(), [&FlagSet](const std::string &F) {
++          return FlagSet.contains(F);
++        }))
++      continue;
++
++    // If this multilib has the same ExclusiveGroup as one we've already
++    // selected, de-select the previous one
++    const std::string &group = M.exclusiveGroup();
++    if (!group.empty()) {
++      auto it = ExclusiveGroupMembers.find(group);
++      if (it != ExclusiveGroupMembers.end())
++        IsSelected[it->second] = false;
++    }
++
++    // Select this multilib
++    IsSelected[i] = true;
++    if (!group.empty())
++      ExclusiveGroupMembers[group] = i;
++  }
++
++  // Now write the selected multilibs into the output
++  for (size_t i = 0, e = Multilibs.size(); i < e; ++i)
++    if (IsSelected[i])
++      Selected.push_back(Multilibs[i]);
++
+   return !Selected.empty();
+ }
+ 
+@@ -140,6 +167,7 @@
+ struct MultilibSerialization {
+   std::string Dir;
+   std::vector<std::string> Flags;
++  std::string ExclusiveGroup;
+ };
+ 
+ struct MultilibSetSerialization {
+@@ -154,6 +182,7 @@
+   static void mapping(llvm::yaml::IO &io, MultilibSerialization &V) {
+     io.mapRequired("Dir", V.Dir);
+     io.mapRequired("Flags", V.Flags);
++    io.mapOptional("ExclusiveGroup", V.ExclusiveGroup);
+   }
+   static std::string validate(IO &io, MultilibSerialization &V) {
+     if (StringRef(V.Dir).starts_with("/"))
+@@ -216,7 +245,7 @@
+     std::string Dir;
+     if (M.Dir != ".")
+       Dir = "/" + M.Dir;
+-    Multilibs.emplace_back(Dir, Dir, Dir, M.Flags);
++    Multilibs.emplace_back(Dir, Dir, Dir, M.Flags, M.ExclusiveGroup);
+   }
+ 
+   return MultilibSet(std::move(Multilibs), std::move(MS.FlagMatchers));
+diff --git a/clang/test/Driver/baremetal-multilib-layered.yaml b/clang/test/Driver/baremetal-multilib-layered.yaml
+index 2f86f8e..9c866db 100644
+--- a/clang/test/Driver/baremetal-multilib-layered.yaml
++++ b/clang/test/Driver/baremetal-multilib-layered.yaml
+@@ -8,30 +8,70 @@
+ # need to duplicate the C library for every libc++ variant.
+ # However -fno-exceptions is not yet supported for multilib selection
+ # so we use a more contrived -mfloat-abi example instead.
++# There are cases when only one of the matching multilibs should be selected.
++# The optional ExlusiveGroup flag can be used for those cases. When it
++# is specified, the last multilib in that group will be selected.
+ 
+-# RUN: rm -rf %T/baremetal_multilib_layered
+-# RUN: mkdir -p %T/baremetal_multilib_layered/bin
+-# RUN: mkdir -p %T/baremetal_multilib_layered/lib/clang-runtimes
+-# RUN: ln -s %clang %T/baremetal_multilib_layered/bin/clang
+-# RUN: ln -s %s %T/baremetal_multilib_layered/lib/clang-runtimes/multilib.yaml
++# RUN: rm -rf %t && split-file %s %t
++# RUN: mkdir -p %t/bin
++# RUN: mkdir -p %t/lib/clang-runtimes
++# RUN: ln -s %clang %t/bin/clang
+ 
+-# RUN: %T/baremetal_multilib_layered/bin/clang -no-canonical-prefixes -x c++ %s -### -o %t.out 2>&1 \
++# No ExclusiveGroup flag.
++# Both variants will be selected.
++# RUN: rm -f %t/lib/clang-runtimes/multilib.yaml
++# RUN: ln -s %t/multilib-nogroups.yaml %t/lib/clang-runtimes/multilib.yaml
++# RUN: %t/bin/clang -no-canonical-prefixes -x c++ %s -### -o %t.out 2>&1 \
+ # RUN:     --target=thumbv7m-none-eabi -mfloat-abi=softfp --sysroot= \
+-# RUN:   | FileCheck -DSYSROOT=%T/baremetal_multilib_layered %s
+-# CHECK:      "-cc1" "-triple" "thumbv7m-none-unknown-eabi"
+-# CHECK-SAME: "-internal-isystem" "[[SYSROOT]]/bin/../lib/clang-runtimes/softfp/include/c++/v1"
+-# CHECK-SAME: "-internal-isystem" "[[SYSROOT]]/bin/../lib/clang-runtimes/soft/include/c++/v1"
+-# CHECK-SAME: "-internal-isystem" "[[SYSROOT]]/bin/../lib/clang-runtimes/softfp/include"
+-# CHECK-SAME: "-internal-isystem" "[[SYSROOT]]/bin/../lib/clang-runtimes/soft/include"
+-# CHECK-NEXT: "-L[[SYSROOT]]/bin/../lib/clang-runtimes/softfp/lib"
+-# CHECK-SAME: "-L[[SYSROOT]]/bin/../lib/clang-runtimes/soft/lib"
+-
+-# RUN: %T/baremetal_multilib_layered/bin/clang -no-canonical-prefixes -print-multi-directory 2>&1 \
++# RUN:   | FileCheck -DSYSROOT=%t %s --check-prefix=BOTH
++# RUN: %t/bin/clang -no-canonical-prefixes -print-multi-directory 2>&1 \
+ # RUN:     --target=arm-none-eabi -mfloat-abi=softfp --sysroot= \
+-# RUN:   | FileCheck --check-prefix=CHECK-PRINT-MULTI-DIRECTORY %s
+-# CHECK-PRINT-MULTI-DIRECTORY:      soft
+-# CHECK-PRINT-MULTI-DIRECTORY-NEXT: softfp
++# RUN:   | FileCheck --check-prefix=BOTH-PRINT-MULTI-DIRECTORY %s
+ 
++# Variants belong to different ExclusiveGroups.
++# Both variants will be selected.
++# RUN: rm -f %t/lib/clang-runtimes/multilib.yaml
++# RUN: ln -s %t/multilib-diffgroups.yaml %t/lib/clang-runtimes/multilib.yaml
++# RUN: %t/bin/clang -no-canonical-prefixes -x c++ %s -### -o %t.out 2>&1 \
++# RUN:     --target=thumbv7m-none-eabi -mfloat-abi=softfp --sysroot= \
++# RUN:   | FileCheck -DSYSROOT=%t %s --check-prefix=BOTH
++# RUN: %t/bin/clang -no-canonical-prefixes -print-multi-directory 2>&1 \
++# RUN:     --target=arm-none-eabi -mfloat-abi=softfp --sysroot= \
++# RUN:   | FileCheck --check-prefix=BOTH-PRINT-MULTI-DIRECTORY %s
++
++# BOTH:      "-cc1" "-triple" "thumbv7m-none-unknown-eabi"
++# BOTH-SAME: "-internal-isystem" "[[SYSROOT]]/bin/../lib/clang-runtimes/softfp/include/c++/v1"
++# BOTH-SAME: "-internal-isystem" "[[SYSROOT]]/bin/../lib/clang-runtimes/soft/include/c++/v1"
++# BOTH-SAME: "-internal-isystem" "[[SYSROOT]]/bin/../lib/clang-runtimes/softfp/include"
++# BOTH-SAME: "-internal-isystem" "[[SYSROOT]]/bin/../lib/clang-runtimes/soft/include"
++# BOTH-NEXT: "-L[[SYSROOT]]/bin/../lib/clang-runtimes/softfp/lib"
++# BOTH-SAME: "-L[[SYSROOT]]/bin/../lib/clang-runtimes/soft/lib"
++# BOTH-PRINT-MULTI-DIRECTORY:      soft
++# BOTH-PRINT-MULTI-DIRECTORY-NEXT:      softfp
++
++# Variants belong to the same ExclusiveGroup.
++# The last variant found (softfp) will be selected.
++# RUN: rm -f %t/lib/clang-runtimes/multilib.yaml
++# RUN: ln -s %t/multilib-samegroup.yaml %t/lib/clang-runtimes/multilib.yaml
++# RUN: %t/bin/clang -no-canonical-prefixes -x c++ %s -### -o %t.out 2>&1 \
++# RUN:     --target=thumbv7m-none-eabi -mfloat-abi=softfp --sysroot= \
++# RUN:   | FileCheck -DSYSROOT=%t %s --check-prefix=SOFTFP
++# RUN: %t/bin/clang -no-canonical-prefixes -print-multi-directory 2>&1 \
++# RUN:     --target=arm-none-eabi -mfloat-abi=softfp --sysroot= \
++# RUN:   | FileCheck --check-prefix=SOFTFP-PRINT-MULTI-DIRECTORY %s
++
++# SOFTFP:      "-cc1" "-triple" "thumbv7m-none-unknown-eabi"
++# SOFTFP-SAME: "-internal-isystem" "[[SYSROOT]]/bin/../lib/clang-runtimes/softfp/include/c++/v1"
++# SOFTFP-NOTE: "-internal-isystem" "[[SYSROOT]]/bin/../lib/clang-runtimes/soft/include/c++/v1"
++# SOFTFP-SAME: "-internal-isystem" "[[SYSROOT]]/bin/../lib/clang-runtimes/softfp/include"
++# SOFTFP-NOT: "-internal-isystem" "[[SYSROOT]]/bin/../lib/clang-runtimes/soft/include"
++# SOFTFP-NEXT: "-L[[SYSROOT]]/bin/../lib/clang-runtimes/softfp/lib"
++# SOFTFP-NOT: "-L[[SYSROOT]]/bin/../lib/clang-runtimes/soft/lib"
++# SOFTFP-PRINT-MULTI-DIRECTORY:      softfp
++# SOFTFP-PRINT-MULTI-DIRECTORY-NOT:      soft
++
++
++//--- multilib-nogroups.yaml
+ ---
+ MultilibVersion: 1.0
+ Variants:
+@@ -43,3 +83,33 @@
+ - Match: -mfloat-abi=softfp
+   Flags: [-mfloat-abi=soft]
+ ...
++
++//--- multilib-diffgroups.yaml
++---
++MultilibVersion: 1.0
++Variants:
++- Dir: soft
++  Flags: [-mfloat-abi=soft]
++  ExclusiveGroup: G1
++- Dir: softfp
++  Flags: [-mfloat-abi=softfp]
++  ExclusiveGroup: G2
++Mappings:
++- Match: -mfloat-abi=softfp
++  Flags: [-mfloat-abi=soft]
++...
++
++//--- multilib-samegroup.yaml
++---
++MultilibVersion: 1.0
++Variants:
++- Dir: soft
++  Flags: [-mfloat-abi=soft]
++  ExclusiveGroup: G
++- Dir: softfp
++  Flags: [-mfloat-abi=softfp]
++  ExclusiveGroup: G
++Mappings:
++- Match: -mfloat-abi=softfp
++  Flags: [-mfloat-abi=soft]
++...

--- a/test/multilib/aarch64.test
+++ b/test/multilib/aarch64.test
@@ -1,2 +1,3 @@
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf | FileCheck %s
 # CHECK: aarch64-none-elf/aarch64
+# CHECK-EMPTY:

--- a/test/multilib/armv4t.test
+++ b/test/multilib/armv4t.test
@@ -1,2 +1,3 @@
 # RUN: %clang -print-multi-directory --target=arm-none-eabi -mfpu=none | FileCheck %s
 # CHECK: arm-none-eabi/armv4t
+# CHECK-EMPTY:

--- a/test/multilib/armv5e.test
+++ b/test/multilib/armv5e.test
@@ -1,2 +1,3 @@
 # RUN: %clang -print-multi-directory --target=armv5e-none-eabi -mfpu=none | FileCheck %s
 # CHECK: arm-none-eabi/armv5te
+# CHECK-EMPTY:

--- a/test/multilib/armv6m.test
+++ b/test/multilib/armv6m.test
@@ -1,2 +1,3 @@
 # RUN: %clang -print-multi-directory --target=armv6m-none-eabi -mfpu=none | FileCheck %s
 # CHECK: arm-none-eabi/armv6m_soft_nofp
+# CHECK-EMPTY:

--- a/test/multilib/armv7a.test
+++ b/test/multilib/armv7a.test
@@ -1,5 +1,7 @@
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=none | FileCheck %s
 # CHECK: arm-none-eabi/armv7a_soft_nofp
+# CHECK-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv3-d16 | FileCheck --check-prefix=VFPV3 %s
 # VFPV3: arm-none-eabi/armv7a_hard_vfpv3_d16
+# VFPV3-EMPTY:

--- a/test/multilib/armv7em.test
+++ b/test/multilib/armv7em.test
@@ -1,8 +1,11 @@
 # RUN: %clang -print-multi-directory --target=armv7em-none-eabi -mfpu=none | FileCheck %s
 # CHECK: arm-none-eabi/armv7em_soft_nofp
+# CHECK-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=armv7em-none-eabihf -mfpu=fpv4-sp-d16 | FileCheck --check-prefix=FPV4 %s
 # FPV4: arm-none-eabi/armv7em_hard_fpv4_sp_d16
+# FPV4-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=armv7em-none-eabihf -mfpu=fpv5-d16 | FileCheck --check-prefix=FPV5 %s
 # FPV5: arm-none-eabi/armv7em_hard_fpv5_d16
+# FPV5-EMPTY:

--- a/test/multilib/armv7m.test
+++ b/test/multilib/armv7m.test
@@ -1,5 +1,8 @@
 # RUN: %clang -print-multi-directory --target=armv7m-none-eabi -mfpu=none | FileCheck %s
+# RUN: %clang -print-multi-directory --target=armv7m-none-eabi -mfpu=none -mfloat-abi=softfp | FileCheck %s
 # CHECK: arm-none-eabi/armv7m_soft_nofp
+# CHECK-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=armv7m-none-eabi -mfpu=none -mfloat-abi=softfp | FileCheck --check-prefix=SOFT_FPV4 %s
-# SOFT_FPV4: arm-none-eabi/armv7m_soft_fpv4_sp_d16
+# RUN: %clang -print-multi-directory --target=armv7m-none-eabi -mfpu=vfp -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-FPV4 %s
+# SOFT-FPV4: arm-none-eabi/armv7m_soft_fpv4_sp_d16
+# SOFT-FPV4-EMPTY:

--- a/test/multilib/armv7r.test
+++ b/test/multilib/armv7r.test
@@ -1,5 +1,7 @@
 # RUN: %clang -print-multi-directory --target=armv7r-none-eabi -mfpu=none | FileCheck %s
 # CHECK: arm-none-eabi/armv7r_soft_nofp
+# CHECK-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3-d16 | FileCheck --check-prefix=VFPV3 %s
 # VFPV3: arm-none-eabi/armv7r_hard_vfpv3_d16
+# VFPV3-EMPTY:

--- a/test/multilib/armv8.1m.main.test
+++ b/test/multilib/armv8.1m.main.test
@@ -1,14 +1,18 @@
 # RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabi -mfpu=none | FileCheck %s
 # CHECK: arm-none-eabi/armv8.1m.main_soft_nofp
+# CHECK-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main -mfpu=fp-armv8-fullfp16-sp-d16 | FileCheck --check-prefix=HARD_FP %s
 # HARD_FP: arm-none-eabi/armv8.1m.main_hard_fp_nomve
+# HARD_FP-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main -mfpu=fp-armv8-fullfp16-d16 | FileCheck --check-prefix=HARD_FPDP %s
 # HARD_FPDP: arm-none-eabi/armv8.1m.main_hard_fpdp_nomve
+# HARD_FPDP-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=none | FileCheck --check-prefix=MVE %s
 # MVE: arm-none-eabi/armv8.1m.main_hard_nofp_mve
+# MVE-EMPTY:
 
 # RUN: %clang -print-multi-flags-experimental --target=arm-none-eabihf -mcpu=cortex-m55 | FileCheck --check-prefix=CORTEXM55 %s
 # CORTEXM55: -march=thumbv8.1m.main+fp16+lob+mve.fp

--- a/test/multilib/armv8m.main.test
+++ b/test/multilib/armv8m.main.test
@@ -1,5 +1,7 @@
 # RUN: %clang -print-multi-directory --target=armv8m.main-none-eabi -mfpu=none | FileCheck %s
 # CHECK: arm-none-eabi/armv8m.main_soft_nofp
+# CHECK-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=armv8m.main-none-eabihf -mfpu=fpv5-sp-d16 | FileCheck --check-prefix=HARD %s
 # HARD: arm-none-eabi/armv8m.main_hard_fp
+# HARD-EMPTY:


### PR DESCRIPTION
Fixes #307
This allows a multilib configuration to specify explicitly that a subset of its
libraries are alternatives to each other, and at most one of that subset should
be selected. To be consistent with existing semantics, the _last_ choice wins,
if more than one of the options matches the given flags.