### PR TITLE
multilib: separate the extension flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1832,7 +1832,7 @@ add_library_variant(
     armv8.1m.main
     SUFFIX hard_nofp_mve
     COMPILE_FLAGS "-mfloat-abi=hard -march=armv8.1m.main+mve -mfpu=none"
-    MULTILIB_FLAGS "--target=thumbv8.1m.main-none-unknown-eabihf -march=thumbv8.1m.main+dsp+mve -mfpu=none"
+    MULTILIB_FLAGS "--target=thumbv8.1m.main-none-unknown-eabihf -march=thumbv8.1m.main+mve -mfpu=none"
     QEMU_MACHINE "mps3-an547"
     QEMU_CPU "cortex-m55"
     BOOT_FLASH_ADDRESS 0x00000000
@@ -1848,7 +1848,7 @@ add_library_variant(
     armv8.1m.main
     SUFFIX hard_nofp_mve_exceptions_rtti
     COMPILE_FLAGS "-mfloat-abi=hard -march=armv8.1m.main+mve -mfpu=none"
-    MULTILIB_FLAGS "--target=thumbv8.1m.main-none-unknown-eabihf -march=thumbv8.1m.main+dsp+mve -mfpu=none"
+    MULTILIB_FLAGS "--target=thumbv8.1m.main-none-unknown-eabihf -march=thumbv8.1m.main+mve -mfpu=none"
     QEMU_MACHINE "mps3-an547"
     QEMU_CPU "cortex-m55"
     BOOT_FLASH_ADDRESS 0x00000000

--- a/cmake/multilib.yaml.in
+++ b/cmake/multilib.yaml.in
@@ -117,15 +117,18 @@ Mappings:
   - --target=armv8a-none-unknown-eabi
 
 # -march extensions
-- Match: -march=thumbv8\.[1-9]m\.main.*\+fp16.*
+- Match: -march=thumbv8\.[1-9]m\.main(\+[^\+]+)*\+fp16(\+[^\+]+)*
   Flags:
   - -march=thumbv8.1m.main+fp16
-- Match: -march=thumbv8\.[1-9]m\.main.*\+dsp.*\+mve.*
+- Match: -march=thumbv8\.[1-9]m\.main(\+[^\+]+)*\+mve(\+[^\+]+)*
   Flags:
-  - -march=thumbv8.1m.main+dsp+mve
-- Match: -march=thumbv8\.[1-9]m\.main.*\+mve\.fp.*\+fp16.*\+lob.*
+  - -march=thumbv8.1m.main+mve
+- Match: -march=thumbv8\.[1-9]m\.main(\+[^\+]+)*\+mve\.fp(\+[^\+]+)*
   Flags:
-  - -march=thumbv8.1m.main+fp16+lob+mve.fp
+  - -march=thumbv8.1m.main+mve.fp
+- Match: -march=thumbv8\.[1-9]m\.main(\+[^\+]+)*\+lob(\+[^\+]+)*
+  Flags:
+  - -march=thumbv8.1m.main+lob
 
 # -mfloat-abi settings
 - Match: -mfloat-abi=softfp

--- a/test/multilib/armv8.1m.main.test
+++ b/test/multilib/armv8.1m.main.test
@@ -15,4 +15,6 @@
 # MVE-EMPTY:
 
 # RUN: %clang -print-multi-flags-experimental --target=arm-none-eabihf -mcpu=cortex-m55 | FileCheck --check-prefix=CORTEXM55 %s
-# CORTEXM55: -march=thumbv8.1m.main+fp16+lob+mve.fp
+# CORTEXM55: -march=thumbv8.1m.main+fp16
+# CORTEXM55: -march=thumbv8.1m.main+lob
+# CORTEXM55: -march=thumbv8.1m.main+mve.fp


### PR DESCRIPTION
The extension flags in -march option were separated, to make them more flexible.
The matching expression was improved, so that it does not accidentally catch longer extenstion names, eg. +mve.fp is not matched by +mve.