### PR TITLE
When building LLVM libc, include its license file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1918,6 +1918,11 @@ if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL newlib)
         ${newlib_SOURCE_DIR}/COPYING.LIBGLOSS           COPYING.LIBGLOSS
     )
 endif()
+if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL llvmlibc)
+    list(APPEND third_party_license_files
+        ${llvmproject_SOURCE_DIR}/libc/LICENSE.TXT      LIBC-LICENSE.TXT
+    )
+endif()
 
 while(third_party_license_files)
     list(POP_FRONT third_party_license_files source_file destination_name)


### PR DESCRIPTION
This copies `libc/LICENSE.TXT` from the llvm-project repository into the `third-party-licenses` directory, renamed to `LIBC-LICENSE.TXT` so you can tell it apart from all the other subdirectory licenses. (We were already doing similar renames for libcxx, libunwind, etc.)

When you build the toolchain in llvm-libc-only mode, that file shows up along with all the others at the top level of `third-party-licenses`. If you build an overlay package, it ends up in the `third-party-licenses/llvmlibc` subdirectory.