### PR TITLE
picolibc: linker script: Add '__lcxx_override' section

### DIFF
--- a/patches/picolibc.patch
+++ b/patches/picolibc.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index d82736966..55105b25c 100644
+index 0fdfa0412..8e679f166 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1212,6 +1212,18 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
+@@ -1224,6 +1224,18 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
    error('newlib-retargetable-locking and newlib-multithread must be set to the same value')
  endif
  
@@ -21,3 +21,15 @@ index d82736966..55105b25c 100644
  conf_data.set('_HAVE_CC_INHIBIT_LOOP_TO_LIBCALL',
  	      cc.has_argument('-fno-tree-loop-distribute-patterns'),
  	      description: 'Compiler flag to prevent detecting memcpy/memset patterns')
+diff --git a/picolibc.ld.in b/picolibc.ld.in
+index b97ea3300..e1a1318a2 100644
+--- a/picolibc.ld.in
++++ b/picolibc.ld.in
+@@ -68,6 +68,7 @@ SECTIONS
+ 		*(.text.unlikely .text.unlikely.*)
+ 		*(.text.startup .text.startup.*)
+ 		*(.text .text.* .opd .opd.*)
++		*(__lcxx_override)
+ 		*(.gnu.linkonce.t.*)
+ 		KEEP (*(.fini .fini.*))
+ 		@PREFIX@__text_end = .;

--- a/patches/picolibc.patch
+++ b/patches/picolibc.patch
@@ -22,14 +22,14 @@ index 0fdfa0412..8e679f166 100644
  	      cc.has_argument('-fno-tree-loop-distribute-patterns'),
  	      description: 'Compiler flag to prevent detecting memcpy/memset patterns')
 diff --git a/picolibc.ld.in b/picolibc.ld.in
-index b97ea3300..e1a1318a2 100644
+index b97ea3300..71cf51afe 100644
 --- a/picolibc.ld.in
 +++ b/picolibc.ld.in
 @@ -68,6 +68,7 @@ SECTIONS
  		*(.text.unlikely .text.unlikely.*)
  		*(.text.startup .text.startup.*)
  		*(.text .text.* .opd .opd.*)
-+		*(__lcxx_override)
++		*(__lcxx_*)
  		*(.gnu.linkonce.t.*)
  		KEEP (*(.fini .fini.*))
  		@PREFIX@__text_end = .;


### PR DESCRIPTION
This section was added into libc++ and conains the "new" operator[1]. Placing the "new" operator in the section allows checking, if the operator (defined as weak symbol) was overridden.

The check relies on the "__start_" and "__end_" symbols generated by linker. These symbols would not be generated for names, which are not valid C identifiers. For this reason name like ".text.__lcxx_generated" cannot be used.

[1] https://github.com/llvm/llvm-project/pull/69498