### PR TITLE
libc++ tests: prevent import of absent atomic types

### DIFF
--- a/patches/llvm-project/0001-libc-tests-with-picolibc-xfail-two-remaining-tests.patch
+++ b/patches/llvm-project/0001-libc-tests-with-picolibc-xfail-two-remaining-tests.patch
@@ -1,4 +1,4 @@
-From d7721befa6b97c3bf1fb1cae342b1e4f07ef6373 Mon Sep 17 00:00:00 2001
+From 60dbe1130f49bc2e79590dc821c8f1bf9f012156 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Mon, 16 Oct 2023 11:35:48 +0200
 Subject: [libc++] tests with picolibc: xfail two remaining tests

--- a/patches/llvm-project/0002-libc-tests-with-picolibc-disable-large-tests.patch
+++ b/patches/llvm-project/0002-libc-tests-with-picolibc-disable-large-tests.patch
@@ -1,4 +1,4 @@
-From a5fdba2f71582b5bff493e0fc59b3c1e6f3251ac Mon Sep 17 00:00:00 2001
+From 08b2f73f8e2e4fd6f30261f3dff46708857ee62d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Wed, 15 Nov 2023 12:18:35 +0100
 Subject: [libc++] tests with picolibc: disable large tests
@@ -9,19 +9,19 @@ Subject: [libc++] tests with picolibc: disable large tests
  2 files changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/libcxx/cmake/caches/Armv7M-picolibc.cmake b/libcxx/cmake/caches/Armv7M-picolibc.cmake
-index 9f8863943444..3ac426ad7948 100644
+index b5f9089308d2..fedf13548131 100644
 --- a/libcxx/cmake/caches/Armv7M-picolibc.cmake
 +++ b/libcxx/cmake/caches/Armv7M-picolibc.cmake
-@@ -17,6 +17,9 @@ set(LIBCXXABI_ENABLE_EXCEPTIONS OFF CACHE BOOL "")
- set(LIBCXXABI_ENABLE_SHARED OFF CACHE BOOL "")
+@@ -18,6 +18,9 @@ set(LIBCXXABI_ENABLE_SHARED OFF CACHE BOOL "")
  set(LIBCXXABI_ENABLE_STATIC ON CACHE BOOL "")
+ set(LIBCXXABI_ENABLE_STATIC_UNWINDER ON CACHE BOOL "")
  set(LIBCXXABI_ENABLE_THREADS OFF CACHE BOOL "")
 +# Long tests are prohibitively slow when run via emulation.
 +# The emulated target has limited memory.
 +set(LIBCXXABI_TEST_PARAMS "long_tests=False large_tests=False" CACHE STRING "")
  set(LIBCXXABI_USE_COMPILER_RT ON CACHE BOOL "")
- set(LIBCXXABI_USE_LLVM_UNWINDER ON CACHE BOOL "")
- set(LIBCXX_ENABLE_EXCEPTIONS OFF CACHE BOOL "")
+ set(LIBCXX_ENABLE_EXCEPTIONS ON CACHE BOOL "")
+ set(LIBCXX_ENABLE_FILESYSTEM OFF CACHE STRING "")
 @@ -30,12 +33,16 @@ set(LIBCXX_ENABLE_THREADS OFF CACHE BOOL "")
  set(LIBCXX_ENABLE_WIDE_CHARACTERS OFF CACHE BOOL "")
  set(LIBCXX_INCLUDE_BENCHMARKS OFF CACHE BOOL "")
@@ -39,7 +39,7 @@ index 9f8863943444..3ac426ad7948 100644
 +# The emulated target has limited memory.
 +set(LIBUNWIND_TEST_PARAMS "long_tests=False large_tests=False" CACHE STRING "")
  set(LIBUNWIND_USE_COMPILER_RT ON CACHE BOOL "")
- find_program(QEMU_SYSTEM_ARM qemu-system-arm)
+ find_program(QEMU_SYSTEM_ARM qemu-system-arm REQUIRED)
 diff --git a/libcxxabi/test/test_demangle.pass.cpp b/libcxxabi/test/test_demangle.pass.cpp
 index b7e41099ebfc..8f04caba6ad9 100644
 --- a/libcxxabi/test/test_demangle.pass.cpp

--- a/patches/llvm-project/0003-Disable-failing-compiler-rt-test.patch
+++ b/patches/llvm-project/0003-Disable-failing-compiler-rt-test.patch
@@ -1,4 +1,4 @@
-From 8f5b99cc6c879fe5111df21de4e679a9e4c9c62c Mon Sep 17 00:00:00 2001
+From 019b0593a2fea25a5cc6c78210c02ffabe5bc7dd Mon Sep 17 00:00:00 2001
 From: Piotr Przybyla <piotr.przybyla@arm.com>
 Date: Wed, 15 Nov 2023 16:04:24 +0000
 Subject: Disable failing compiler-rt test

--- a/patches/llvm-project/0004-libc-tests-with-picolibc-mark-sort-test-as-long-one.patch
+++ b/patches/llvm-project/0004-libc-tests-with-picolibc-mark-sort-test-as-long-one.patch
@@ -1,4 +1,4 @@
-From 23fdd8b7eae7ad1b4a76accf6a8369f83b51be3e Mon Sep 17 00:00:00 2001
+From 4b433e4baba54480bde65465a3abc70c3357d611 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Thu, 9 Nov 2023 14:14:30 +0100
 Subject: [libc++] tests with picolibc: mark sort test as long one

--- a/patches/llvm-project/0005-libc-tests-with-picolibc-XFAIL-uses-of-atomics.patch
+++ b/patches/llvm-project/0005-libc-tests-with-picolibc-XFAIL-uses-of-atomics.patch
@@ -1,4 +1,4 @@
-From 9d9f7585ef58f0c17a12999dd9ed0850cf599728 Mon Sep 17 00:00:00 2001
+From 1044139f897608b9f684c614211e1ffb9639529c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Thu, 9 Nov 2023 15:25:14 +0100
 Subject: [libc++] tests with picolibc: XFAIL uses of atomics
@@ -88,10 +88,10 @@ index 000000000000..5ecc58f3e385
 +if "has-no-atomics" in config.available_features:
 +    config.unsupported = True
 diff --git a/libcxx/utils/libcxx/test/features.py b/libcxx/utils/libcxx/test/features.py
-index 5e854917e6ef..c8db925bb51e 100644
+index 6ef40755c59d..6c2960260189 100644
 --- a/libcxx/utils/libcxx/test/features.py
 +++ b/libcxx/utils/libcxx/test/features.py
-@@ -198,6 +198,21 @@ DEFAULT_FEATURES = [
+@@ -206,6 +206,21 @@ DEFAULT_FEATURES = [
            """,
          ),
      ),

--- a/patches/llvm-project/0006-libc-tests-with-picolibc-mark-two-more-large-tests.patch
+++ b/patches/llvm-project/0006-libc-tests-with-picolibc-mark-two-more-large-tests.patch
@@ -1,4 +1,4 @@
-From ae2a3310adb8fd08895b408f6b65284718b1c8cb Mon Sep 17 00:00:00 2001
+From dde9dae50d209a05ad11edd1ba938230a479cce2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Wed, 22 Nov 2023 16:12:39 +0100
 Subject: [libc++] tests with picolibc: mark two more large tests

--- a/patches/llvm-project/0007-libc-tests-with-picoilbc-protect-absent-atomic-types.patch
+++ b/patches/llvm-project/0007-libc-tests-with-picoilbc-protect-absent-atomic-types.patch
@@ -1,0 +1,29 @@
+From f69c5ad51f5a148c6b3ee917ba7897d7d1c01269 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
+Date: Mon, 19 Feb 2024 11:23:25 +0100
+Subject: [libc++] tests with picoilbc: protect absent atomic types with ifdef
+
+On some platforms, like armv4t, there are currently no atomic types at
+all. This ifdef prevents module from trying to import absent types.
+---
+ libcxx/modules/std/atomic.inc | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/libcxx/modules/std/atomic.inc b/libcxx/modules/std/atomic.inc
+index 88b31ccdb208..2b54cef863e5 100644
+--- a/libcxx/modules/std/atomic.inc
++++ b/libcxx/modules/std/atomic.inc
+@@ -111,8 +111,10 @@ export namespace std {
+   using std::atomic_uintmax_t;
+   using std::atomic_uintptr_t;
+ 
++#ifndef _LIBCPP_NO_LOCK_FREE_TYPES
+   using std::atomic_signed_lock_free;
+   using std::atomic_unsigned_lock_free;
++#endif
+ 
+   // [atomics.flag], flag type and operations
+   using std::atomic_flag;
+-- 
+2.34.1
+


### PR DESCRIPTION
This fixes the modules.std.compat.pass.cpp test in libc++ test suite for variants which currently have no atomic support, like armv4t.

The refreshed patches apply cleanly to
6d7de46155fece05ab5a44aedd573a811f4b208a.