### PR TITLE
picolibc: update test wrapper to match upstream

### DIFF
--- a/test-support/picolibc-test-wrapper.py
+++ b/test-support/picolibc-test-wrapper.py
@@ -38,7 +38,7 @@ def run(args):
         args.qemu_cpu,
         args.qemu_params.split(":") if args.qemu_params else [],
         args.image,
-        args.arguments,
+        ["program-name"] + args.arguments,
         None,
         pathlib.Path.cwd(),
     )


### PR DESCRIPTION
Two upstream changes:
c368f318 Remove c_args from per-multilib args
acc9b941 scripts: Change run-arm, run-aarch64 and run-riscv arg processing
changed the way comandline arguments are passed in semihosting tests.
Adjusted picolibc-test-wrappter.py to match run-arm used in upstream.