### PR TITLE
Update lit config files to match new variable names used in upstream

### DIFF
--- a/test-support/llvm-libc++-picolibc.cfg.in
+++ b/test-support/llvm-libc++-picolibc.cfg.in
@@ -5,14 +5,11 @@ lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
 config.name = 'libc++-@RUNTIME_VARIANT_NAME@'
 
-config.substitutions.append(('%{libc-include}', '@CMAKE_INSTALL_PREFIX@/include'))
-config.substitutions.append(('%{libc-lib}', '@CMAKE_INSTALL_PREFIX@/lib'))
 config.substitutions.append(('%{libc-linker-script}', '@LIBC_LINKER_SCRIPT@'))
 
 config.substitutions.append(('%{flags}', '@RUNTIME_TEST_ARCH_FLAGS@'))
 config.substitutions.append(('%{compile_flags}',
-    '-nostdinc++ -I %{include} -I %{target-include} -I %{libcxx}/test/support'
-    ' -isystem %{libc-include}'
+    '-nostdinc++ -I %{include-dir} -I %{target-include-dir} -I %{libcxx-dir}/test/support'
 
     # Disable warnings in cxx_atomic_impl.h:
     # "large atomic operation may incur significant performance penalty; the
@@ -24,11 +21,10 @@ config.substitutions.append(('%{compile_flags}',
     ' -include picolibc.h'
 ))
 config.substitutions.append(('%{link_flags}',
-    '-nostdlib++ -nostdlib -L %{lib} -lc++ -lc++abi'
+    '-nostdlib -nostdlib++ -L %{lib-dir}'
+    ' -lc++ -lc++abi'
+    ' -lc -lm -lclang_rt.builtins -lsemihost -lcrt0-semihost'
     ' -T %{libc-linker-script}'
-    ' -lc -lm -lclang_rt.builtins -lsemihost'
-    ' %{libc-lib}/crt0-semihost.o'
-    ' -L %{libc-lib} -lc++ -lc++abi'
 ))
 config.substitutions.append(('%{exec}',
     '%{executor} --execdir %T -- '
@@ -37,13 +33,6 @@ config.substitutions.append(('%{exec}',
 # Long tests are prohibitively slow when run via emulation.
 config.long_tests = False
 config.large_tests = False
-
-# LIBCXX-PICOLIBC-FIXME is the feature name used to XFAIL the
-# initial picolibc failures until they can be properly diagnosed
-# and fixed. This allows easier detection of new test failures
-# and regressions. Note: New failures should not be suppressed
-# using this feature.
-config.available_features.add('LIBCXX-PICOLIBC-FIXME')
 
 import os, site
 site.addsitedir(os.path.join('@LIBCXX_SOURCE_DIR@', 'utils'))

--- a/test-support/llvm-libc++abi-picolibc.cfg.in
+++ b/test-support/llvm-libc++abi-picolibc.cfg.in
@@ -5,8 +5,6 @@ lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
 config.name = 'libc++abi-@RUNTIME_VARIANT_NAME@'
 
-config.substitutions.append(('%{libc-include}', '@CMAKE_INSTALL_PREFIX@/include'))
-config.substitutions.append(('%{libc-lib}', '@CMAKE_INSTALL_PREFIX@/lib'))
 config.substitutions.append(('%{libc-linker-script}', '@LIBC_LINKER_SCRIPT@'))
 
 config.substitutions.append(('%{flags}', '@RUNTIME_TEST_ARCH_FLAGS@'))
@@ -16,11 +14,10 @@ config.substitutions.append(('%{compile_flags}',
     ' -isystem %{libc-include}'
 ))
 config.substitutions.append(('%{link_flags}',
-    '-nostdlib++ -nostdlib '
+    '-nostdlib -nostdlib++ -L %{lib}'
+    ' -lc++ -lc++abi'
+    ' -lc -lm -lclang_rt.builtins -lsemihost -lcrt0-semihost'
     ' -T %{libc-linker-script}'
-    ' -lc -lm -lclang_rt.builtins -lsemihost'
-    ' %{libc-lib}/crt0-semihost.o'
-    ' -L %{lib} -L %{libc-lib} -lc++ -lc++abi'
 ))
 config.substitutions.append(('%{exec}',
     '%{executor} --execdir %T -- '

--- a/test-support/llvm-libunwind-picolibc.cfg.in
+++ b/test-support/llvm-libunwind-picolibc.cfg.in
@@ -6,14 +6,9 @@ lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
 config.name = 'libunwind-@RUNTIME_VARIANT_NAME@'
 
-config.substitutions.append(('%{libc-include}', '@CMAKE_INSTALL_PREFIX@/include'))
-config.substitutions.append(('%{libc-lib}', '@CMAKE_INSTALL_PREFIX@/lib'))
 config.substitutions.append(('%{libc-linker-script}', '@LIBC_LINKER_SCRIPT@'))
 
-compile_flags = ['-isystem %{libc-include}']
-link_flags = ['-nostdlib', '-T %{libc-linker-script}',
-              '-lc', '-lm', '-lclang_rt.builtins', '-lsemihost',
-              '%{libc-lib}/crt0-semihost.o', '-L', '%{libc-lib}']
+compile_flags = []
 
 if @LIBUNWIND_ENABLE_CET@:
     compile_flags.append('-fcf-protection=full')
@@ -30,7 +25,11 @@ config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{{include}} {}'.format(' '.join(compile_flags))
 ))
 config.substitutions.append(('%{link_flags}',
-    '%{{lib}}/libunwind.a {}'.format(' '.join(link_flags))
+    '-nostdlib -nostdlib++ -L %{lib}'
+    ' -lc++ -lc++abi'
+    ' -lc -lm -lclang_rt.builtins -lsemihost -lcrt0-semihost'
+    ' -T %{libc-linker-script}'
+    ' -lunwind'
 ))
 config.substitutions.append(('%{exec}',
     '%{executor} --execdir %T -- '


### PR DESCRIPTION
Removed manual definition of LIBCXX-PICOLIBC-FIXME. The upstream scripts detect it automatically.