### PR TITLE
Fix lit config files for libc++, libc++abi and libunwind

### DIFF
--- a/test-support/llvm-libc++-picolibc.cfg.in
+++ b/test-support/llvm-libc++-picolibc.cfg.in
@@ -5,11 +5,14 @@ lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
 config.name = 'libc++-@RUNTIME_VARIANT_NAME@'
 
+config.substitutions.append(('%{libc-include}', '@CMAKE_INSTALL_PREFIX@/include'))
+config.substitutions.append(('%{libc-lib}', '@CMAKE_INSTALL_PREFIX@/lib'))
 config.substitutions.append(('%{libc-linker-script}', '@LIBC_LINKER_SCRIPT@'))
 
 config.substitutions.append(('%{flags}', '@RUNTIME_TEST_ARCH_FLAGS@'))
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{include-dir} -I %{target-include-dir} -I %{libcxx-dir}/test/support'
+    ' -isystem %{libc-include}'
 
     # Disable warnings in cxx_atomic_impl.h:
     # "large atomic operation may incur significant performance penalty; the
@@ -21,8 +24,9 @@ config.substitutions.append(('%{compile_flags}',
     ' -include picolibc.h'
 ))
 config.substitutions.append(('%{link_flags}',
-    '-nostdlib -nostdlib++ -L %{lib-dir}'
+    ' -nostdlib++ -L %{lib-dir}'
     ' -lc++ -lc++abi'
+    ' -nostdlib -L %{libc-lib}'
     ' -lc -lm -lclang_rt.builtins -lsemihost -lcrt0-semihost'
     ' -T %{libc-linker-script}'
 ))

--- a/test-support/llvm-libc++abi-picolibc.cfg.in
+++ b/test-support/llvm-libc++abi-picolibc.cfg.in
@@ -5,17 +5,20 @@ lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
 config.name = 'libc++abi-@RUNTIME_VARIANT_NAME@'
 
+config.substitutions.append(('%{libc-include}', '@CMAKE_INSTALL_PREFIX@/include'))
+config.substitutions.append(('%{libc-lib}', '@CMAKE_INSTALL_PREFIX@/lib'))
 config.substitutions.append(('%{libc-linker-script}', '@LIBC_LINKER_SCRIPT@'))
 
 config.substitutions.append(('%{flags}', '@RUNTIME_TEST_ARCH_FLAGS@'))
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{include} -I %{cxx-include} -I %{cxx-target-include} %{maybe-include-libunwind} '
-    ' -I %{libcxx}/test/support -I %{libcxx}/src -D_LIBCPP_ENABLE_CXX17_REMOVED_UNEXPECTED_FUNCTIONS '
+    ' -I %{libcxx}/test/support -I %{libcxx}/src -D_LIBCPP_ENABLE_CXX17_REMOVED_UNEXPECTED_FUNCTIONS'
     ' -isystem %{libc-include}'
 ))
 config.substitutions.append(('%{link_flags}',
-    '-nostdlib -nostdlib++ -L %{lib}'
+    ' -nostdlib++ -L %{lib}'
     ' -lc++ -lc++abi'
+    ' -nostdlib -L %{libc-lib}'
     ' -lc -lm -lclang_rt.builtins -lsemihost -lcrt0-semihost'
     ' -T %{libc-linker-script}'
 ))

--- a/test-support/llvm-libunwind-picolibc.cfg.in
+++ b/test-support/llvm-libunwind-picolibc.cfg.in
@@ -6,6 +6,8 @@ lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
 config.name = 'libunwind-@RUNTIME_VARIANT_NAME@'
 
+config.substitutions.append(('%{libc-include}', '@CMAKE_INSTALL_PREFIX@/include'))
+config.substitutions.append(('%{libc-lib}', '@CMAKE_INSTALL_PREFIX@/lib'))
 config.substitutions.append(('%{libc-linker-script}', '@LIBC_LINKER_SCRIPT@'))
 
 compile_flags = []
@@ -22,14 +24,16 @@ config.substitutions.append(('%{flags}',
     (' -isysroot {}'.format(local_sysroot) if local_sysroot else '')
 ))
 config.substitutions.append(('%{compile_flags}',
-    '-nostdinc++ -I %{{include}} {}'.format(' '.join(compile_flags))
+    '-nostdinc++ -I %{include} '
+    ' -isystem %{libc-include} '
+    + ' '.join(compile_flags)
 ))
 config.substitutions.append(('%{link_flags}',
-    '-nostdlib -nostdlib++ -L %{lib}'
-    ' -lc++ -lc++abi'
+    ' -nostdlib++ -L %{lib}'
+    ' -lc++ -lc++abi -lunwind'
+    ' -nostdlib -L %{libc-lib}'
     ' -lc -lm -lclang_rt.builtins -lsemihost -lcrt0-semihost'
     ' -T %{libc-linker-script}'
-    ' -lunwind'
 ))
 config.substitutions.append(('%{exec}',
     '%{executor} --execdir %T -- '


### PR DESCRIPTION
Restore libc-include and libc-lib variables.
Alternatively the tests could depend on multilib_yaml and rely on multilib providing the right paths to C-library.
Fix the order of c and c++ libs