### PR TITLE
Adjust file and path names of the newlib overlay package.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,7 +359,14 @@ set(CPACK_ARCHIVE_COMPONENT_INSTALL TRUE)
 # Don't create a separate archive for each component.
 set(CPACK_COMPONENTS_GROUPING ALL_COMPONENTS_IN_ONE)
 # When extracting the files put them in an ArmCompiler-.../ directory.
-set(CPACK_COMPONENT_INCLUDE_TOPLEVEL_DIRECTORY TRUE)
+# Exception: the newlib overlay package does not do this, because it has
+# to be able to unpack over the top of an existing installation on all
+# platforms, and each platform has a different top-level directory name.
+if(LLVM_TOOLCHAIN_NEWLIB_OVERLAY_INSTALL)
+    set(CPACK_COMPONENT_INCLUDE_TOPLEVEL_DIRECTORY FALSE)
+else()
+    set(CPACK_COMPONENT_INCLUDE_TOPLEVEL_DIRECTORY TRUE)
+endif()
 # Compress package in parallel.
 set(CPACK_THREADS 0 CACHE STRING "")
 
@@ -399,6 +406,10 @@ endif()
 add_subdirectory(
     ${llvmproject_SOURCE_DIR}/llvm llvm
 )
+
+if(LLVM_TOOLCHAIN_NEWLIB_OVERLAY_INSTALL)
+    set(CPACK_PACKAGE_FILE_NAME ${CMAKE_PROJECT_NAME}-newlib-overlay-${CMAKE_PROJECT_VERSION})
+endif()
 
 # Including CPack again after llvm CMakeLists.txt included it
 # resets CPACK_PACKAGE_VERSION to the default MAJOR.MINOR.PATCH format.


### PR DESCRIPTION
My initial patch to add the newlib-overlay mode didn't change the archive name. So the newlib overlay archive would get the same name as the archive that would be built in the ordinary whole-toolchain mode, e.g. 'LLVMEmbeddedToolchainForArm-18.0.0-Linux-x86_64.tar.xz'.

That's semantically misleading (it suggests there's a whole toolchain in the archive), and worse, it means the two files can't be downloaded into the same directory without colliding.

Also, the newlib overlay package unpacked its files into a top-level directory called 'LLVMEmbeddedToolchainForArm-18.0.0-Linux-x86_64'. That's fine if you're unpacking it over the top of the Linux-x86_64 package of the main toolchain, but if you're trying to install the newlib overlay on a different platform, then the two top-level directories will have different names, so the newlib files won't be overlaid on the original package, but will be in a separate directory alongside it.

This patch fixes both of these issues. It manually resets CPACK_PACKAGE_FILE_NAME to call the overlay package something like 'LLVMEmbeddedToolchainForArm-newlib-overlay-18.0.0.tar.xz' (with variable version number, as usual). And it unsets the variable CPACK_COMPONENT_INCLUDE_TOPLEVEL_DIRECTORY, so that the overlay package has no internal top-level directory name _at all_: unpacking it just produces 'bin/newlib.cfg' and 'lib/clang-runtimes/newlib/...' files in the directory where you ran the tar or zip command.

That's not normally the most convenient way to set up a tar archive. But I think this case is an exception, because it's the only way to arrange that a user on _any_ platform can easily overlay this archive on the toolchain they've already installed.