### PR TITLE
Set picolibc version to a working revision

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -12,8 +12,8 @@
       "tag": "main"
     },
     "picolibc": {
-      "tagType": "branch",
-      "tag": "main"
+      "tagType": "commithash",
+      "tag": "e434fa1f41a83a888d6498922ab7f140011933d1"
     },
     "newlib": {
       "tagType": "tag",


### PR DESCRIPTION
Commit hash e434fa1f41a83a888d6498922ab7f140011933d1 was the last one working. Set it as the default revision while recent breakages are not fixed.