### PR TITLE
[CMakeLists] Correct suggested -DFETCHCONTENT_SOURCE_DIR script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,9 @@
 # If you prefer you can check out and patch the repos manually and use those:
 #   mkdir repos
 #   git -C repos clone https://github.com/llvm/llvm-project.git
-#   git -C repos/llvm-project am -k ../../patches/llvm-project/*.patch
+#   git -C repos/llvm-project am -k $PWD/patches/llvm-project/*.patch
 #   git -C repos clone https://github.com/picolibc/picolibc.git
-#   git -C repos/picolibc apply ../../patches/picolibc.patch
+#   git -C repos/picolibc apply $PWD/patches/picolibc.patch
 #   mkdir build
 #   cd build
 #   cmake .. -GNinja -DFETCHCONTENT_SOURCE_DIR_LLVMPROJECT=../repos/llvm-project -DFETCHCONTENT_SOURCE_DIR_PICOLIBC=../repos/picolibc


### PR DESCRIPTION
A header comment in CMakeLists.txt suggests a sequence of commands for manually checking out the source repos and applying the patches. But it doesn't work, because it includes the command

  git -C repos/llvm-project am -k ../../patches/llvm-project/*.patch

which, under POSIX shell semantics, is handled by first trying to expand the wildcard, then running the git command, which will change directory into `repos/llvm-project` because of the `-C` option. But the command only works if the wildcard is expanded _after_ changing directory, because the `../..` on the front of the pathname is intended to get back out of `repos/llvm-project`.

To fix this, I've replaced the relative paths with `$PWD`, which will be expanded before git changes directory, so the pathnames will refer to the root of this repo.

(I wondered if the command would have worked as written on Windows, where wildcards are expanded by the application and not the shell. But it doesn't look like it: on Windows, `git am` doesn't seem to expand wildcards at all. So it would be much more painful to rewrite this command sequence in a Windows-compatible way, and in this commit I haven't tried.)