### PR TITLE
Do not default to linking crt0 when using crt0-semihosting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1073,7 +1073,7 @@ Hard-float library with target triple \"${target_triple}\" must end \"-eabihf\""
 
     get_runtimes_flags("${directory}" "${flags}")
 
-    set(compiler_rt_test_flags "${runtimes_flags} -fno-exceptions -fno-rtti -lcrt0-semihost -lsemihost -T picolibcpp.ld")
+    set(compiler_rt_test_flags "${runtimes_flags} -fno-exceptions -fno-rtti -nostartfiles -lcrt0-semihost -lsemihost -T picolibcpp.ld")
     if(variant STREQUAL "armv6m_soft_nofp")
         set(compiler_rt_test_flags "${compiler_rt_test_flags} -fomit-frame-pointer")
     endif()

--- a/README.md
+++ b/README.md
@@ -171,4 +171,3 @@ Please raise an issue via [Github issues](https://github.com/ARM-software/LLVM-e
 ## Contributions and Pull Requests
 
 Please see the [Contribution Guide](docs/contributing.md) for details.
-

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ To use the toolchain, on the command line you need to provide the following opti
 * The FPU to use.
 * Disabling/enabling C++ exceptions and RTTI.
 * The C runtime library: either `crt0` or `crt0-semihost`.
+  `crt0` will be linked automatically, but this can be suppressed
+  with the `-nostartfiles` option so that `crt0-semihost` can be used.
 * The semihosting library, if using `crt0-semihost`.
 * A [linker script](
   https://sourceware.org/binutils/docs/ld/Scripts.html) specified with `-T`.
@@ -102,6 +104,7 @@ $ clang \
 -mfpu=none \
 -fno-exceptions \
 -fno-rtti \
+-nostartfiles \
 -lcrt0-semihost \
 -lsemihost \
 -T picolibc.ld \
@@ -130,6 +133,7 @@ $ clang \
 -mfpu=none \
 -fno-exceptions \
 -fno-rtti \
+-nostartfiles \
 -lcrt0-semihost \
 -lsemihost \
 -T picolibc.ld \
@@ -167,3 +171,4 @@ Please raise an issue via [Github issues](https://github.com/ARM-software/LLVM-e
 ## Contributions and Pull Requests
 
 Please see the [Contribution Guide](docs/contributing.md) for details.
+

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -88,8 +88,8 @@ however uses different command line options to control selection of semihosting.
 
 |Use case|GNU options|LLVM options|
 |--------|-----------|------------|
-|No semihosting|`--specs=nosys.specs`|`-lcrt0`|
-|Semihosting|`--specs=rdimon.specs`|`-lcrt0-semihost -lsemihost`|
+|No semihosting|`--specs=nosys.specs`|
+|Semihosting|`--specs=rdimon.specs`|`-nostartfiles -lcrt0-semihost -lsemihost`|
 |Newlib-nano|`--specs=nano.specs`|Not available: `picolibc` is an equivalent of `newlib-nano`.
 
 ## Linker

--- a/packagetest/hello.c
+++ b/packagetest/hello.c
@@ -1,4 +1,4 @@
-// RUN: %clang --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -lcrt0-semihost -lsemihost -T %S/Inputs/microbit.ld %s -o %t.out
+// RUN: %clang --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -nostartfiles -lcrt0-semihost -lsemihost -T %S/Inputs/microbit.ld %s -o %t.out
 // RUN: qemu-system-arm -M microbit -semihosting -nographic -device loader,file=%t.out 2>&1 | FileCheck %s
 
 #include <stdio.h>

--- a/packagetest/hello.cpp
+++ b/packagetest/hello.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti -T %S/Inputs/microbit.ld %s -o %t.out
+// RUN: %clangxx --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -nostartfiles -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti -T %S/Inputs/microbit.ld %s -o %t.out
 // RUN: qemu-system-arm -M microbit -semihosting -nographic -device loader,file=%t.out 2>&1 | FileCheck %s
 
 // Include as many C++17 headers as possible.

--- a/samples/Makefile.conf
+++ b/samples/Makefile.conf
@@ -22,7 +22,6 @@ endif
 MICROBIT_TARGET=--target=armv6m-none-eabi -march=armv6m -mfpu=none -mfloat-abi=soft
 AARCH64_TARGET=--target=aarch64-none-elf
 
-CRT=-lcrt0
-CRT_SEMIHOST=-lcrt0-semihost -lsemihost
+CRT_SEMIHOST=-nostartfiles -lcrt0-semihost -lsemihost
 
 CPP_FLAGS=-fno-exceptions -fno-rtti

--- a/samples/src/baremetal-semihosting-aarch64/make.bat
+++ b/samples/src/baremetal-semihosting-aarch64/make.bat
@@ -49,6 +49,6 @@ if exist hello.img del /q hello.img
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang.exe --target=aarch64-none-elf -lcrt0-semihost -lsemihost -g -T ..\..\ldscripts\raspi3b.ld -o hello.elf hello.c
+%BIN_PATH%\clang.exe --target=aarch64-none-elf -nostartfiles -lcrt0-semihost -lsemihost -g -T ..\..\ldscripts\raspi3b.ld -o hello.elf hello.c
 %BIN_PATH%\llvm-objcopy.exe -O binary hello.elf hello.img
 @exit /B

--- a/samples/src/baremetal-semihosting/make.bat
+++ b/samples/src/baremetal-semihosting/make.bat
@@ -49,6 +49,6 @@ if exist hello.hex del /q hello.hex
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -lcrt0-semihost -lsemihost -g -T ..\..\ldscripts\microbit.ld -o hello.elf hello.c
+%BIN_PATH%\clang.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -nostartfiles -lcrt0-semihost -lsemihost -g -T ..\..\ldscripts\microbit.ld -o hello.elf hello.c
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B

--- a/samples/src/baremetal-uart/Makefile
+++ b/samples/src/baremetal-uart/Makefile
@@ -20,7 +20,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	$(BIN_PATH)/clang $(MICROBIT_TARGET) $(CRT) -g -T ../../ldscripts/microbit.ld -o hello.elf $^
+	$(BIN_PATH)/clang $(MICROBIT_TARGET) -g -T ../../ldscripts/microbit.ld -o hello.elf $^
 
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@

--- a/samples/src/baremetal-uart/make.bat
+++ b/samples/src/baremetal-uart/make.bat
@@ -49,6 +49,6 @@ if exist hello.hex del /q hello.hex
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -lcrt0 -g -T ..\..\ldscripts\microbit.ld -o hello.elf hello.c
+%BIN_PATH%\clang.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -g -T ..\..\ldscripts\microbit.ld -o hello.elf hello.c
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B

--- a/samples/src/cpp-baremetal-semihosting-cfi/make.bat
+++ b/samples/src/cpp-baremetal-semihosting-cfi/make.bat
@@ -57,12 +57,12 @@ if exist hello.hex del /q hello.hex
 
 :build_fn
 %BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -fno-exceptions -fno-rtti -flto -fsanitize=cfi -fvisibility=hidden -fno-sanitize-ignorelist -g -c hello.cpp
-%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti -flto -T ..\..\ldscripts\microbit.ld -g -o hello.elf hello.o
+%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -nostartfiles -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti -flto -T ..\..\ldscripts\microbit.ld -g -o hello.elf hello.o
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B
 
 :build_no_cfi_fn
 %BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -fno-exceptions -fno-rtti -flto -g -c hello.cpp
-%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti -flto -T ..\..\ldscripts\microbit.ld -g -o hello.elf hello.o
+%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -nostartfiles -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti -flto -T ..\..\ldscripts\microbit.ld -g -o hello.elf hello.o
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B

--- a/samples/src/cpp-baremetal-semihosting-prof/make.bat
+++ b/samples/src/cpp-baremetal-semihosting-prof/make.bat
@@ -55,6 +55,6 @@ if exist proflib.o del /q proflib.o
 
 :build_fn
 %BIN_PATH%\clang.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -g -c proflib.c
-%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti -g -T ..\..\ldscripts\microbit.ld -fprofile-instr-generate -fcoverage-mapping -o hello.elf hello.cpp proflib.o
+%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -nostartfiles -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti -g -T ..\..\ldscripts\microbit.ld -fprofile-instr-generate -fcoverage-mapping -o hello.elf hello.cpp proflib.o
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B

--- a/samples/src/cpp-baremetal-semihosting-ubsan/make.bat
+++ b/samples/src/cpp-baremetal-semihosting-ubsan/make.bat
@@ -55,11 +55,11 @@ if exist hello.hex del /q hello.hex
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti --std=c++17 -fsanitize=undefined -fsanitize-minimal-runtime -g -T ../../ldscripts/microbit.ld -o hello.elf *.cpp
+%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -nostartfiles -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti --std=c++17 -fsanitize=undefined -fsanitize-minimal-runtime -g -T ../../ldscripts/microbit.ld -o hello.elf *.cpp
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B
 
 :build_trap_fn
-%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti --std=c++17 -fsanitize=undefined -fsanitize-trap=all -g -T ../../ldscripts/microbit.ld -o hello.elf *.cpp
+%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -nostartfiles -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti --std=c++17 -fsanitize=undefined -fsanitize-trap=all -g -T ../../ldscripts/microbit.ld -o hello.elf *.cpp
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B

--- a/samples/src/cpp-baremetal-semihosting/make.bat
+++ b/samples/src/cpp-baremetal-semihosting/make.bat
@@ -49,6 +49,6 @@ if exist hello.hex del /q hello.hex
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti -g -T ..\..\ldscripts\microbit.ld -o hello.elf hello.cpp
+%BIN_PATH%\clang++.exe --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -nostartfiles -lcrt0-semihost -lsemihost -fno-exceptions -fno-rtti -g -T ..\..\ldscripts\microbit.ld -o hello.elf hello.cpp
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B

--- a/test-support/llvm-libc++-picolibc.cfg.in
+++ b/test-support/llvm-libc++-picolibc.cfg.in
@@ -27,7 +27,7 @@ config.substitutions.append(('%{link_flags}',
     ' -nostdlib++ -L %{lib-dir}'
     ' -lc++ -lc++abi'
     ' -nostdlib -L %{libc-lib}'
-    ' -lc -lm -lclang_rt.builtins -lsemihost -lcrt0-semihost'
+    ' -lc -lm -lclang_rt.builtins -lsemihost -nostartfiles -lcrt0-semihost'
     ' -T %{libc-linker-script}'
 ))
 config.substitutions.append(('%{exec}',

--- a/test-support/llvm-libc++abi-picolibc.cfg.in
+++ b/test-support/llvm-libc++abi-picolibc.cfg.in
@@ -19,7 +19,7 @@ config.substitutions.append(('%{link_flags}',
     ' -nostdlib++ -L %{lib}'
     ' -lc++ -lc++abi'
     ' -nostdlib -L %{libc-lib}'
-    ' -lc -lm -lclang_rt.builtins -lsemihost -lcrt0-semihost'
+    ' -lc -lm -lclang_rt.builtins -lsemihost -nostartfiles -lcrt0-semihost'
     ' -T %{libc-linker-script}'
 ))
 config.substitutions.append(('%{exec}',

--- a/test-support/llvm-libunwind-picolibc.cfg.in
+++ b/test-support/llvm-libunwind-picolibc.cfg.in
@@ -32,7 +32,7 @@ config.substitutions.append(('%{link_flags}',
     ' -nostdlib++ -L %{lib}'
     ' -lc++ -lc++abi -lunwind'
     ' -nostdlib -L %{libc-lib}'
-    ' -lc -lm -lclang_rt.builtins -lsemihost -lcrt0-semihost'
+    ' -lc -lm -lclang_rt.builtins -lsemihost -nostartfiles -lcrt0-semihost'
     ' -T %{libc-linker-script}'
 ))
 config.substitutions.append(('%{exec}',


### PR DESCRIPTION
This commit adds the -nostartfiles option to tests using semihosting. This is in response to a recent change in clang which modified the driver to include crt0.o in the link:
https://github.com/llvm/llvm-project/pull/101258

While the change to clang removes the need to include the crt0 library directly, the tests using semihosting need to link against a different crt0 library. Therefore the new default behavior needs to be suppressed in these cases, which can be done by adding the -nostartfiles option.