### PR TITLE
Change filenames in picolibc test-ungetc-ftell,test-fgets-eof

### DIFF
--- a/patches/picolibc.patch
+++ b/patches/picolibc.patch
@@ -35,3 +35,63 @@ index b97ea3300..04b94f35c 100644
  		*(.gnu.linkonce.t.*)
  		KEEP (*(.fini .fini.*))
  		@PREFIX@__text_end = .;
+diff --git a/test/test-fgets-eof.c b/test/test-fgets-eof.c
+index 4c9e141b7..704e1a3ac 100644
+--- a/test/test-fgets-eof.c
++++ b/test/test-fgets-eof.c
+@@ -36,6 +36,10 @@
+ #include <stdio.h>
+ #include <string.h>
+ 
++#ifndef TEST_FILE_NAME
++#define TEST_FILE_NAME "FGETSEOF.TXT"
++#endif
++
+ const char *string = "123456789";
+ 
+ int main(void)
+@@ -46,12 +50,12 @@ int main(void)
+     FILE *file;
+     int ret = 0;
+ 
+-    file = fopen("testfile.dat", "w");
++    file = fopen( TEST_FILE_NAME, "w" );
+     if(file == NULL) return 1;
+     fputs(string, file);
+     fclose(file);
+ 
+-    file = fopen( "testfile.dat", "r" );
++    file = fopen( TEST_FILE_NAME, "r" );
+     if(file == NULL) return 1;
+ 
+     /*Calling fgets to reach EOF and check on the returned value*/
+diff --git a/test/test-ungetc-ftell.c b/test/test-ungetc-ftell.c
+index 245679814..a3e702312 100644
+--- a/test/test-ungetc-ftell.c
++++ b/test/test-ungetc-ftell.c
+@@ -36,6 +36,10 @@
+ #include <stdio.h>
+ #include <string.h>
+ 
++#ifndef TEST_FILE_NAME
++#define TEST_FILE_NAME "UNGETCFTELL.DAT"
++#endif
++
+ const char *str = "This is a string";
+ 
+ int main(void) {
+@@ -44,12 +48,12 @@ int main(void) {
+     char first;
+     long position, start;
+ 
+-    file = fopen( "testfile.dat", "wb" );
++    file = fopen( TEST_FILE_NAME, "wb" );
+     if( file == NULL ) return 1;
+     fputs(str, file);
+     fclose(file);
+ 
+-    file = fopen( "testfile.dat", "rb" );
++    file = fopen( TEST_FILE_NAME, "rb" );
+     if(file == NULL) return 1;
+ 
+     first = fgetc(file);


### PR DESCRIPTION
This adds the patch in https://github.com/picolibc/picolibc/pull/734 to our picolibc patch. We think this is the cause of those two picolibc tests failing intermittently: they're both trying to make test output files with the same name in the test directory, and colliding whenever they happen to run concurrently.