### PR TITLE
multilib: simplify softfp variant selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1503,6 +1503,38 @@ add_library_variant(
 )
 add_library_variant(
     armv7m
+    SUFFIX soft_nofp
+    COMPILE_FLAGS "-mfloat-abi=soft -march=armv7m -mfpu=none"
+    MULTILIB_FLAGS "--target=thumbv7m-none-unknown-eabi -mfpu=none"
+    QEMU_MACHINE "mps2-an385"
+    QEMU_CPU "cortex-m3"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x21000000
+    FLASH_SIZE 0x600000
+    RAM_ADDRESS 0x21600000
+    RAM_SIZE 0xa00000
+    STACK_SIZE 4K
+    ENABLE_RTTI_EXCEPTIONS OFF
+)
+add_library_variant(
+    armv7m
+    SUFFIX soft_nofp_exceptions_rtti
+    COMPILE_FLAGS "-mfloat-abi=soft -march=armv7m -mfpu=none"
+    MULTILIB_FLAGS "--target=thumbv7m-none-unknown-eabi -mfpu=none"
+    QEMU_MACHINE "mps2-an385"
+    QEMU_CPU "cortex-m3"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x21000000
+    FLASH_SIZE 0x600000
+    RAM_ADDRESS 0x21600000
+    RAM_SIZE 0xa00000
+    STACK_SIZE 4K
+    ENABLE_RTTI_EXCEPTIONS ON
+)
+add_library_variant(
+    armv7m
     SUFFIX soft_fpv4_sp_d16
     COMPILE_FLAGS "-mfloat-abi=softfp -march=armv7m -mfpu=fpv4-sp-d16"
     MULTILIB_FLAGS "--target=thumbv7m-none-unknown-eabi -mfpu=fpv4-sp-d16"
@@ -1533,19 +1565,13 @@ add_library_variant(
     STACK_SIZE 4K
     ENABLE_RTTI_EXCEPTIONS ON
 )
-# When no -mfpu=none is specified, the compiler internally adds all other
-# possible fpu settings before searching for matching variants. So for the
-# no-fpu variant to win, it has to be in multilab.yaml after all other
-# fpu variants. The order of variants in multilab.yaml depends on the order
-# of the add_library_variant calls. So the add_library_variant that adds
-# the soft_nofp for armv7m is placed after all other armv7m variants.
 add_library_variant(
-    armv7m
+    armv7em
     SUFFIX soft_nofp
-    COMPILE_FLAGS "-mfloat-abi=soft -march=armv7m -mfpu=none"
-    MULTILIB_FLAGS "--target=thumbv7m-none-unknown-eabi -mfpu=none"
-    QEMU_MACHINE "mps2-an385"
-    QEMU_CPU "cortex-m3"
+    COMPILE_FLAGS "-mfloat-abi=soft -march=armv7em -mfpu=none"
+    MULTILIB_FLAGS "--target=thumbv7em-none-unknown-eabi -mfpu=none"
+    QEMU_MACHINE "mps2-an386"
+    QEMU_CPU "cortex-m4"
     BOOT_FLASH_ADDRESS 0x00000000
     BOOT_FLASH_SIZE 0x1000
     FLASH_ADDRESS 0x21000000
@@ -1556,12 +1582,12 @@ add_library_variant(
     ENABLE_RTTI_EXCEPTIONS OFF
 )
 add_library_variant(
-    armv7m
+    armv7em
     SUFFIX soft_nofp_exceptions_rtti
-    COMPILE_FLAGS "-mfloat-abi=soft -march=armv7m -mfpu=none"
-    MULTILIB_FLAGS "--target=thumbv7m-none-unknown-eabi -mfpu=none"
-    QEMU_MACHINE "mps2-an385"
-    QEMU_CPU "cortex-m3"
+    COMPILE_FLAGS "-mfloat-abi=soft -march=armv7em -mfpu=none"
+    MULTILIB_FLAGS "--target=thumbv7em-none-unknown-eabi -mfpu=none"
+    QEMU_MACHINE "mps2-an386"
+    QEMU_CPU "cortex-m4"
     BOOT_FLASH_ADDRESS 0x00000000
     BOOT_FLASH_SIZE 0x1000
     FLASH_ADDRESS 0x21000000
@@ -1631,44 +1657,6 @@ add_library_variant(
     FLASH_ADDRESS 0x60000000
     FLASH_SIZE 0x600000
     RAM_ADDRESS 0x60600000
-    RAM_SIZE 0xa00000
-    STACK_SIZE 4K
-    ENABLE_RTTI_EXCEPTIONS ON
-)
-# When no -mfpu=none is specified, the compiler internally adds all other
-# possible fpu settings before searching for matching variants. So for the
-# no-fpu variant to win, it has to be in multilab.yaml after all other
-# fpu variants. The order of variants in multilab.yaml depends on the order
-# of the add_library_variant calls. So the add_library_variant that adds
-# the soft_nofp for armv7em is placed after all other armv7em variants.
-add_library_variant(
-    armv7em
-    SUFFIX soft_nofp
-    COMPILE_FLAGS "-mfloat-abi=soft -march=armv7em -mfpu=none"
-    MULTILIB_FLAGS "--target=thumbv7em-none-unknown-eabi -mfpu=none"
-    QEMU_MACHINE "mps2-an386"
-    QEMU_CPU "cortex-m4"
-    BOOT_FLASH_ADDRESS 0x00000000
-    BOOT_FLASH_SIZE 0x1000
-    FLASH_ADDRESS 0x21000000
-    FLASH_SIZE 0x600000
-    RAM_ADDRESS 0x21600000
-    RAM_SIZE 0xa00000
-    STACK_SIZE 4K
-    ENABLE_RTTI_EXCEPTIONS OFF
-)
-add_library_variant(
-    armv7em
-    SUFFIX soft_nofp_exceptions_rtti
-    COMPILE_FLAGS "-mfloat-abi=soft -march=armv7em -mfpu=none"
-    MULTILIB_FLAGS "--target=thumbv7em-none-unknown-eabi -mfpu=none"
-    QEMU_MACHINE "mps2-an386"
-    QEMU_CPU "cortex-m4"
-    BOOT_FLASH_ADDRESS 0x00000000
-    BOOT_FLASH_SIZE 0x1000
-    FLASH_ADDRESS 0x21000000
-    FLASH_SIZE 0x600000
-    RAM_ADDRESS 0x21600000
     RAM_SIZE 0xa00000
     STACK_SIZE 4K
     ENABLE_RTTI_EXCEPTIONS ON

--- a/cmake/multilib.yaml.in
+++ b/cmake/multilib.yaml.in
@@ -129,8 +129,3 @@ Mappings:
 - Match: -march=thumbv8\.[1-9]m\.main(\+[^\+]+)*\+lob(\+[^\+]+)*
   Flags:
   - -march=thumbv8.1m.main+lob
-
-# -mfloat-abi settings
-- Match: -mfloat-abi=softfp
-  Flags:
-  - -mfpu=fpv4-sp-d16

--- a/test/multilib/armv7m.test
+++ b/test/multilib/armv7m.test
@@ -3,6 +3,7 @@
 # CHECK: arm-none-eabi/armv7m_soft_nofp
 # CHECK-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=armv7m-none-eabi -mfpu=vfp -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-FPV4 %s
+# RUN: %clang -print-multi-directory --target=armv7m-none-eabi -mfpu=fpv4-sp-d16 -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-FPV4 %s
+# RUN: %clang -print-multi-directory --target=armv7m-none-eabi -mfpu=fpv5-d16 -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-FPV4 %s
 # SOFT-FPV4: arm-none-eabi/armv7m_soft_fpv4_sp_d16
 # SOFT-FPV4-EMPTY:


### PR DESCRIPTION
The fpu option in test was not applicable to armv7m - fixed to a valid one.
Restored the order of variants and removed the comment. "-mfpu=none" variant will not be selected in case different fpu was specified. Removed a hack in multlib.yaml.in.