### PR TITLE
Separate LTO options from Omax.cfg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,7 +355,7 @@ install(
     FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Omax.cfg
     DESTINATION bin
-    COMPONENT llvm-toolchain-omax-cfg
+    COMPONENT llvm-toolchain-config-files
 )
 
 if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL llvmlibc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,6 +354,7 @@ endif()
 install(
     FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Omax.cfg
+    ${CMAKE_CURRENT_SOURCE_DIR}/OmaxLTO.cfg
     DESTINATION bin
     COMPONENT llvm-toolchain-config-files
 )

--- a/Omax.cfg
+++ b/Omax.cfg
@@ -5,6 +5,3 @@
 -mllvm -unroll-max-iteration-count-to-analyze=20 \
 -mllvm -lsr-complexity-limit=1073741823 \
 -mllvm -force-attribute=main:norecurse \
--flto=full \
--fvirtual-function-elimination \
--fwhole-program-vtables

--- a/OmaxLTO.cfg
+++ b/OmaxLTO.cfg
@@ -1,0 +1,3 @@
+-flto=full \
+-fvirtual-function-elimination \
+-fwhole-program-vtables


### PR DESCRIPTION

The motivation for this change is that users
may wish to disable LTO when using the the Omax.cfg
file. Removing the LTO flags to a seperate file allows
the user to enable LTO related flags seperately.
