### PR TITLE
Fix cmake argument-passing bug in the newlib patch.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -760,11 +760,56 @@ function(
     )
 endfunction()
 
-macro(add_libc)
+macro(
+    add_libc
+    directory
+    variant
+    target_triple
+    flags
+    test_executor_params
+    default_boot_flash_addr
+    default_boot_flash_size
+    default_flash_addr
+    default_flash_size
+    default_ram_addr
+    default_ram_size
+    default_stack_size
+)
+    # It would be nice to just pass ${ARGN} to both the underlying functions,
+    # but that has the side effect of expanding any list arguments (e.g.
+    # test_executor_params) into lots of separate words - the same bug that
+    # $* has in POSIX sh. We want the analogue of "$@" here, but I don't know
+    # of one for cmake.
     if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
-        add_picolibc(${ARGN})
+        add_picolibc(
+            "${directory}"
+            "${variant}"
+            "${target_triple}"
+            "${flags}"
+            "${test_executor_params}"
+            "${default_boot_flash_addr}"
+            "${default_boot_flash_size}"
+            "${default_flash_addr}"
+            "${default_flash_size}"
+            "${default_ram_addr}"
+            "${default_ram_size}"
+            "${default_stack_size}"
+        )
     elseif(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL newlib)
-        add_newlib(${ARGN})
+        add_newlib(
+            "${directory}"
+            "${variant}"
+            "${target_triple}"
+            "${flags}"
+            "${test_executor_params}"
+            "${default_boot_flash_addr}"
+            "${default_boot_flash_size}"
+            "${default_flash_addr}"
+            "${default_flash_size}"
+            "${default_ram_addr}"
+            "${default_ram_size}"
+            "${default_stack_size}"
+        )
     endif()
 endmacro()
 


### PR DESCRIPTION
I wrapped the existing add_picolibc() function with a macro add_libc(), so that I could conditionally replace it with add_newlib() which has the same API. To avoid having to write out the entire argument list another three times, I made the macro just pass its entire argument list through unchanged using ${ARGN}.

However, it turns out that this _doesn't_ pass the list through unchanged, because the effect is to expand any list parameters into lots of individual arguments, the same way that $* does in POSIX sh. So 'test_executor_params', which contains multiple qemu options, was being broken up and distributed between all the subsequent default_* parameters, causing chaos at test time.

In sh, you avoid unwanted argument splitting by writing "$@" instead of $*, but I don't know of any analogue in cmake. So I've done it the boring way, writing the argument list out three more times.