### PR TITLE
Add missing armv7 library variants.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1605,7 +1605,7 @@ add_library_variants_for_cpu(
 )
 add_library_variants_for_cpu(
     armv7a
-    SUFFIX softfp_vfpv3_d16
+    SUFFIX soft_vfpv3_d16
     COMPILE_FLAGS "-mfloat-abi=softfp -march=armv7a -mfpu=vfpv3-d16"
     MULTILIB_FLAGS "--target=armv7-unknown-none-eabi -mfpu=vfpv3-d16"
     PICOLIBC_BUILD_TYPE "release"
@@ -1656,9 +1656,9 @@ add_library_variants_for_cpu(
 )
 add_library_variants_for_cpu(
     armv7r
-    SUFFIX soft_vfpv3_d16
-    COMPILE_FLAGS "-mfloat-abi=soft -march=armv7r -mfpu=vfpv3-d16"
-    MULTILIB_FLAGS "--target=armv7r-unknown-none-eabihf -mfpu=vfpv3-d16"
+    SUFFIX hard_vfpv3xd
+    COMPILE_FLAGS "-mfloat-abi=hard -march=armv7r -mfpu=vfpv3xd"
+    MULTILIB_FLAGS "--target=armv7r-unknown-none-eabihf -mfpu=vfpv3xd"
     PICOLIBC_BUILD_TYPE "release"
     QEMU_MACHINE "none"
     QEMU_CPU "cortex-r5f"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1604,6 +1604,23 @@ add_library_variants_for_cpu(
     STACK_SIZE 4K
 )
 add_library_variants_for_cpu(
+    armv7a
+    SUFFIX softfp_vfpv3_d16
+    COMPILE_FLAGS "-mfloat-abi=softfp -march=armv7a -mfpu=vfpv3-d16"
+    MULTILIB_FLAGS "--target=armv7-unknown-none-eabi -mfpu=vfpv3-d16"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "cortex-a8"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
     armv7r
     SUFFIX soft_nofp
     COMPILE_FLAGS "-mfloat-abi=soft -march=armv7r -mfpu=none"
@@ -1624,6 +1641,23 @@ add_library_variants_for_cpu(
     armv7r
     SUFFIX hard_vfpv3_d16
     COMPILE_FLAGS "-mfloat-abi=hard -march=armv7r -mfpu=vfpv3-d16"
+    MULTILIB_FLAGS "--target=armv7r-unknown-none-eabihf -mfpu=vfpv3-d16"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "cortex-r5f"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    armv7r
+    SUFFIX soft_vfpv3_d16
+    COMPILE_FLAGS "-mfloat-abi=soft -march=armv7r -mfpu=vfpv3-d16"
     MULTILIB_FLAGS "--target=armv7r-unknown-none-eabihf -mfpu=vfpv3-d16"
     PICOLIBC_BUILD_TYPE "release"
     QEMU_MACHINE "none"

--- a/test-support/picolibc-test-wrapper.py
+++ b/test-support/picolibc-test-wrapper.py
@@ -18,6 +18,8 @@ disabled_tests = [
     # https://github.com/picolibc/picolibc/pull/500
     "picolibc_armv7m_soft_fpv4_sp_d16-build/test/math_errhandling",
     "picolibc_armv7m_hard_fpv4_sp_d16-build/test/math_errhandling",
+    "picolibc_armv7r_hard_vfpv3xd-build/test/math_errhandling",
+    "picolibc_armv7r_hard_vfpv3xd_exn_rtti-build/test/math_errhandling",
     "picolibc_armv8.1m.main_hard_fp_nomve-build/test/math_errhandling",
     "picolibc_armv7m_soft_fpv4_sp_d16_exn_rtti-build/test/math_errhandling",
     "picolibc_armv7m_hard_fpv4_sp_d16_exn_rtti-build/test/math_errhandling",

--- a/test/multilib/armv7a.test
+++ b/test/multilib/armv7a.test
@@ -23,6 +23,20 @@
 # VFPV3: arm-none-eabi/armv7a_hard_vfpv3_d16_exn_rtti{{$}}
 # VFPV3-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv3-d16 -mfloat-abi=softfp | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=neon-vfpv3 -mfloat-abi=softfp | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv3 -mfloat-abi=softfp | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv3-d16-fp16 -mfloat-abi=softfp | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv3-fp16 -mfloat-abi=softfp | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv4-d16 -mfloat-abi=softfp | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv4 -mfloat-abi=softfp | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=neon-fp16 -mfloat-abi=softfp | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=neon-vfpv4 -mfloat-abi=softfp | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv3-d16 -marm -mfloat-abi=softfp | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv3-d16 -mthumb -mfloat-abi=softfp | FileCheck --check-prefix=VFPV3 %s
+# VFPV3: arm-none-eabi/armv7a_soft_vfpv3_d16_exn_rtti{{$}}
+# VFPV3-EMPTY:
+
 # We have no valid variant for this configuration, yet.
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=vfpv3-d16 2>&1 | FileCheck --check-prefix=NOT-FOUND %s
 

--- a/test/multilib/armv7r.test
+++ b/test/multilib/armv7r.test
@@ -9,3 +9,9 @@
 # RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3-d16 -mthumb | FileCheck --check-prefix=VFPV3 %s
 # VFPV3: arm-none-eabi/armv7r_hard_vfpv3_d16_exn_rtti{{$}}
 # VFPV3-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3xd         | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3xd -marm   | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3xd -mthumb | FileCheck --check-prefix=VFPV3 %s
+# VFPV3: arm-none-eabi/armv7r_hard_vfpv3xd_exn_rtti{{$}}
+# VFPV3-EMPTY:


### PR DESCRIPTION
This patch adds the following library variants.

                1. armv7r hard_vfpv3xd
                2. armv7a soft_vfpv3_d16.

Also disable the math_errhandling tests to the set of disabled
tests for the armv7r_hard_vfpv3xd library variant.These tests were
already disabled for the previously existing variants, due to a known
issue in compiler-rt where the floating point exceptions are not set
correctly for computations on types implemented in software.