### PR TITLE
Disable small versions of ctype functions

### DIFF
--- a/patches/picolibc.patch
+++ b/patches/picolibc.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index c49856ee0..3e927ea75 100644
+index d82736966..55105b25c 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -972,6 +972,12 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
+@@ -1212,6 +1212,18 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
    error('newlib-retargetable-locking and newlib-multithread must be set to the same value')
  endif
  
@@ -10,6 +10,12 @@ index c49856ee0..3e927ea75 100644
 +        description: '''Enable GNU functions like strtof_l.
 +It's necessary to set this globally because inline functions in
 +libc++ headers call the GNU functions.'''
++)
++
++conf_data.set('_PICOLIBC_CTYPE_SMALL', '0',
++        description: '''Disable picolibc's small ctype implementation.
++libc++ expects newlib-style ctype tables, and also expects support for locales
++and extended character sets, so picolibc's small ctype is not compatible with it'''
 +)
 +
  conf_data.set('_HAVE_CC_INHIBIT_LOOP_TO_LIBCALL',


### PR DESCRIPTION
https://github.com/picolibc/picolibc/commit/43a3894158561b568118d31376edb465238fd320 adds support for a small ctype implementation -- an inline version which performs direct character value comparisons without needing a table.

However this implementation does not support locales or extended character sets. Therefore fallback to the classic, table based ctype implementation.