### PR TITLE
[libc++] add missing "has-unix-headers" requirement in PSTL test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,7 @@ set(
     ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project/0012-libc-tests-with-picolibc-XFAIL-uses-of-atomics.patch
     ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project/0013-libc-tests-with-picolibc-mark-two-more-large-tests.patch
     ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project/0014-libc-tests-with-picolibc-xfail-test-missing-rt-libra.patch
+    ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project/0015-libc-add-missing-has-unix-headers-requirement-in-PST.patch
 )
 FetchContent_Declare(llvmproject
     GIT_REPOSITORY https://github.com/llvm/llvm-project.git

--- a/patches/llvm-project/0015-libc-add-missing-has-unix-headers-requirement-in-PST.patch
+++ b/patches/llvm-project/0015-libc-add-missing-has-unix-headers-requirement-in-PST.patch
@@ -1,0 +1,24 @@
+From a3a3381cd4246646d9a48ceb1d592e4704c0f83f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
+Date: Mon, 27 Nov 2023 13:23:48 +0100
+Subject: [libc++] add missing "has-unix-headers" requirement in PSTL test
+
+---
+ .../alg.nonmodifying/alg.all_of/pstl.exception_handling.pass.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libcxx/test/std/algorithms/alg.nonmodifying/alg.all_of/pstl.exception_handling.pass.cpp b/libcxx/test/std/algorithms/alg.nonmodifying/alg.all_of/pstl.exception_handling.pass.cpp
+index cc6297983536..ae5063c5264e 100644
+--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.all_of/pstl.exception_handling.pass.cpp
++++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.all_of/pstl.exception_handling.pass.cpp
+@@ -8,6 +8,7 @@
+ 
+ // UNSUPPORTED: c++03, c++11, c++14
+ // UNSUPPORTED: no-exceptions
++// REQUIRES: has-unix-headers
+ 
+ // UNSUPPORTED: libcpp-has-no-incomplete-pstl
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
This fixes new failure in libc++ tests.