### PR TITLE
Add patches to make some libcxx armv7m tests pass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,7 +244,12 @@ endfunction()
 read_repo_version(llvmproject llvm-project)
 read_repo_version(picolibc picolibc)
 
-file(GLOB llvm_project_patches ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project/*.patch)
+set(
+    llvm_project_patches
+    ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project/0001-Fix-llvm-test-CodeGen-ARM-build-attributes.ll-test.patch
+    ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project/0002-libc-Add-check-for-building-with-picolibc.patch
+    ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project/0003-Run-picolibc-tests-with-qemu.patch
+    ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project/0004-xfail-two-remaining-libcxx-with-picolibc-tests.patch)
 FetchContent_Declare(llvmproject
     GIT_REPOSITORY https://github.com/llvm/llvm-project.git
     GIT_TAG "${llvmproject_TAG}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@
 # If you prefer you can check out and patch the repos manually and use those:
 #   mkdir repos
 #   git -C repos clone https://github.com/llvm/llvm-project.git
-#   git -C repos/llvm-project apply ../../patches/llvm-project.patch
+#   git -C repos/llvm-project am ../../patches/llvm-project/*.patch
 #   git -C repos clone https://github.com/picolibc/picolibc.git
 #   git -C repos/picolibc apply ../../patches/picolibc.patch
 #   mkdir build
@@ -244,12 +244,13 @@ endfunction()
 read_repo_version(llvmproject llvm-project)
 read_repo_version(picolibc picolibc)
 
+file(GLOB llvm_project_patches ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project/*.patch)
 FetchContent_Declare(llvmproject
     GIT_REPOSITORY https://github.com/llvm/llvm-project.git
     GIT_TAG "${llvmproject_TAG}"
     GIT_SHALLOW "${llvmproject_SHALLOW}"
     GIT_PROGRESS TRUE
-    PATCH_COMMAND git reset --quiet --hard && git clean --quiet --force -dx && git apply ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project.patch
+    PATCH_COMMAND git reset --quiet --hard && git clean --quiet --force -dx && git am ${llvm_project_patches}
     # Add the llvm subdirectory later to ensure that
     # LLVMEmbeddedToolchainForArm is the first project declared.
     # Otherwise CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -61,7 +61,7 @@ If you check out repos manually then it is your responsibility to ensure that th
 ```
 mkdir repos
 git -C repos clone https://github.com/llvm/llvm-project.git
-git -C repos/llvm-project apply ../../patches/llvm-project.patch
+git -C repos/llvm-project am ../../patches/llvm-project/*.patch
 git -C repos clone https://github.com/picolibc/picolibc.git
 git -C repos/picolibc apply ../../patches/picolibc.patch
 mkdir build

--- a/patches/llvm-project/0001-Fix-llvm-test-CodeGen-ARM-build-attributes.ll-test.patch
+++ b/patches/llvm-project/0001-Fix-llvm-test-CodeGen-ARM-build-attributes.ll-test.patch
@@ -1,16 +1,30 @@
-diff --git a/.gitignore b/.gitignore
-index 20c4f52cd378..eefdedbcb4f4 100644
---- a/.gitignore
-+++ b/.gitignore
-@@ -1,2 +1,2 @@
--#==============================================================================#
-+#==============================================================================#
- # This file specifies intentionally untracked files that git should ignore.
+From 51276c6bbfa92054ec01890d67bb797464d9563c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
+Date: Tue, 10 Oct 2023 15:43:59 +0200
+Subject: [PATCH 1/3] Fix llvm/test/CodeGen/ARM/build-attributes.ll test.
+
+The test llvm/test/CodeGen/ARM/build-attributes.ll
+needs updating to incorporate the change
+https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/pull/313.
+
+Changing the expected FPU to fp-armv8-fullfp16-d16
+from fpv5-d16.
+---
+ clang/include/clang/Driver/Multilib.h         |  16 ++-
+ clang/lib/Driver/Multilib.cpp                 |  49 ++++++--
+ clang/test/CodeGen/arm-v8.1m-check-fpu.ll     |  55 +++++++++
+ .../Driver/baremetal-multilib-layered.yaml    | 108 +++++++++++++++---
+ .../ARM/MCTargetDesc/ARMELFStreamer.cpp       |   2 +
+ .../ARM/MCTargetDesc/ARMTargetStreamer.cpp    |  16 ++-
+ llvm/test/CodeGen/ARM/build-attributes.ll     |   4 +-
+ 7 files changed, 211 insertions(+), 39 deletions(-)
+ create mode 100644 clang/test/CodeGen/arm-v8.1m-check-fpu.ll
+
 diff --git a/clang/include/clang/Driver/Multilib.h b/clang/include/clang/Driver/Multilib.h
-index 1416559..6a9533e 100644
+index 1416559414f8..6a9533e6dd83 100644
 --- a/clang/include/clang/Driver/Multilib.h
 +++ b/clang/include/clang/Driver/Multilib.h
-@@ -39,13 +39,22 @@
+@@ -39,13 +39,22 @@ private:
    std::string IncludeSuffix;
    flags_list Flags;
  
@@ -35,7 +49,7 @@ index 1416559..6a9533e 100644
  
    /// Get the detected GCC installation path suffix for the multi-arch
    /// target variant. Always starts with a '/', unless empty
-@@ -63,6 +72,9 @@
+@@ -63,6 +72,9 @@ public:
    /// All elements begin with either '-' or '!'
    const flags_list &flags() const { return Flags; }
  
@@ -46,10 +60,10 @@ index 1416559..6a9533e 100644
    /// print summary of the Multilib
    void print(raw_ostream &OS) const;
 diff --git a/clang/lib/Driver/Multilib.cpp b/clang/lib/Driver/Multilib.cpp
-index a37dffc..33b5db7 100644
+index a37dffc8a6f1..33b5db72c0b9 100644
 --- a/clang/lib/Driver/Multilib.cpp
 +++ b/clang/lib/Driver/Multilib.cpp
-@@ -30,9 +30,10 @@
+@@ -30,9 +30,10 @@ using namespace driver;
  using namespace llvm::sys;
  
  Multilib::Multilib(StringRef GCCSuffix, StringRef OSSuffix,
@@ -62,7 +76,7 @@ index a37dffc..33b5db7 100644
    assert(GCCSuffix.empty() ||
           (StringRef(GCCSuffix).front() == '/' && GCCSuffix.size() > 1));
    assert(OSSuffix.empty() ||
-@@ -97,13 +98,39 @@
+@@ -97,13 +98,39 @@ bool MultilibSet::select(const Multilib::flags_list &Flags,
                           llvm::SmallVector<Multilib> &Selected) const {
    llvm::StringSet<> FlagSet(expandFlags(Flags));
    Selected.clear();
@@ -109,7 +123,7 @@ index a37dffc..33b5db7 100644
    return !Selected.empty();
  }
  
-@@ -140,6 +167,7 @@
+@@ -140,6 +167,7 @@ static const VersionTuple MultilibVersionCurrent(1, 0);
  struct MultilibSerialization {
    std::string Dir;
    std::vector<std::string> Flags;
@@ -117,7 +131,7 @@ index a37dffc..33b5db7 100644
  };
  
  struct MultilibSetSerialization {
-@@ -154,6 +182,7 @@
+@@ -154,6 +182,7 @@ template <> struct llvm::yaml::MappingTraits<MultilibSerialization> {
    static void mapping(llvm::yaml::IO &io, MultilibSerialization &V) {
      io.mapRequired("Dir", V.Dir);
      io.mapRequired("Flags", V.Flags);
@@ -125,7 +139,7 @@ index a37dffc..33b5db7 100644
    }
    static std::string validate(IO &io, MultilibSerialization &V) {
      if (StringRef(V.Dir).starts_with("/"))
-@@ -216,7 +245,7 @@
+@@ -216,7 +245,7 @@ MultilibSet::parseYaml(llvm::MemoryBufferRef Input,
      std::string Dir;
      if (M.Dir != ".")
        Dir = "/" + M.Dir;
@@ -134,11 +148,72 @@ index a37dffc..33b5db7 100644
    }
  
    return MultilibSet(std::move(Multilibs), std::move(MS.FlagMatchers));
+diff --git a/clang/test/CodeGen/arm-v8.1m-check-fpu.ll b/clang/test/CodeGen/arm-v8.1m-check-fpu.ll
+new file mode 100644
+index 000000000000..5cff0457a190
+--- /dev/null
++++ b/clang/test/CodeGen/arm-v8.1m-check-fpu.ll
+@@ -0,0 +1,55 @@
++; REQUIRES: arm-registered-target
++; RUN: %clang --target=arm-none-eabi -mcpu=cortex-m85 -mfloat-abi=hard -save-temps=obj -S -o - %s | FileCheck %s
++; RUN: %clang --target=arm-none-eabi -mcpu=cortex-m55 -mfloat-abi=hard -save-temps=obj -S -o - %s | FileCheck %s
++; RUN: %clang --target=arm-none-eabi -mcpu=cortex-m85 -mfloat-abi=hard -O2 -c -mthumb -save-temps=obj %s
++; RUN: %clang --target=arm-none-eabi -mcpu=cortex-m55 -mfloat-abi=hard -O2 -c -mthumb -save-temps=obj %s
++; CHECK: .fpu   fp-armv8-fullfp16-d16
++target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
++target triple = "thumbv8.1m.main-none-unknown-eabihf"
++
++%struct.dummy_t = type { float, float, float, float }
++
++define dso_local signext i8 @foo(ptr noundef %handle) #0 {
++entry:
++  %handle.addr = alloca ptr, align 4
++  store ptr %handle, ptr %handle.addr, align 4
++  %0 = load ptr, ptr %handle.addr, align 4
++  %a = getelementptr inbounds %struct.dummy_t, ptr %0, i32 0, i32 0
++  %1 = load float, ptr %a, align 4
++  %sub = fsub float 0x3F5439DE40000000, %1
++  %2 = load ptr, ptr %handle.addr, align 4
++  %a1 = getelementptr inbounds %struct.dummy_t, ptr %2, i32 0, i32 0
++  %3 = load float, ptr %a1, align 4
++  %4 = call float @llvm.fmuladd.f32(float 0x3F847AE140000000, float %sub, float %3)
++  store float %4, ptr %a1, align 4
++  %5 = load ptr, ptr %handle.addr, align 4
++  %b = getelementptr inbounds %struct.dummy_t, ptr %5, i32 0, i32 1
++  %6 = load float, ptr %b, align 4
++  %sub2 = fsub float 0x3F5439DE40000000, %6
++  %7 = load ptr, ptr %handle.addr, align 4
++  %b3 = getelementptr inbounds %struct.dummy_t, ptr %7, i32 0, i32 1
++  %8 = load float, ptr %b3, align 4
++  %9 = call float @llvm.fmuladd.f32(float 0x3F947AE140000000, float %sub2, float %8)
++  store float %9, ptr %b3, align 4
++  %10 = load ptr, ptr %handle.addr, align 4
++  %c = getelementptr inbounds %struct.dummy_t, ptr %10, i32 0, i32 2
++  %11 = load float, ptr %c, align 4
++  %sub4 = fsub float 0x3F5439DE40000000, %11
++  %12 = load ptr, ptr %handle.addr, align 4
++  %c5 = getelementptr inbounds %struct.dummy_t, ptr %12, i32 0, i32 2
++  %13 = load float, ptr %c5, align 4
++  %14 = call float @llvm.fmuladd.f32(float 0x3F9EB851E0000000, float %sub4, float %13)
++  store float %14, ptr %c5, align 4
++  %15 = load ptr, ptr %handle.addr, align 4
++  %d = getelementptr inbounds %struct.dummy_t, ptr %15, i32 0, i32 3
++  %16 = load float, ptr %d, align 4
++  %sub6 = fsub float 0x3F5439DE40000000, %16
++  %17 = load ptr, ptr %handle.addr, align 4
++  %d7 = getelementptr inbounds %struct.dummy_t, ptr %17, i32 0, i32 3
++  %18 = load float, ptr %d7, align 4
++  %19 = call float @llvm.fmuladd.f32(float 0x3FA47AE140000000, float %sub6, float %18)
++  store float %19, ptr %d7, align 4
++  ret i8 0
++}
++
++declare float @llvm.fmuladd.f32(float, float, float) #1
 diff --git a/clang/test/Driver/baremetal-multilib-layered.yaml b/clang/test/Driver/baremetal-multilib-layered.yaml
-index 2f86f8e..9c866db 100644
+index 2f86f8e3ea4f..9c866dbff916 100644
 --- a/clang/test/Driver/baremetal-multilib-layered.yaml
 +++ b/clang/test/Driver/baremetal-multilib-layered.yaml
-@@ -8,30 +8,70 @@
+@@ -8,37 +8,107 @@
  # need to duplicate the C library for every libc++ variant.
  # However -fno-exceptions is not yet supported for multilib selection
  # so we use a more contrived -mfloat-abi example instead.
@@ -225,13 +300,17 @@ index 2f86f8e..9c866db 100644
 +
 +
 +//--- multilib-nogroups.yaml
- ---
- MultilibVersion: 1.0
- Variants:
-@@ -43,3 +83,33 @@
- - Match: -mfloat-abi=softfp
-   Flags: [-mfloat-abi=soft]
- ...
++---
++MultilibVersion: 1.0
++Variants:
++- Dir: soft
++  Flags: [-mfloat-abi=soft]
++- Dir: softfp
++  Flags: [-mfloat-abi=softfp]
++Mappings:
++- Match: -mfloat-abi=softfp
++  Flags: [-mfloat-abi=soft]
++...
 +
 +//--- multilib-diffgroups.yaml
 +---
@@ -249,80 +328,18 @@ index 2f86f8e..9c866db 100644
 +...
 +
 +//--- multilib-samegroup.yaml
-+---
-+MultilibVersion: 1.0
-+Variants:
-+- Dir: soft
-+  Flags: [-mfloat-abi=soft]
+ ---
+ MultilibVersion: 1.0
+ Variants:
+ - Dir: soft
+   Flags: [-mfloat-abi=soft]
 +  ExclusiveGroup: G
-+- Dir: softfp
-+  Flags: [-mfloat-abi=softfp]
+ - Dir: softfp
+   Flags: [-mfloat-abi=softfp]
 +  ExclusiveGroup: G
-+Mappings:
-+- Match: -mfloat-abi=softfp
-+  Flags: [-mfloat-abi=soft]
-+...
-diff --git a/clang/test/CodeGen/arm-v8.1m-check-fpu.ll b/clang/test/CodeGen/arm-v8.1m-check-fpu.ll
-new file mode 100644
-index 000000000000..5cff0457a190
---- /dev/null
-+++ b/clang/test/CodeGen/arm-v8.1m-check-fpu.ll
-@@ -0,0 +1,55 @@
-+; REQUIRES: arm-registered-target
-+; RUN: %clang --target=arm-none-eabi -mcpu=cortex-m85 -mfloat-abi=hard -save-temps=obj -S -o - %s | FileCheck %s
-+; RUN: %clang --target=arm-none-eabi -mcpu=cortex-m55 -mfloat-abi=hard -save-temps=obj -S -o - %s | FileCheck %s
-+; RUN: %clang --target=arm-none-eabi -mcpu=cortex-m85 -mfloat-abi=hard -O2 -c -mthumb -save-temps=obj %s
-+; RUN: %clang --target=arm-none-eabi -mcpu=cortex-m55 -mfloat-abi=hard -O2 -c -mthumb -save-temps=obj %s
-+; CHECK: .fpu   fp-armv8-fullfp16-d16
-+target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
-+target triple = "thumbv8.1m.main-none-unknown-eabihf"
-+
-+%struct.dummy_t = type { float, float, float, float }
-+
-+define dso_local signext i8 @foo(ptr noundef %handle) #0 {
-+entry:
-+  %handle.addr = alloca ptr, align 4
-+  store ptr %handle, ptr %handle.addr, align 4
-+  %0 = load ptr, ptr %handle.addr, align 4
-+  %a = getelementptr inbounds %struct.dummy_t, ptr %0, i32 0, i32 0
-+  %1 = load float, ptr %a, align 4
-+  %sub = fsub float 0x3F5439DE40000000, %1
-+  %2 = load ptr, ptr %handle.addr, align 4
-+  %a1 = getelementptr inbounds %struct.dummy_t, ptr %2, i32 0, i32 0
-+  %3 = load float, ptr %a1, align 4
-+  %4 = call float @llvm.fmuladd.f32(float 0x3F847AE140000000, float %sub, float %3)
-+  store float %4, ptr %a1, align 4
-+  %5 = load ptr, ptr %handle.addr, align 4
-+  %b = getelementptr inbounds %struct.dummy_t, ptr %5, i32 0, i32 1
-+  %6 = load float, ptr %b, align 4
-+  %sub2 = fsub float 0x3F5439DE40000000, %6
-+  %7 = load ptr, ptr %handle.addr, align 4
-+  %b3 = getelementptr inbounds %struct.dummy_t, ptr %7, i32 0, i32 1
-+  %8 = load float, ptr %b3, align 4
-+  %9 = call float @llvm.fmuladd.f32(float 0x3F947AE140000000, float %sub2, float %8)
-+  store float %9, ptr %b3, align 4
-+  %10 = load ptr, ptr %handle.addr, align 4
-+  %c = getelementptr inbounds %struct.dummy_t, ptr %10, i32 0, i32 2
-+  %11 = load float, ptr %c, align 4
-+  %sub4 = fsub float 0x3F5439DE40000000, %11
-+  %12 = load ptr, ptr %handle.addr, align 4
-+  %c5 = getelementptr inbounds %struct.dummy_t, ptr %12, i32 0, i32 2
-+  %13 = load float, ptr %c5, align 4
-+  %14 = call float @llvm.fmuladd.f32(float 0x3F9EB851E0000000, float %sub4, float %13)
-+  store float %14, ptr %c5, align 4
-+  %15 = load ptr, ptr %handle.addr, align 4
-+  %d = getelementptr inbounds %struct.dummy_t, ptr %15, i32 0, i32 3
-+  %16 = load float, ptr %d, align 4
-+  %sub6 = fsub float 0x3F5439DE40000000, %16
-+  %17 = load ptr, ptr %handle.addr, align 4
-+  %d7 = getelementptr inbounds %struct.dummy_t, ptr %17, i32 0, i32 3
-+  %18 = load float, ptr %d7, align 4
-+  %19 = call float @llvm.fmuladd.f32(float 0x3FA47AE140000000, float %sub6, float %18)
-+  store float %19, ptr %d7, align 4
-+  ret i8 0
-+}
-+
-+declare float @llvm.fmuladd.f32(float, float, float) #1
+ Mappings:
+ - Match: -mfloat-abi=softfp
+   Flags: [-mfloat-abi=soft]
 diff --git a/llvm/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp b/llvm/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
 index 9c9af6068079..e7c37767c6ed 100644
 --- a/llvm/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
@@ -387,3 +404,6 @@ index e8c83b92f3f9..0abe13aeb4fe 100644
  ; CORTEX-M85: .eabi_attribute 36, 1   @ Tag_FP_HP_extension
  ; CORTEX-M85: .eabi_attribute 48, 2   @ Tag_MVE_arch
  ; CORTEX-M85: .eabi_attribute 46, 1   @ Tag_DSP_extension
+-- 
+2.34.1
+

--- a/patches/llvm-project/0002-libc-Add-check-for-building-with-picolibc.patch
+++ b/patches/llvm-project/0002-libc-Add-check-for-building-with-picolibc.patch
@@ -1,0 +1,1006 @@
+From a269f6727984dfddf1df528014d86b6d006bffab Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
+Date: Tue, 10 Oct 2023 15:45:15 +0200
+Subject: [PATCH 2/3] [libc++] Add check for building with picolibc
+
+This is intended to identify changes that would fail to build on
+embedded platforms e.g. D152382
+---
+ libcxx/cmake/caches/Armv7M-picolibc.cmake     |  38 ++++++
+ libcxx/docs/index.rst                         |  19 +--
+ libcxx/test/configs/armv7m-libc++.cfg.in      |  48 ++++++++
+ .../test/libcxx/clang_modules_include.gen.py  |   3 +
+ libcxx/test/libcxx/selftest/dsl/dsl.sh.py     |   3 +
+ .../selftest/pass.cpp/run-error.pass.cpp      |   1 +
+ .../libcxx/selftest/pass.mm/run-error.pass.mm |   1 +
+ .../test/libcxx/system_reserved_names.gen.py  |   5 +-
+ .../atomics.types.generic/integral.pass.cpp   |   2 +
+ .../atomic_fetch_add.pass.cpp                 |   2 +
+ .../atomic_fetch_add_explicit.pass.cpp        |   2 +
+ .../atomic_fetch_and.pass.cpp                 |   2 +
+ .../atomic_fetch_and_explicit.pass.cpp        |   2 +
+ .../atomic_fetch_or.pass.cpp                  |   2 +
+ .../atomic_fetch_or_explicit.pass.cpp         |   2 +
+ .../atomic_fetch_sub.pass.cpp                 |   2 +
+ .../atomic_fetch_sub_explicit.pass.cpp        |   2 +
+ .../atomic_fetch_xor.pass.cpp                 |   2 +
+ .../atomic_fetch_xor_explicit.pass.cpp        |   2 +
+ .../ctor.pass.cpp                             |   2 +
+ .../depr.c.headers/fenv_h.compile.pass.cpp    |   3 +
+ .../depr.c.headers/stdio_h.compile.pass.cpp   |   3 +
+ .../depr.c.headers/uchar_h.compile.pass.cpp   |   3 +
+ .../narrow.stream.objects/cerr.sh.cpp         |   2 +
+ .../narrow.stream.objects/clog.sh.cpp         |   2 +
+ .../narrow.stream.objects/cout.sh.cpp         |   2 +
+ .../cxx20_iterator_traits.compile.pass.cpp    |   5 +
+ .../sized_delete_array14.pass.cpp             |   1 +
+ .../new.delete.single/sized_delete14.pass.cpp |   1 +
+ .../ctime.timespec.compile.pass.cpp           |   3 +
+ .../numerics/cfenv/cfenv.syn/cfenv.pass.cpp   |   3 +
+ .../strings/c.strings/cuchar.compile.pass.cpp |   3 +
+ .../time.clock.file/to_from_sys.pass.cpp      |   3 +
+ .../time.clock/time.clock.hires/now.pass.cpp  |   3 +
+ .../time.clock.system/from_time_t.pass.cpp    |   3 +
+ .../time.clock/time.clock.system/now.pass.cpp |   3 +
+ .../time.clock.system/to_time_t.pass.cpp      |   3 +
+ .../op_-duration.pass.cpp                     |   3 +
+ libcxx/utils/ci/BOT_OWNERS.txt                |   2 +-
+ libcxx/utils/ci/build-picolibc.sh             | 109 ++++++++++++++++++
+ libcxx/utils/ci/buildkite-pipeline.yml        |  14 +++
+ libcxx/utils/ci/run-buildbot                  |  35 ++++++
+ libcxx/utils/libcxx/test/features.py          |  14 ++-
+ .../test/configs/armv7m-libc++abi.cfg.in      |  39 +++++++
+ libcxxabi/test/test_demangle.pass.cpp         |   3 +
+ .../test/test_exception_storage.pass.cpp      |   3 +
+ .../test/configs/armv7m-libunwind.cfg.in      |  32 +++++
+ 47 files changed, 430 insertions(+), 12 deletions(-)
+ create mode 100644 libcxx/cmake/caches/Armv7M-picolibc.cmake
+ create mode 100644 libcxx/test/configs/armv7m-libc++.cfg.in
+ create mode 100755 libcxx/utils/ci/build-picolibc.sh
+ create mode 100644 libcxxabi/test/configs/armv7m-libc++abi.cfg.in
+ create mode 100644 libunwind/test/configs/armv7m-libunwind.cfg.in
+
+diff --git a/libcxx/cmake/caches/Armv7M-picolibc.cmake b/libcxx/cmake/caches/Armv7M-picolibc.cmake
+new file mode 100644
+index 000000000000..6ed1866a5084
+--- /dev/null
++++ b/libcxx/cmake/caches/Armv7M-picolibc.cmake
+@@ -0,0 +1,38 @@
++set(CMAKE_ASM_COMPILER_TARGET "armv7m-none-eabi" CACHE STRING "")
++set(CMAKE_CXX_COMPILER_TARGET "armv7m-none-eabi" CACHE STRING "")
++set(CMAKE_CXX_FLAGS "-mfloat-abi=soft" CACHE STRING "")
++set(CMAKE_C_COMPILER_TARGET "armv7m-none-eabi" CACHE STRING "")
++set(CMAKE_C_FLAGS "-mfloat-abi=soft" CACHE STRING "")
++set(CMAKE_SYSTEM_NAME Generic CACHE STRING "")
++set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY CACHE STRING "")
++set(COMPILER_RT_BAREMETAL_BUILD ON CACHE BOOL "")
++set(COMPILER_RT_BUILD_LIBFUZZER OFF CACHE BOOL "")
++set(COMPILER_RT_BUILD_PROFILE OFF CACHE BOOL "")
++set(COMPILER_RT_BUILD_SANITIZERS OFF CACHE BOOL "")
++set(COMPILER_RT_BUILD_XRAY OFF CACHE BOOL "")
++set(COMPILER_RT_DEFAULT_TARGET_ONLY ON CACHE BOOL "")
++set(LIBCXXABI_BAREMETAL ON CACHE BOOL "")
++set(LIBCXXABI_ENABLE_ASSERTIONS OFF CACHE BOOL "")
++set(LIBCXXABI_ENABLE_EXCEPTIONS OFF CACHE BOOL "")
++set(LIBCXXABI_ENABLE_SHARED OFF CACHE BOOL "")
++set(LIBCXXABI_ENABLE_STATIC ON CACHE BOOL "")
++set(LIBCXXABI_ENABLE_THREADS OFF CACHE BOOL "")
++set(LIBCXXABI_USE_COMPILER_RT ON CACHE BOOL "")
++set(LIBCXXABI_USE_LLVM_UNWINDER ON CACHE BOOL "")
++set(LIBCXX_ENABLE_EXCEPTIONS OFF CACHE BOOL "")
++set(LIBCXX_ENABLE_FILESYSTEM OFF CACHE STRING "")
++set(LIBCXX_ENABLE_MONOTONIC_CLOCK OFF CACHE BOOL "")
++set(LIBCXX_ENABLE_RANDOM_DEVICE OFF CACHE BOOL "")
++set(LIBCXX_ENABLE_RTTI OFF CACHE BOOL "")
++set(LIBCXX_ENABLE_SHARED OFF CACHE BOOL "")
++set(LIBCXX_ENABLE_STATIC ON CACHE BOOL "")
++set(LIBCXX_ENABLE_THREADS OFF CACHE BOOL "")
++set(LIBCXX_ENABLE_WIDE_CHARACTERS OFF CACHE BOOL "")
++set(LIBCXX_INCLUDE_BENCHMARKS OFF CACHE BOOL "")
++set(LIBCXX_USE_COMPILER_RT ON CACHE BOOL "")
++set(LIBUNWIND_ENABLE_SHARED OFF CACHE BOOL "")
++set(LIBUNWIND_ENABLE_STATIC ON CACHE BOOL "")
++set(LIBUNWIND_ENABLE_THREADS OFF CACHE BOOL "")
++set(LIBUNWIND_IS_BAREMETAL ON CACHE BOOL "")
++set(LIBUNWIND_REMEMBER_HEAP_ALLOC ON CACHE BOOL "")
++set(LIBUNWIND_USE_COMPILER_RT ON CACHE BOOL "")
+diff --git a/libcxx/docs/index.rst b/libcxx/docs/index.rst
+index 9c2a83bde3c0..4258b423eb93 100644
+--- a/libcxx/docs/index.rst
++++ b/libcxx/docs/index.rst
+@@ -124,15 +124,16 @@ GCC          12              In C++11 or later only     latest stable release pe
+ 
+ Libc++ also supports common platforms and architectures:
+ 
+-=============== ========================= ============================
+-Target platform Target architecture       Notes
+-=============== ========================= ============================
+-macOS 10.9+     i386, x86_64, arm64       Building the shared library itself requires targetting macOS 10.13+
+-FreeBSD 12+     i386, x86_64, arm
+-Linux           i386, x86_64, arm, arm64  Only glibc-2.24 and later and no other libc is officially supported
+-Windows         i386, x86_64              Both MSVC and MinGW style environments, ABI in MSVC environments is :doc:`unstable <DesignDocs/ABIVersioning>`
+-AIX 7.2TL5+     powerpc, powerpc64
+-=============== ========================= ============================
++===================== ========================= ============================
++Target platform       Target architecture       Notes
++===================== ========================= ============================
++macOS 10.9+           i386, x86_64, arm64       Building the shared library itself requires targetting macOS 10.13+
++FreeBSD 12+           i386, x86_64, arm
++Linux                 i386, x86_64, arm, arm64  Only glibc-2.24 and later and no other libc is officially supported
++Windows               i386, x86_64              Both MSVC and MinGW style environments, ABI in MSVC environments is :doc:`unstable <DesignDocs/ABIVersioning>`
++AIX 7.2TL5+           powerpc, powerpc64
++Embedded (picolibc)   arm                       Support for building with picolibc is currently work-in-progress
++===================== ========================= ============================
+ 
+ Generally speaking, libc++ should work on any platform that provides a fairly complete
+ C Standard Library. It is also possible to turn off parts of the library for use on
+diff --git a/libcxx/test/configs/armv7m-libc++.cfg.in b/libcxx/test/configs/armv7m-libc++.cfg.in
+new file mode 100644
+index 000000000000..cb72e5da4838
+--- /dev/null
++++ b/libcxx/test/configs/armv7m-libc++.cfg.in
+@@ -0,0 +1,48 @@
++lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
++
++config.substitutions.append(('%{libc-linker-script}', '@CMAKE_INSTALL_PREFIX@/lib/picolibcpp.ld'))
++
++config.substitutions.append(('%{flags}', '--sysroot=@CMAKE_INSTALL_PREFIX@'))
++
++config.substitutions.append(('%{compile_flags}',
++    '-nostdinc++ -I %{include} -I %{target-include} -I %{libcxx}/test/support'
++
++    # Disable warnings in cxx_atomic_impl.h:
++    # "large atomic operation may incur significant performance penalty; the
++    # access size (4 bytes) exceeds the max lock-free size (0  bytes)"
++    ' -Wno-atomic-alignment'
++
++    # Various libc++ headers check for the definition of _NEWLIB_VERSION
++    # which for picolibc is defined in picolibc.h.
++    ' -include picolibc.h'
++))
++config.substitutions.append(('%{link_flags}',
++    '-nostdlib -nostdlib++ -L %{lib} -lc++ -lc++abi'
++    ' -lc -lm -lclang_rt.builtins -lsemihost -lcrt0-semihost'
++    ' -T %{libc-linker-script}'
++    ' -Wl,--defsym=__flash=0x0'
++    ' -Wl,--defsym=__flash_size=0x400000'
++    ' -Wl,--defsym=__ram=0x21000000'
++    ' -Wl,--defsym=__ram_size=0x1000000'
++    ' -Wl,--defsym=__stack_size=0x1000'
++))
++config.substitutions.append(('%{exec}',
++    'true' # TODO use qemu-system-arm
++))
++
++# LIBCXX-PICOLIBC-FIXME is the feature name used to XFAIL the
++# initial picolibc failures until they can be properly diagnosed
++# and fixed. This allows easier detection of new test failures
++# and regressions. Note: New failures should not be suppressed
++# using this feature.
++config.available_features.add('LIBCXX-PICOLIBC-FIXME')
++
++import os, site
++site.addsitedir(os.path.join('@LIBCXX_SOURCE_DIR@', 'utils'))
++import libcxx.test.params, libcxx.test.config
++libcxx.test.config.configure(
++    libcxx.test.params.DEFAULT_PARAMETERS,
++    libcxx.test.features.DEFAULT_FEATURES,
++    config,
++    lit_config
++)
+diff --git a/libcxx/test/libcxx/clang_modules_include.gen.py b/libcxx/test/libcxx/clang_modules_include.gen.py
+index b4c5c79a47f6..82a114507218 100644
+--- a/libcxx/test/libcxx/clang_modules_include.gen.py
++++ b/libcxx/test/libcxx/clang_modules_include.gen.py
+@@ -39,6 +39,9 @@ for header in public_headers:
+ // TODO: Investigate this failure
+ // UNSUPPORTED{BLOCKLIT}: LIBCXX-FREEBSD-FIXME
+ 
++// TODO: Investigate this failure
++// UNSUPPORTED{BLOCKLIT}: LIBCXX-PICOLIBC-FIXME
++
+ {lit_header_restrictions.get(header, '')}
+ 
+ #include <{header}>
+diff --git a/libcxx/test/libcxx/selftest/dsl/dsl.sh.py b/libcxx/test/libcxx/selftest/dsl/dsl.sh.py
+index dfe290b21fbb..c543898c083b 100644
+--- a/libcxx/test/libcxx/selftest/dsl/dsl.sh.py
++++ b/libcxx/test/libcxx/selftest/dsl/dsl.sh.py
+@@ -6,6 +6,9 @@
+ #
+ # ===----------------------------------------------------------------------===##
+ 
++# Picolibc test executor is `true` at present.
++# XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ # Note: We prepend arguments with 'x' to avoid thinking there are too few
+ #       arguments in case an argument is an empty string.
+ # RUN: %{python} %s x%S x%T x%{substitutions}
+diff --git a/libcxx/test/libcxx/selftest/pass.cpp/run-error.pass.cpp b/libcxx/test/libcxx/selftest/pass.cpp/run-error.pass.cpp
+index eac7d8846e23..035761530078 100644
+--- a/libcxx/test/libcxx/selftest/pass.cpp/run-error.pass.cpp
++++ b/libcxx/test/libcxx/selftest/pass.cpp/run-error.pass.cpp
+@@ -6,6 +6,7 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
+ // XFAIL: *
+ 
+ // Make sure the test DOES NOT pass if it fails at runtime.
+diff --git a/libcxx/test/libcxx/selftest/pass.mm/run-error.pass.mm b/libcxx/test/libcxx/selftest/pass.mm/run-error.pass.mm
+index 22e17666eab0..d3889686b69d 100644
+--- a/libcxx/test/libcxx/selftest/pass.mm/run-error.pass.mm
++++ b/libcxx/test/libcxx/selftest/pass.mm/run-error.pass.mm
+@@ -7,6 +7,7 @@
+ //===----------------------------------------------------------------------===//
+ 
+ // REQUIRES: objective-c++
++// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
+ 
+ // XFAIL: *
+ 
+diff --git a/libcxx/test/libcxx/system_reserved_names.gen.py b/libcxx/test/libcxx/system_reserved_names.gen.py
+index e2aa8fc47348..99ca86cfd830 100644
+--- a/libcxx/test/libcxx/system_reserved_names.gen.py
++++ b/libcxx/test/libcxx/system_reserved_names.gen.py
+@@ -101,7 +101,10 @@ for header in public_headers:
+ # define __pre SYSTEM_RESERVED_NAME
+ #endif
+ 
+-#define __input SYSTEM_RESERVED_NAME
++// Newlib & picolibc use __input as a parameter name of a64l & l64a
++#ifndef _NEWLIB_VERSION
++# define __input SYSTEM_RESERVED_NAME
++#endif
+ #define __output SYSTEM_RESERVED_NAME
+ 
+ #define __acquire SYSTEM_RESERVED_NAME
+diff --git a/libcxx/test/std/atomics/atomics.types.generic/integral.pass.cpp b/libcxx/test/std/atomics/atomics.types.generic/integral.pass.cpp
+index 058db2dc3ab0..a030c63f07fa 100644
+--- a/libcxx/test/std/atomics/atomics.types.generic/integral.pass.cpp
++++ b/libcxx/test/std/atomics/atomics.types.generic/integral.pass.cpp
+@@ -6,6 +6,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// XFAIL: !has-64-bit-atomics
++
+ // <atomic>
+ 
+ // template <>
+diff --git a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add.pass.cpp b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add.pass.cpp
+index 31563789227e..069b64b09784 100644
+--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add.pass.cpp
++++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add.pass.cpp
+@@ -6,6 +6,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// XFAIL: !has-64-bit-atomics
++
+ // <atomic>
+ 
+ // template<class T>
+diff --git a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add_explicit.pass.cpp b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add_explicit.pass.cpp
+index 747a62ae1829..2b75e915d22b 100644
+--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add_explicit.pass.cpp
++++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add_explicit.pass.cpp
+@@ -6,6 +6,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// XFAIL: !has-64-bit-atomics
++
+ // <atomic>
+ 
+ // template<class T>
+diff --git a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_and.pass.cpp b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_and.pass.cpp
+index 04b279ca9d4d..e106e1a38b0b 100644
+--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_and.pass.cpp
++++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_and.pass.cpp
+@@ -6,6 +6,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// XFAIL: !has-64-bit-atomics
++
+ // <atomic>
+ 
+ // template<class T>
+diff --git a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_and_explicit.pass.cpp b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_and_explicit.pass.cpp
+index f6887a28ce14..ed878e222477 100644
+--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_and_explicit.pass.cpp
++++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_and_explicit.pass.cpp
+@@ -6,6 +6,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// XFAIL: !has-64-bit-atomics
++
+ // <atomic>
+ 
+ // template<class T>
+diff --git a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_or.pass.cpp b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_or.pass.cpp
+index 76a66dc6d478..01e73f4503e0 100644
+--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_or.pass.cpp
++++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_or.pass.cpp
+@@ -6,6 +6,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// XFAIL: !has-64-bit-atomics
++
+ // <atomic>
+ 
+ // template<class T>
+diff --git a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_or_explicit.pass.cpp b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_or_explicit.pass.cpp
+index 73161232ae7e..f8ae8fbbd76a 100644
+--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_or_explicit.pass.cpp
++++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_or_explicit.pass.cpp
+@@ -6,6 +6,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// XFAIL: !has-64-bit-atomics
++
+ // <atomic>
+ 
+ // template<class T>
+diff --git a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub.pass.cpp b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub.pass.cpp
+index 37a9586a0ba1..9212f03b0fd9 100644
+--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub.pass.cpp
++++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub.pass.cpp
+@@ -6,6 +6,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// XFAIL: !has-64-bit-atomics
++
+ // <atomic>
+ 
+ // template<class T>
+diff --git a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub_explicit.pass.cpp b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub_explicit.pass.cpp
+index 19240968ee7e..628b81521f19 100644
+--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub_explicit.pass.cpp
++++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub_explicit.pass.cpp
+@@ -6,6 +6,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// XFAIL: !has-64-bit-atomics
++
+ // <atomic>
+ 
+ // template<class T>
+diff --git a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_xor.pass.cpp b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_xor.pass.cpp
+index 3875f9e2161c..0c648fce5749 100644
+--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_xor.pass.cpp
++++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_xor.pass.cpp
+@@ -6,6 +6,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// XFAIL: !has-64-bit-atomics
++
+ // <atomic>
+ 
+ // template<class T>
+diff --git a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_xor_explicit.pass.cpp b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_xor_explicit.pass.cpp
+index 7521a027755d..4bdad43f19ff 100644
+--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_xor_explicit.pass.cpp
++++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_xor_explicit.pass.cpp
+@@ -6,6 +6,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// XFAIL: !has-64-bit-atomics
++
+ // <atomic>
+ 
+ // template<class T>
+diff --git a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/ctor.pass.cpp b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/ctor.pass.cpp
+index 32baca49e307..3ee44a1771b7 100644
+--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/ctor.pass.cpp
++++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/ctor.pass.cpp
+@@ -8,6 +8,8 @@
+ 
+ // UNSUPPORTED: c++03
+ 
++// XFAIL: !has-64-bit-atomics
++
+ // <atomic>
+ 
+ // constexpr atomic<T>::atomic(T value)
+diff --git a/libcxx/test/std/depr/depr.c.headers/fenv_h.compile.pass.cpp b/libcxx/test/std/depr/depr.c.headers/fenv_h.compile.pass.cpp
+index fda5e186c036..dcc97573d607 100644
+--- a/libcxx/test/std/depr/depr.c.headers/fenv_h.compile.pass.cpp
++++ b/libcxx/test/std/depr/depr.c.headers/fenv_h.compile.pass.cpp
+@@ -6,6 +6,9 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// Floating point exceptions are required for the FE_... macros to be defined.
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ // <fenv.h>
+ 
+ #include <fenv.h>
+diff --git a/libcxx/test/std/depr/depr.c.headers/stdio_h.compile.pass.cpp b/libcxx/test/std/depr/depr.c.headers/stdio_h.compile.pass.cpp
+index 27a97627cee3..35be03e41f8f 100644
+--- a/libcxx/test/std/depr/depr.c.headers/stdio_h.compile.pass.cpp
++++ b/libcxx/test/std/depr/depr.c.headers/stdio_h.compile.pass.cpp
+@@ -6,6 +6,9 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// stderr et al are not macros in picolibc's tinystdio.
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ // test <stdio.h>
+ 
+ #include <stdio.h>
+diff --git a/libcxx/test/std/depr/depr.c.headers/uchar_h.compile.pass.cpp b/libcxx/test/std/depr/depr.c.headers/uchar_h.compile.pass.cpp
+index 2b6455466681..a1560c8ee585 100644
+--- a/libcxx/test/std/depr/depr.c.headers/uchar_h.compile.pass.cpp
++++ b/libcxx/test/std/depr/depr.c.headers/uchar_h.compile.pass.cpp
+@@ -11,6 +11,9 @@
+ // Apple platforms don't provide <uchar.h> yet, so these tests fail.
+ // XFAIL: target={{.+}}-apple-{{.+}}
+ 
++// mbrtoc16 not defined.
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ // <uchar.h>
+ 
+ #include <uchar.h>
+diff --git a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cerr.sh.cpp b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cerr.sh.cpp
+index b9e274af7334..9a4b437ab109 100644
+--- a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cerr.sh.cpp
++++ b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cerr.sh.cpp
+@@ -6,6 +6,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
++
+ // <iostream>
+ 
+ // ostream cerr;
+diff --git a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/clog.sh.cpp b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/clog.sh.cpp
+index 476addba050d..783be3a52e94 100644
+--- a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/clog.sh.cpp
++++ b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/clog.sh.cpp
+@@ -6,6 +6,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
++
+ // <iostream>
+ 
+ // ostream clog;
+diff --git a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cout.sh.cpp b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cout.sh.cpp
+index b8d319385ca1..1234da38de03 100644
+--- a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cout.sh.cpp
++++ b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cout.sh.cpp
+@@ -6,6 +6,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
++
+ // <iostream>
+ 
+ // ostream cout;
+diff --git a/libcxx/test/std/iterators/iterator.primitives/iterator.traits/cxx20_iterator_traits.compile.pass.cpp b/libcxx/test/std/iterators/iterator.primitives/iterator.traits/cxx20_iterator_traits.compile.pass.cpp
+index f6b7f6f9d463..f56750bb495e 100644
+--- a/libcxx/test/std/iterators/iterator.primitives/iterator.traits/cxx20_iterator_traits.compile.pass.cpp
++++ b/libcxx/test/std/iterators/iterator.primitives/iterator.traits/cxx20_iterator_traits.compile.pass.cpp
+@@ -11,6 +11,11 @@
+ // This test uses iterator types from std::filesystem
+ // XFAIL: availability-filesystem-missing
+ 
++// std::same_as<typename Traits::difference_type, DiffType> failed.
++// The former was long and the latter was long long.
++// Possibly related to "using streamoff = long int" in ios.h.
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ // template<class T>
+ // struct iterator_traits;
+ 
+diff --git a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array14.pass.cpp b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array14.pass.cpp
+index 21663cdf956d..901f2cca4ce0 100644
+--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array14.pass.cpp
++++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array14.pass.cpp
+@@ -9,6 +9,7 @@
+ // test sized operator delete[] replacement.
+ 
+ // UNSUPPORTED: sanitizer-new-delete, c++03, c++11
++// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
+ 
+ // NOTE: Clang does not enable sized-deallocation in C++14 and beyond by
+ // default. It is only enabled when -fsized-deallocation is given.
+diff --git a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14.pass.cpp b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14.pass.cpp
+index a8701ce7a86c..d0b10b65be28 100644
+--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14.pass.cpp
++++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14.pass.cpp
+@@ -9,6 +9,7 @@
+ // test sized operator delete replacement.
+ 
+ // UNSUPPORTED: sanitizer-new-delete, c++03, c++11
++// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
+ 
+ // NOTE: Clang does not enable sized-deallocation in C++14 and beyond by
+ // default. It is only enabled when -fsized-deallocation is given.
+diff --git a/libcxx/test/std/language.support/support.runtime/ctime.timespec.compile.pass.cpp b/libcxx/test/std/language.support/support.runtime/ctime.timespec.compile.pass.cpp
+index 9a512f6ccfbd..bbf602188ae4 100644
+--- a/libcxx/test/std/language.support/support.runtime/ctime.timespec.compile.pass.cpp
++++ b/libcxx/test/std/language.support/support.runtime/ctime.timespec.compile.pass.cpp
+@@ -13,6 +13,9 @@
+ 
+ // XFAIL: LIBCXX-AIX-FIXME
+ 
++// picolibc doesn't define TIME_UTC.
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ // ::timespec_get is provided by the C library, but it's marked as
+ // unavailable until macOS 10.15
+ // XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+diff --git a/libcxx/test/std/numerics/cfenv/cfenv.syn/cfenv.pass.cpp b/libcxx/test/std/numerics/cfenv/cfenv.syn/cfenv.pass.cpp
+index 557a93cdefe0..7b3b490eba27 100644
+--- a/libcxx/test/std/numerics/cfenv/cfenv.syn/cfenv.pass.cpp
++++ b/libcxx/test/std/numerics/cfenv/cfenv.syn/cfenv.pass.cpp
+@@ -6,6 +6,9 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// Floating point exceptions are required for the FE_... macros to be defined.
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ // <cfenv>
+ 
+ #include <cfenv>
+diff --git a/libcxx/test/std/strings/c.strings/cuchar.compile.pass.cpp b/libcxx/test/std/strings/c.strings/cuchar.compile.pass.cpp
+index db00cbde3336..2076384deb2b 100644
+--- a/libcxx/test/std/strings/c.strings/cuchar.compile.pass.cpp
++++ b/libcxx/test/std/strings/c.strings/cuchar.compile.pass.cpp
+@@ -11,6 +11,9 @@
+ // Apple platforms don't provide <uchar.h> yet, so these tests fail.
+ // XFAIL: target={{.+}}-apple-{{.+}}
+ 
++// mbrtoc16 not defined.
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ // <cuchar>
+ 
+ #include <cuchar>
+diff --git a/libcxx/test/std/time/time.clock/time.clock.file/to_from_sys.pass.cpp b/libcxx/test/std/time/time.clock/time.clock.file/to_from_sys.pass.cpp
+index 5b1f46599111..b1031c815610 100644
+--- a/libcxx/test/std/time/time.clock/time.clock.file/to_from_sys.pass.cpp
++++ b/libcxx/test/std/time/time.clock/time.clock.file/to_from_sys.pass.cpp
+@@ -10,6 +10,9 @@
+ 
+ // UNSUPPORTED: availability-filesystem-missing
+ 
++// "unable to find library from dependent library specifier: rt"
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ // <chrono>
+ //
+ // file_clock
+diff --git a/libcxx/test/std/time/time.clock/time.clock.hires/now.pass.cpp b/libcxx/test/std/time/time.clock/time.clock.hires/now.pass.cpp
+index db1fb55df907..8625ac58bde5 100644
+--- a/libcxx/test/std/time/time.clock/time.clock.hires/now.pass.cpp
++++ b/libcxx/test/std/time/time.clock/time.clock.hires/now.pass.cpp
+@@ -6,6 +6,9 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// "unable to find library from dependent library specifier: rt"
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ // <chrono>
+ 
+ // high_resolution_clock
+diff --git a/libcxx/test/std/time/time.clock/time.clock.system/from_time_t.pass.cpp b/libcxx/test/std/time/time.clock/time.clock.system/from_time_t.pass.cpp
+index 70dd8117e6ce..5ff667445b1a 100644
+--- a/libcxx/test/std/time/time.clock/time.clock.system/from_time_t.pass.cpp
++++ b/libcxx/test/std/time/time.clock/time.clock.system/from_time_t.pass.cpp
+@@ -6,6 +6,9 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// "unable to find library from dependent library specifier: rt"
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ // <chrono>
+ 
+ // system_clock
+diff --git a/libcxx/test/std/time/time.clock/time.clock.system/now.pass.cpp b/libcxx/test/std/time/time.clock/time.clock.system/now.pass.cpp
+index dade6bafa471..70fbe98d8dfd 100644
+--- a/libcxx/test/std/time/time.clock/time.clock.system/now.pass.cpp
++++ b/libcxx/test/std/time/time.clock/time.clock.system/now.pass.cpp
+@@ -6,6 +6,9 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// "unable to find library from dependent library specifier: rt"
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ // <chrono>
+ 
+ // system_clock
+diff --git a/libcxx/test/std/time/time.clock/time.clock.system/to_time_t.pass.cpp b/libcxx/test/std/time/time.clock/time.clock.system/to_time_t.pass.cpp
+index bf4339c32d1c..f3238f7bb1bb 100644
+--- a/libcxx/test/std/time/time.clock/time.clock.system/to_time_t.pass.cpp
++++ b/libcxx/test/std/time/time.clock/time.clock.system/to_time_t.pass.cpp
+@@ -6,6 +6,9 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// "unable to find library from dependent library specifier: rt"
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ // <chrono>
+ 
+ // system_clock
+diff --git a/libcxx/test/std/time/time.point/time.point.nonmember/op_-duration.pass.cpp b/libcxx/test/std/time/time.point/time.point.nonmember/op_-duration.pass.cpp
+index 80e9d04a769f..199bdec66878 100644
+--- a/libcxx/test/std/time/time.point/time.point.nonmember/op_-duration.pass.cpp
++++ b/libcxx/test/std/time/time.point/time.point.nonmember/op_-duration.pass.cpp
+@@ -6,6 +6,9 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// "unable to find library from dependent library specifier: rt"
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ // <chrono>
+ 
+ // time_point
+diff --git a/libcxx/utils/ci/BOT_OWNERS.txt b/libcxx/utils/ci/BOT_OWNERS.txt
+index f6eb91cdac4b..4adb45ca02e2 100644
+--- a/libcxx/utils/ci/BOT_OWNERS.txt
++++ b/libcxx/utils/ci/BOT_OWNERS.txt
+@@ -10,7 +10,7 @@ least the (N), (E) and (D) fields.
+ 
+ N: Linaro Toolchain Working Group
+ E: linaro-toolchain@lists.linaro.org
+-D: Armv7, Armv8, AArch64
++D: Arm platforms
+ 
+ N: LLVM on Power
+ E: powerllvm@ca.ibm.com
+diff --git a/libcxx/utils/ci/build-picolibc.sh b/libcxx/utils/ci/build-picolibc.sh
+new file mode 100755
+index 000000000000..acdcabe96e96
+--- /dev/null
++++ b/libcxx/utils/ci/build-picolibc.sh
+@@ -0,0 +1,109 @@
++#!/usr/bin/env bash
++#===----------------------------------------------------------------------===##
++#
++# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
++# See https://llvm.org/LICENSE.txt for license information.
++# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
++#
++#===----------------------------------------------------------------------===##
++
++#
++# This script builds picolibc (https://github.com/picolibc/picolibc) from
++# source to facilitate building libc++ against it.
++#
++
++set -e
++
++PROGNAME="$(basename "${0}")"
++
++function error() { printf "error: %s\n" "$*" >&2; exit 1; }
++
++function usage() {
++cat <<EOF
++Usage:
++${PROGNAME} [options]
++
++[-h|--help]                  Display this help and exit.
++
++--build-dir <DIR>            Path to the directory to use for building.
++
++--install-dir <DIR>          Path to the directory to install the library to.
++EOF
++}
++
++while [[ $# -gt 0 ]]; do
++    case ${1} in
++        -h|--help)
++            usage
++            exit 0
++            ;;
++        --build-dir)
++            build_dir="${2}"
++            shift; shift
++            ;;
++        --install-dir)
++            install_dir="${2}"
++            shift; shift
++            ;;
++        --target)
++            target="${2}"
++            shift; shift
++            ;;
++        *)
++            error "Unknown argument '${1}'"
++            ;;
++    esac
++done
++
++for arg in build_dir install_dir target; do
++    if [ -z ${!arg+x} ]; then
++        error "Missing required argument '--${arg//_/-}'"
++    elif [ "${!arg}" == "" ]; then
++        error "Argument to --${arg//_/-} must not be empty"
++    fi
++done
++
++
++echo "--- Downloading picolibc"
++picolibc_source_dir="${build_dir}/picolibc-source"
++picolibc_build_dir="${build_dir}/picolibc-build"
++mkdir -p "${picolibc_source_dir}"
++mkdir -p "${picolibc_build_dir}"
++# Download the version of picolibc that was the latest at the time this script was written.
++# The picolibc linker script was changed after version 1.8.2 to work with ld.lld so a
++# more recent version is required, which at the time of writing is not yet released.
++picolibc_commit="8dd225aa1469c03805617106020d494912c6d265"
++curl -L "https://github.com/picolibc/picolibc/archive/${picolibc_commit}.zip" --output "${picolibc_source_dir}/picolibc.zip"
++unzip -q "${picolibc_source_dir}/picolibc.zip" -d "${picolibc_source_dir}"
++mv "${picolibc_source_dir}/picolibc-${picolibc_commit}"/* "${picolibc_source_dir}"
++rm -rf "${picolibc_source_dir}/picolibc-${picolibc_commit}"
++
++cat <<EOF > "${picolibc_build_dir}/meson-cross-build.txt"
++[binaries]
++c = ['${CC:-cc}', '--target=${target}', '-mfloat-abi=soft', '-nostdlib']
++ar = 'llvm-ar'
++as = 'llvm-as'
++ld = 'lld'
++strip = 'llvm-strip'
++[host_machine]
++system = 'none'
++cpu_family = 'arm'
++cpu = 'arm'
++endian = 'little'
++[properties]
++skip_sanity_check = true
++EOF
++
++venv_dir="${build_dir}/meson-venv"
++python3 -m venv "${venv_dir}"
++# Install the version of meson that was the latest at the time this script was written.
++"${venv_dir}/bin/pip" install "meson==1.1.1"
++
++"${venv_dir}/bin/meson" setup \
++  -Dincludedir=include -Dlibdir=lib -Dspecsdir=none -Dmultilib=false -Dpicoexit=false \
++  --prefix "${install_dir}" \
++  --cross-file "${picolibc_build_dir}/meson-cross-build.txt" \
++  "${picolibc_build_dir}" \
++  "${picolibc_source_dir}"
++
++"${venv_dir}/bin/meson" install -C "${picolibc_build_dir}"
+diff --git a/libcxx/utils/ci/buildkite-pipeline.yml b/libcxx/utils/ci/buildkite-pipeline.yml
+index ebfb35eee91e..01ed5f4b78d2 100644
+--- a/libcxx/utils/ci/buildkite-pipeline.yml
++++ b/libcxx/utils/ci/buildkite-pipeline.yml
+@@ -1078,6 +1078,20 @@ steps:
+             limit: 2
+       timeout_in_minutes: 120
+ 
++    - label: "Armv7-M picolibc"
++      command: "libcxx/utils/ci/run-buildbot armv7m-picolibc"
++      artifact_paths:
++        - "**/test-results.xml"
++        - "**/*.abilist"
++      agents:
++        queue: "libcxx-builders-linaro-arm"
++        arch: "aarch64"
++      retry:
++        automatic:
++          - exit_status: -1  # Agent was lost
++            limit: 2
++      timeout_in_minutes: 120
++
+   - group: "AIX"
+     steps:
+     - label: "AIX (32-bit)"
+diff --git a/libcxx/utils/ci/run-buildbot b/libcxx/utils/ci/run-buildbot
+index a71318123db3..a95911cd9d29 100755
+--- a/libcxx/utils/ci/run-buildbot
++++ b/libcxx/utils/ci/run-buildbot
+@@ -616,6 +616,41 @@ armv7-no-exceptions)
+     generate-cmake -C "${MONOREPO_ROOT}/libcxx/cmake/caches/Armv7Thumb-no-exceptions.cmake"
+     check-runtimes
+ ;;
++armv7m-picolibc)
++    clean
++
++    # To make it easier to get this builder up and running, build picolibc
++    # from scratch. Anecdotally, the build-picolibc script takes about 16 seconds.
++    # This could be optimised by building picolibc into the Docker container.
++    ${MONOREPO_ROOT}/libcxx/utils/ci/build-picolibc.sh \
++        --build-dir "${BUILD_DIR}" \
++        --install-dir "${INSTALL_DIR}" \
++        --target armv7m-none-eabi
++
++    echo "--- Generating CMake"
++    flags="--sysroot=${INSTALL_DIR}"
++    ${CMAKE} \
++        -S "${MONOREPO_ROOT}/compiler-rt" \
++        -B "${BUILD_DIR}/compiler-rt" \
++        -GNinja -DCMAKE_MAKE_PROGRAM="${NINJA}" \
++        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
++        -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
++        -C "${MONOREPO_ROOT}/libcxx/cmake/caches/Armv7M-picolibc.cmake" \
++        -DCMAKE_C_FLAGS="${flags}" \
++        -DCMAKE_CXX_FLAGS="${flags}" \
++        -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON
++    generate-cmake -C "${MONOREPO_ROOT}/libcxx/cmake/caches/Armv7M-picolibc.cmake" \
++        -DLIBCXX_TEST_CONFIG="armv7m-libc++.cfg.in" \
++        -DLIBCXXABI_TEST_CONFIG="armv7m-libc++abi.cfg.in" \
++        -DLIBUNWIND_TEST_CONFIG="armv7m-libunwind.cfg.in" \
++        -DCMAKE_C_FLAGS="${flags}" \
++        -DCMAKE_CXX_FLAGS="${flags}"
++
++    ${NINJA} -vC "${BUILD_DIR}/compiler-rt" install
++    mv "${BUILD_DIR}/install/lib/armv7m-none-eabi"/* "${BUILD_DIR}/install/lib"
++
++    check-runtimes
++;;
+ clang-cl-dll)
+     clean
+     # TODO: Currently, building with the experimental library breaks running
+diff --git a/libcxx/utils/libcxx/test/features.py b/libcxx/utils/libcxx/test/features.py
+index 3779af1094d5..f6ac01c8468d 100644
+--- a/libcxx/utils/libcxx/test/features.py
++++ b/libcxx/utils/libcxx/test/features.py
+@@ -94,6 +94,17 @@ DEFAULT_FEATURES = [
+         name="verify-support",
+         when=lambda cfg: hasCompileFlag(cfg, "-Xclang -verify-ignore-unexpected"),
+     ),
++    Feature(
++        name="has-64-bit-atomics",
++        when=lambda cfg: sourceBuilds(
++            cfg,
++            """
++            #include <atomic>
++            std::atomic_uint64_t x;
++            int main(int, char**) { (void)x.load(); return 0; }
++          """,
++        ),
++    ),
+     Feature(
+         name="non-lockfree-atomics",
+         when=lambda cfg: sourceBuilds(
+@@ -199,7 +210,8 @@ DEFAULT_FEATURES = [
+             #include <unistd.h>
+             #include <sys/wait.h>
+             int main(int, char**) {
+-              return 0;
++              int fd[2];
++              return pipe(fd);
+             }
+           """,
+         ),
+diff --git a/libcxxabi/test/configs/armv7m-libc++abi.cfg.in b/libcxxabi/test/configs/armv7m-libc++abi.cfg.in
+new file mode 100644
+index 000000000000..d022e84fb19e
+--- /dev/null
++++ b/libcxxabi/test/configs/armv7m-libc++abi.cfg.in
+@@ -0,0 +1,39 @@
++lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
++
++config.substitutions.append(('%{libc-linker-script}', '@CMAKE_INSTALL_PREFIX@/lib/picolibcpp.ld'))
++
++config.substitutions.append(('%{flags}', '--sysroot=@CMAKE_INSTALL_PREFIX@'))
++
++config.substitutions.append(('%{compile_flags}',
++    '-nostdinc++ -I %{include} -I %{cxx-include} -I %{cxx-target-include} %{maybe-include-libunwind} -I %{libcxx}/test/support -I %{libcxx}/src -D_LIBCPP_ENABLE_CXX17_REMOVED_UNEXPECTED_FUNCTIONS'
++))
++config.substitutions.append(('%{link_flags}',
++    '-nostdlib -nostdlib++ -L %{lib} -lc++ -lc++abi'
++    ' -lc -lm -lclang_rt.builtins -lsemihost -lcrt0-semihost'
++    ' -T %{libc-linker-script}'
++    ' -Wl,--defsym=__flash=0x0'
++    ' -Wl,--defsym=__flash_size=0x400000'
++    ' -Wl,--defsym=__ram=0x21000000'
++    ' -Wl,--defsym=__ram_size=0x1000000'
++    ' -Wl,--defsym=__stack_size=0x1000'
++))
++config.substitutions.append(('%{exec}',
++    'true' # TODO use qemu-system-arm
++))
++
++# LIBCXX-PICOLIBC-FIXME is the feature name used to XFAIL the
++# initial picolibc failures until they can be properly diagnosed
++# and fixed. This allows easier detection of new test failures
++# and regressions. Note: New failures should not be suppressed
++# using this feature.
++config.available_features.add('LIBCXX-PICOLIBC-FIXME')
++
++import os, site
++site.addsitedir(os.path.join('@LIBCXXABI_LIBCXX_PATH@', 'utils'))
++import libcxx.test.params, libcxx.test.config
++libcxx.test.config.configure(
++    libcxx.test.params.DEFAULT_PARAMETERS,
++    libcxx.test.features.DEFAULT_FEATURES,
++    config,
++    lit_config
++)
+diff --git a/libcxxabi/test/test_demangle.pass.cpp b/libcxxabi/test/test_demangle.pass.cpp
+index df7bedc73c28..ee35a4171ef0 100644
+--- a/libcxxabi/test/test_demangle.pass.cpp
++++ b/libcxxabi/test/test_demangle.pass.cpp
+@@ -9,6 +9,9 @@
+ // The demangler does not pass all these tests with the system dylibs on macOS.
+ // XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14|15}}
+ 
++// This test is too big for most embedded devices.
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ // https://llvm.org/PR51407 was not fixed in some previously-released
+ // demanglers, which causes them to run into the infinite loop.
+ // UNSUPPORTED: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14|15}}
+diff --git a/libcxxabi/test/test_exception_storage.pass.cpp b/libcxxabi/test/test_exception_storage.pass.cpp
+index 03393c402cd4..9dca5aa23360 100644
+--- a/libcxxabi/test/test_exception_storage.pass.cpp
++++ b/libcxxabi/test/test_exception_storage.pass.cpp
+@@ -8,6 +8,9 @@
+ 
+ // UNSUPPORTED: c++03
+ 
++// This test fails with picolibc since 42d55676833bacfdc6ec66785b74a7a51e6de474
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ #include "assert_macros.h"
+ #include "concat_macros.h"
+ #include "../src/cxa_exception.h"
+diff --git a/libunwind/test/configs/armv7m-libunwind.cfg.in b/libunwind/test/configs/armv7m-libunwind.cfg.in
+new file mode 100644
+index 000000000000..5f15ccd3613c
+--- /dev/null
++++ b/libunwind/test/configs/armv7m-libunwind.cfg.in
+@@ -0,0 +1,32 @@
++lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
++
++config.substitutions.append(('%{libc-linker-script}', '@CMAKE_INSTALL_PREFIX@/lib/picolibcpp.ld'))
++
++config.substitutions.append(('%{flags}', '--sysroot=@CMAKE_INSTALL_PREFIX@'))
++
++config.substitutions.append(('%{compile_flags}',
++    '-nostdinc++ -I %{include}'
++))
++config.substitutions.append(('%{link_flags}',
++    '-nostdlib -nostdlib++ -L %{lib} -lunwind'
++    ' -lc -lm -lclang_rt.builtins -lsemihost -lcrt0-semihost'
++    ' -T %{libc-linker-script}'
++    ' -Wl,--defsym=__flash=0x0'
++    ' -Wl,--defsym=__flash_size=0x400000'
++    ' -Wl,--defsym=__ram=0x21000000'
++    ' -Wl,--defsym=__ram_size=0x1000000'
++    ' -Wl,--defsym=__stack_size=0x1000'
++))
++config.substitutions.append(('%{exec}',
++    'true' # TODO use qemu-system-arm
++))
++
++import os, site
++site.addsitedir(os.path.join('@LIBUNWIND_LIBCXX_PATH@', 'utils'))
++import libcxx.test.params, libcxx.test.config
++libcxx.test.config.configure(
++    libcxx.test.params.DEFAULT_PARAMETERS,
++    libcxx.test.features.DEFAULT_FEATURES,
++    config,
++    lit_config
++)
+-- 
+2.34.1
+

--- a/patches/llvm-project/0003-Run-picolibc-tests-with-qemu.patch
+++ b/patches/llvm-project/0003-Run-picolibc-tests-with-qemu.patch
@@ -1,0 +1,366 @@
+From ed4600a83ab1ad56673706299f6a28dad8bf1d24 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
+Date: Tue, 10 Oct 2023 15:45:54 +0200
+Subject: [PATCH 3/3] Run picolibc tests with qemu
+
+---
+ libcxx/cmake/caches/Armv7M-picolibc.cmake     |  1 +
+ libcxx/docs/index.rst                         |  2 +-
+ libcxx/test/configs/armv7m-libc++.cfg.in      | 10 ++++++-
+ libcxx/test/libcxx/selftest/dsl/dsl.sh.py     |  3 ++-
+ .../selftest/pass.cpp/run-error.pass.cpp      |  1 -
+ .../libcxx/selftest/pass.mm/run-error.pass.mm |  1 -
+ .../libcxx/selftest/stdin-is-piped.sh.cpp     |  2 ++
+ .../alg.sorting/alg.sort/sort/sort.pass.cpp   |  3 +++
+ .../generic_category.pass.cpp                 |  1 +
+ .../system_category.pass.cpp                  |  1 +
+ .../narrow.stream.objects/cerr.sh.cpp         |  2 +-
+ .../narrow.stream.objects/cin.sh.cpp          |  1 +
+ .../narrow.stream.objects/clog.sh.cpp         |  2 +-
+ .../narrow.stream.objects/cout.sh.cpp         |  2 --
+ .../sized_delete_array14.pass.cpp             |  1 -
+ .../new.delete.single/sized_delete14.pass.cpp |  1 -
+ .../classic_table.pass.cpp                    |  2 ++
+ .../put_long_double.pass.cpp                  |  1 +
+ .../rand.dist.bern.bin/eval.PR44847.pass.cpp  |  3 +++
+ .../time.clock/time.clock.file/now.pass.cpp   |  3 +++
+ libcxx/utils/run-qemu.sh                      | 27 +++++++++++++++++++
+ .../test/configs/armv7m-libc++abi.cfg.in      |  7 ++++-
+ .../test/configs/armv7m-libunwind.cfg.in      |  7 ++++-
+ 23 files changed, 71 insertions(+), 13 deletions(-)
+ create mode 100755 libcxx/utils/run-qemu.sh
+
+diff --git a/libcxx/cmake/caches/Armv7M-picolibc.cmake b/libcxx/cmake/caches/Armv7M-picolibc.cmake
+index 6ed1866a5084..e308ac31d1d1 100644
+--- a/libcxx/cmake/caches/Armv7M-picolibc.cmake
++++ b/libcxx/cmake/caches/Armv7M-picolibc.cmake
+@@ -36,3 +36,4 @@ set(LIBUNWIND_ENABLE_THREADS OFF CACHE BOOL "")
+ set(LIBUNWIND_IS_BAREMETAL ON CACHE BOOL "")
+ set(LIBUNWIND_REMEMBER_HEAP_ALLOC ON CACHE BOOL "")
+ set(LIBUNWIND_USE_COMPILER_RT ON CACHE BOOL "")
++find_program(QEMU_SYSTEM_ARM qemu-system-arm)
+diff --git a/libcxx/docs/index.rst b/libcxx/docs/index.rst
+index 4258b423eb93..2e91265655a4 100644
+--- a/libcxx/docs/index.rst
++++ b/libcxx/docs/index.rst
+@@ -132,7 +132,7 @@ FreeBSD 12+           i386, x86_64, arm
+ Linux                 i386, x86_64, arm, arm64  Only glibc-2.24 and later and no other libc is officially supported
+ Windows               i386, x86_64              Both MSVC and MinGW style environments, ABI in MSVC environments is :doc:`unstable <DesignDocs/ABIVersioning>`
+ AIX 7.2TL5+           powerpc, powerpc64
+-Embedded (picolibc)   arm                       Support for building with picolibc is currently work-in-progress
++Embedded (picolibc)   arm
+ ===================== ========================= ============================
+ 
+ Generally speaking, libc++ should work on any platform that provides a fairly complete
+diff --git a/libcxx/test/configs/armv7m-libc++.cfg.in b/libcxx/test/configs/armv7m-libc++.cfg.in
+index cb72e5da4838..88241fa06ded 100644
+--- a/libcxx/test/configs/armv7m-libc++.cfg.in
++++ b/libcxx/test/configs/armv7m-libc++.cfg.in
+@@ -27,9 +27,17 @@ config.substitutions.append(('%{link_flags}',
+     ' -Wl,--defsym=__stack_size=0x1000'
+ ))
+ config.substitutions.append(('%{exec}',
+-    'true' # TODO use qemu-system-arm
++    '%{executor}'
++    ' --execdir %T'
++    ' @LIBCXX_SOURCE_DIR@/utils/run-qemu.sh'
++    ' @QEMU_SYSTEM_ARM@'
++    ' mps2-an385'
++    ' cortex-m3'
+ ))
+ 
++# Long tests are prohibitively slow when run via emulation.
++config.long_tests = False
++
+ # LIBCXX-PICOLIBC-FIXME is the feature name used to XFAIL the
+ # initial picolibc failures until they can be properly diagnosed
+ # and fixed. This allows easier detection of new test failures
+diff --git a/libcxx/test/libcxx/selftest/dsl/dsl.sh.py b/libcxx/test/libcxx/selftest/dsl/dsl.sh.py
+index c543898c083b..012759436d89 100644
+--- a/libcxx/test/libcxx/selftest/dsl/dsl.sh.py
++++ b/libcxx/test/libcxx/selftest/dsl/dsl.sh.py
+@@ -6,7 +6,8 @@
+ #
+ # ===----------------------------------------------------------------------===##
+ 
+-# Picolibc test executor is `true` at present.
++# With picolibc, test_program_stderr_is_not_conflated_with_stdout fails
++# because stdout & stderr are treated as the same.
+ # XFAIL: LIBCXX-PICOLIBC-FIXME
+ 
+ # Note: We prepend arguments with 'x' to avoid thinking there are too few
+diff --git a/libcxx/test/libcxx/selftest/pass.cpp/run-error.pass.cpp b/libcxx/test/libcxx/selftest/pass.cpp/run-error.pass.cpp
+index 035761530078..eac7d8846e23 100644
+--- a/libcxx/test/libcxx/selftest/pass.cpp/run-error.pass.cpp
++++ b/libcxx/test/libcxx/selftest/pass.cpp/run-error.pass.cpp
+@@ -6,7 +6,6 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
+-// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
+ // XFAIL: *
+ 
+ // Make sure the test DOES NOT pass if it fails at runtime.
+diff --git a/libcxx/test/libcxx/selftest/pass.mm/run-error.pass.mm b/libcxx/test/libcxx/selftest/pass.mm/run-error.pass.mm
+index d3889686b69d..22e17666eab0 100644
+--- a/libcxx/test/libcxx/selftest/pass.mm/run-error.pass.mm
++++ b/libcxx/test/libcxx/selftest/pass.mm/run-error.pass.mm
+@@ -7,7 +7,6 @@
+ //===----------------------------------------------------------------------===//
+ 
+ // REQUIRES: objective-c++
+-// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
+ 
+ // XFAIL: *
+ 
+diff --git a/libcxx/test/libcxx/selftest/stdin-is-piped.sh.cpp b/libcxx/test/libcxx/selftest/stdin-is-piped.sh.cpp
+index ffd10631c6a6..897e10e94783 100644
+--- a/libcxx/test/libcxx/selftest/stdin-is-piped.sh.cpp
++++ b/libcxx/test/libcxx/selftest/stdin-is-piped.sh.cpp
+@@ -8,6 +8,8 @@
+ 
+ // Make sure that the executor pipes standard input to the test-executable being run.
+ 
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ // RUN: %{build}
+ // RUN: echo "abc" | %{exec} %t.exe
+ 
+diff --git a/libcxx/test/std/algorithms/alg.sorting/alg.sort/sort/sort.pass.cpp b/libcxx/test/std/algorithms/alg.sorting/alg.sort/sort/sort.pass.cpp
+index ed26c5b861f5..56c0964c8750 100644
+--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/sort/sort.pass.cpp
++++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/sort/sort.pass.cpp
+@@ -6,6 +6,9 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// This test appears to hang with picolibc & qemu.
++// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
++
+ // <algorithm>
+ 
+ // template<RandomAccessIterator Iter>
+diff --git a/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/generic_category.pass.cpp b/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/generic_category.pass.cpp
+index 90e5bd39e5b0..49ec48c7bc95 100644
+--- a/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/generic_category.pass.cpp
++++ b/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/generic_category.pass.cpp
+@@ -8,6 +8,7 @@
+ 
+ // XFAIL: suse-linux-enterprise-server-11
+ // XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.{{9|10|11|12}}
++// XFAIL: LIBCXX-PICOLIBC-FIXME
+ 
+ // <system_error>
+ 
+diff --git a/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/system_category.pass.cpp b/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/system_category.pass.cpp
+index 1de1b59e5c6c..5ebc7a056b71 100644
+--- a/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/system_category.pass.cpp
++++ b/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/system_category.pass.cpp
+@@ -14,6 +14,7 @@
+ 
+ // XFAIL: suse-linux-enterprise-server-11
+ // XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.{{9|10|11|12}}
++// XFAIL: LIBCXX-PICOLIBC-FIXME
+ 
+ #include <system_error>
+ #include <cassert>
+diff --git a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cerr.sh.cpp b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cerr.sh.cpp
+index 9a4b437ab109..da5563f87df4 100644
+--- a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cerr.sh.cpp
++++ b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cerr.sh.cpp
+@@ -6,7 +6,7 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
+-// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
++// XFAIL: LIBCXX-PICOLIBC-FIXME
+ 
+ // <iostream>
+ 
+diff --git a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cin.sh.cpp b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cin.sh.cpp
+index b39cd57ab212..65c21658f91d 100644
+--- a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cin.sh.cpp
++++ b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cin.sh.cpp
+@@ -8,6 +8,7 @@
+ 
+ // TODO: Investigate
+ // UNSUPPORTED: LIBCXX-AIX-FIXME
++// XFAIL: LIBCXX-PICOLIBC-FIXME
+ 
+ // <iostream>
+ 
+diff --git a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/clog.sh.cpp b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/clog.sh.cpp
+index 783be3a52e94..9bedd67e816e 100644
+--- a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/clog.sh.cpp
++++ b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/clog.sh.cpp
+@@ -6,7 +6,7 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
+-// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
++// XFAIL: LIBCXX-PICOLIBC-FIXME
+ 
+ // <iostream>
+ 
+diff --git a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cout.sh.cpp b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cout.sh.cpp
+index 1234da38de03..b8d319385ca1 100644
+--- a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cout.sh.cpp
++++ b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cout.sh.cpp
+@@ -6,8 +6,6 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
+-// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
+-
+ // <iostream>
+ 
+ // ostream cout;
+diff --git a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array14.pass.cpp b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array14.pass.cpp
+index 901f2cca4ce0..21663cdf956d 100644
+--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array14.pass.cpp
++++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array14.pass.cpp
+@@ -9,7 +9,6 @@
+ // test sized operator delete[] replacement.
+ 
+ // UNSUPPORTED: sanitizer-new-delete, c++03, c++11
+-// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
+ 
+ // NOTE: Clang does not enable sized-deallocation in C++14 and beyond by
+ // default. It is only enabled when -fsized-deallocation is given.
+diff --git a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14.pass.cpp b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14.pass.cpp
+index d0b10b65be28..a8701ce7a86c 100644
+--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14.pass.cpp
++++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14.pass.cpp
+@@ -9,7 +9,6 @@
+ // test sized operator delete replacement.
+ 
+ // UNSUPPORTED: sanitizer-new-delete, c++03, c++11
+-// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
+ 
+ // NOTE: Clang does not enable sized-deallocation in C++14 and beyond by
+ // default. It is only enabled when -fsized-deallocation is given.
+diff --git a/libcxx/test/std/localization/locale.categories/category.ctype/facet.ctype.special/facet.ctype.char.statics/classic_table.pass.cpp b/libcxx/test/std/localization/locale.categories/category.ctype/facet.ctype.special/facet.ctype.char.statics/classic_table.pass.cpp
+index 8fe8080bde98..50c60180ce0d 100644
+--- a/libcxx/test/std/localization/locale.categories/category.ctype/facet.ctype.special/facet.ctype.char.statics/classic_table.pass.cpp
++++ b/libcxx/test/std/localization/locale.categories/category.ctype/facet.ctype.special/facet.ctype.char.statics/classic_table.pass.cpp
+@@ -6,6 +6,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ // <locale>
+ 
+ // template <> class ctype<char>
+diff --git a/libcxx/test/std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_long_double.pass.cpp b/libcxx/test/std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_long_double.pass.cpp
+index 3327a35a6045..2a0c2a49ec51 100644
+--- a/libcxx/test/std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_long_double.pass.cpp
++++ b/libcxx/test/std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_long_double.pass.cpp
+@@ -13,6 +13,7 @@
+ // iter_type put(iter_type s, ios_base& iob, char_type fill, long double v) const;
+ 
+ // XFAIL: win32-broken-printf-g-precision
++// XFAIL: LIBCXX-PICOLIBC-FIXME
+ 
+ #include <locale>
+ #include <ios>
+diff --git a/libcxx/test/std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.bin/eval.PR44847.pass.cpp b/libcxx/test/std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.bin/eval.PR44847.pass.cpp
+index 9213d2bac5a6..572a59b7a192 100644
+--- a/libcxx/test/std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.bin/eval.PR44847.pass.cpp
++++ b/libcxx/test/std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.bin/eval.PR44847.pass.cpp
+@@ -18,6 +18,9 @@
+ // Serializing/deserializing the state of the RNG requires iostreams
+ // UNSUPPORTED: no-localization
+ 
++// This test appears to hang with picolibc & qemu.
++// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
++
+ #include <random>
+ #include <numeric>
+ #include <vector>
+diff --git a/libcxx/test/std/time/time.clock/time.clock.file/now.pass.cpp b/libcxx/test/std/time/time.clock/time.clock.file/now.pass.cpp
+index 0852483a8b39..4ba17a48988b 100644
+--- a/libcxx/test/std/time/time.clock/time.clock.file/now.pass.cpp
++++ b/libcxx/test/std/time/time.clock/time.clock.file/now.pass.cpp
+@@ -10,6 +10,9 @@
+ 
+ // UNSUPPORTED: availability-filesystem-missing
+ 
++// qemu: Unsupported SemiHosting SWI 0x30
++// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
++
+ // <chrono>
+ 
+ // file_clock
+diff --git a/libcxx/utils/run-qemu.sh b/libcxx/utils/run-qemu.sh
+new file mode 100755
+index 000000000000..7a9a8acb95ad
+--- /dev/null
++++ b/libcxx/utils/run-qemu.sh
+@@ -0,0 +1,27 @@
++#!/bin/sh
++
++# This script makes it easy to pass an image and arguments to qemu.
++
++# Usage:
++# run-qemu.sh QEMU_EXECUTABLE MACHINE CPU IMAGE ARGS...
++
++QEMU_EXECUTABLE=$1; shift
++MACHINE=$1; shift
++CPU=$1; shift
++IMAGE=$1; shift
++
++semihosting_config="enable=on,chardev=stdio0"
++for arg in "$@"
++do
++    semihosting_config="${semihosting_config},arg=${arg}"
++done
++
++"${QEMU_EXECUTABLE}" \
++    -chardev stdio,mux=on,id=stdio0 \
++    -semihosting-config "${semihosting_config}" \
++    -monitor none \
++    -serial none \
++    -machine "${MACHINE},accel=tcg" \
++    -cpu "${CPU}" \
++    -device loader,file="${IMAGE}",cpu-num=0 \
++    -nographic
+diff --git a/libcxxabi/test/configs/armv7m-libc++abi.cfg.in b/libcxxabi/test/configs/armv7m-libc++abi.cfg.in
+index d022e84fb19e..9962541426a1 100644
+--- a/libcxxabi/test/configs/armv7m-libc++abi.cfg.in
++++ b/libcxxabi/test/configs/armv7m-libc++abi.cfg.in
+@@ -18,7 +18,12 @@ config.substitutions.append(('%{link_flags}',
+     ' -Wl,--defsym=__stack_size=0x1000'
+ ))
+ config.substitutions.append(('%{exec}',
+-    'true' # TODO use qemu-system-arm
++    '%{executor}'
++    ' --execdir %T'
++    ' @LIBCXXABI_LIBCXX_PATH@/utils/run-qemu.sh'
++    ' @QEMU_SYSTEM_ARM@'
++    ' mps2-an385'
++    ' cortex-m3'
+ ))
+ 
+ # LIBCXX-PICOLIBC-FIXME is the feature name used to XFAIL the
+diff --git a/libunwind/test/configs/armv7m-libunwind.cfg.in b/libunwind/test/configs/armv7m-libunwind.cfg.in
+index 5f15ccd3613c..2004c8010883 100644
+--- a/libunwind/test/configs/armv7m-libunwind.cfg.in
++++ b/libunwind/test/configs/armv7m-libunwind.cfg.in
+@@ -18,7 +18,12 @@ config.substitutions.append(('%{link_flags}',
+     ' -Wl,--defsym=__stack_size=0x1000'
+ ))
+ config.substitutions.append(('%{exec}',
+-    'true' # TODO use qemu-system-arm
++    '%{executor}'
++    ' --execdir %T'
++    ' @LIBUNWIND_LIBCXX_PATH@/utils/run-qemu.sh'
++    ' @QEMU_SYSTEM_ARM@'
++    ' mps2-an385'
++    ' cortex-m3'
+ ))
+ 
+ import os, site
+-- 
+2.34.1
+

--- a/patches/llvm-project/0004-xfail-two-remaining-libcxx-with-picolibc-tests.patch
+++ b/patches/llvm-project/0004-xfail-two-remaining-libcxx-with-picolibc-tests.patch
@@ -1,0 +1,43 @@
+From 97129cae67b401c7e46ca7e7ed4381178181443a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
+Date: Mon, 16 Oct 2023 11:35:48 +0200
+Subject: [PATCH 4/4] xfail two remaining libcxx with picolibc tests
+
+---
+ .../cmp/cmp.alg/strong_order_long_double.verify.cpp          | 5 +++++
+ .../language.support/support.start.term/quick_exit.pass.cpp  | 3 +++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/libcxx/test/std/language.support/cmp/cmp.alg/strong_order_long_double.verify.cpp b/libcxx/test/std/language.support/cmp/cmp.alg/strong_order_long_double.verify.cpp
+index fd16afeefb03..004ebc0a6bcd 100644
+--- a/libcxx/test/std/language.support/cmp/cmp.alg/strong_order_long_double.verify.cpp
++++ b/libcxx/test/std/language.support/cmp/cmp.alg/strong_order_long_double.verify.cpp
+@@ -12,6 +12,11 @@
+ // This test does apply to aarch64 where Arm's AAPCS64 is followed. There they are different sizes.
+ // UNSUPPORTED: target={{arm64|arm64e|armv(7|8)(l|m)?|powerpc|powerpc64}}-{{.+}}
+ 
++// In internal LLVM arm BMT tests the target is fixed to "arm-none-eabi", so the
++// "unsupported" cluase above does not work. TODO: find more generic way to
++// detect equal sizes of double and long double
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ // MSVC configurations have long double equal to regular double on all
+ // architectures.
+ // UNSUPPORTED: target={{.+}}-pc-windows-msvc
+diff --git a/libcxx/test/std/language.support/support.start.term/quick_exit.pass.cpp b/libcxx/test/std/language.support/support.start.term/quick_exit.pass.cpp
+index 5a70ea5bd570..92dfbe8eb1ab 100644
+--- a/libcxx/test/std/language.support/support.start.term/quick_exit.pass.cpp
++++ b/libcxx/test/std/language.support/support.start.term/quick_exit.pass.cpp
+@@ -16,6 +16,9 @@
+ 
+ // test quick_exit and at_quick_exit
+ 
++// TODO: Find out why the at_quick_exit symbol is not found.
++// XFAIL: LIBCXX-PICOLIBC-FIXME
++
+ #include <cstdlib>
+ 
+ void f() {}
+-- 
+2.34.1
+

--- a/test-support/lit-exec-qemu.py
+++ b/test-support/lit-exec-qemu.py
@@ -35,8 +35,8 @@ def main():
     parser.add_argument(
         "--timeout",
         type=int,
-        default=60,
-        help="timeout, in seconds (default: 60)",
+        default=120,
+        help="timeout, in seconds (default: 120)",
     )
     parser.add_argument(
         "--execdir",
@@ -69,7 +69,7 @@ def main():
         args.qemu_cpu,
         args.qemu_params.split(":") if args.qemu_params else [],
         args.image,
-        args.arguments,
+        [args.image] + args.arguments,
         args.timeout,
         args.execdir,
     )

--- a/test-support/llvm-libc++-picolibc.cfg.in
+++ b/test-support/llvm-libc++-picolibc.cfg.in
@@ -13,6 +13,15 @@ config.substitutions.append(('%{flags}', '@RUNTIME_TEST_ARCH_FLAGS@'))
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{include} -I %{target-include} -I %{libcxx}/test/support'
     ' -isystem %{libc-include}'
+
+    # Disable warnings in cxx_atomic_impl.h:
+    # "large atomic operation may incur significant performance penalty; the
+    # access size (4 bytes) exceeds the max lock-free size (0  bytes)"
+    ' -Wno-atomic-alignment'
+
+    # Various libc++ headers check for the definition of _NEWLIB_VERSION
+    # which for picolibc is defined in picolibc.h.
+    ' -include picolibc.h'
 ))
 config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -nostdlib -L %{lib} -lc++ -lc++abi'
@@ -24,6 +33,16 @@ config.substitutions.append(('%{link_flags}',
 config.substitutions.append(('%{exec}',
     '%{executor} --execdir %T -- '
 ))
+
+# Long tests are prohibitively slow when run via emulation.
+config.long_tests = False
+
+# LIBCXX-PICOLIBC-FIXME is the feature name used to XFAIL the
+# initial picolibc failures until they can be properly diagnosed
+# and fixed. This allows easier detection of new test failures
+# and regressions. Note: New failures should not be suppressed
+# using this feature.
+config.available_features.add('LIBCXX-PICOLIBC-FIXME')
 
 import os, site
 site.addsitedir(os.path.join('@LIBCXX_SOURCE_DIR@', 'utils'))

--- a/test-support/run_qemu.py
+++ b/test-support/run_qemu.py
@@ -43,9 +43,6 @@ def run_qemu(
     else:
         qemu_params += ["-device", f"loader,file={image},cpu-num=0"]
 
-    print(qemu_params)
-    sys.stdout.flush()
-
     # setting stdin to devnull prevents qemu from fiddling with the echo bit of
     # the parent terminal
     result = subprocess.run(


### PR DESCRIPTION
Added patches from reviews in upstream.
https://reviews.llvm.org/D154246 (build)
https://reviews.llvm.org/D155521 (run with qemu)

Split llvm-project patches, so it is easier to track them.

Updated lit configuration.