### PR TITLE
Only use normalized target triple for compiler-rt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -859,7 +859,7 @@ function(
     # Exceptions are architectures pre-armv7, which compiler-rt expects to
     # see in the triple because that's where it looks to decide whether to
     # use specific assembly sources.
-    if(NOT target_triple MATCHES "^(aarch64-none-unknown-elf|arm-none-unknown-eabi|armv[4-6])")
+    if(NOT target_triple MATCHES "^(aarch64-none-elf|arm-none-eabi|armv[4-6])")
         message(FATAL_ERROR "\
 Target triple name \"${target_triple}\" not compatible with compiler-rt.
 Use -march to specify the architecture.")
@@ -870,6 +870,7 @@ Use -march to specify the architecture.")
         message(FATAL_ERROR "\
 Hard-float library with target triple \"${target_triple}\" must end \"-eabihf\"")
     endif()
+    string(REPLACE "-none-" "-none-unknown-" normalized_target_triple ${target_triple})
 
     get_runtimes_flags("${directory}" "${flags}")
 
@@ -930,7 +931,7 @@ Hard-float library with target triple \"${target_triple}\" must end \"-eabihf\""
         COMMAND
             ${CMAKE_COMMAND}
             -E copy_directory
-            <INSTALL_DIR>/lib/${target_triple}
+            <INSTALL_DIR>/lib/${normalized_target_triple}
             "${LLVM_BINARY_DIR}/${directory}/lib"
     )
 
@@ -1081,7 +1082,7 @@ endfunction()
 
 function(get_compiler_rt_target_triple target_arch flags)
     if(target_arch STREQUAL "aarch64")
-        set(target_triple "aarch64-none-unknown-elf")
+        set(target_triple "aarch64-none-elf")
     else()
         # Choose the target triple so that compiler-rt will do the
         # right thing. We can't always put the exact target
@@ -1093,9 +1094,9 @@ function(get_compiler_rt_target_triple target_arch flags)
         # see in the triple because that's where it looks to decide whether to
         # use specific assembly sources.
         if(target_arch MATCHES "^armv[4-6]")
-            set(target_triple "${target_arch}-none-unknown-eabi")
+            set(target_triple "${target_arch}-none-eabi")
         else()
-            set(target_triple "arm-none-unknown-eabi")
+            set(target_triple "arm-none-eabi")
         endif()
         if(flags MATCHES "-mfloat-abi=hard")
             # Also, compiler-rt looks in the ABI component of the


### PR DESCRIPTION
A newlib overlay build does not recognise a target triple as normalized by clang, however compiler-rt build needs the normalized triple to find the correct output directory. So this patch uses the normalized triple only for compiler-rt.