### PR TITLE
Add Armv8.1-M PACBTI library variants

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1818,6 +1818,74 @@ add_library_variants_for_cpu(
     RAM_SIZE 0x1000000
     STACK_SIZE 4K
 )
+# FIXME: qemu currently has no support for PACBTI-M, so the branch protection
+# variants below can't be fully tested in runtime. Since PACBTI-M instructions
+# are NOP-compatible we can use the cortext-m55 CPU for now, but these should be
+# updated to use a PACBTI-M enabled CPU once this is available.
+add_library_variants_for_cpu(
+    armv8.1m.main
+    SUFFIX soft_nofp_nomve_pacret_bti
+    COMPILE_FLAGS "-mfloat-abi=soft -march=armv8.1m.main+nomve -mfpu=none -mbranch-protection=standard"
+    MULTILIB_FLAGS "--target=thumbv8.1m.main-unknown-none-eabi -mfpu=none -mbranch-protection=standard"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "mps3-an547"
+    QEMU_CPU "cortex-m55"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 512K
+    FLASH_ADDRESS 0x60000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x61000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    armv8.1m.main
+    SUFFIX hard_fp_nomve_pacret_bti
+    COMPILE_FLAGS "-mfloat-abi=hard -march=armv8.1m.main+nomve -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=standard"
+    MULTILIB_FLAGS "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=standard"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "mps3-an547"
+    QEMU_CPU "cortex-m55"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 512K
+    FLASH_ADDRESS 0x60000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x61000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    armv8.1m.main
+    SUFFIX hard_fpdp_nomve_pacret_bti
+    COMPILE_FLAGS "-mfloat-abi=hard -march=armv8.1m.main+nomve -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=standard"
+    MULTILIB_FLAGS "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=standard"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "mps3-an547"
+    QEMU_CPU "cortex-m55"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 512K
+    FLASH_ADDRESS 0x60000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x61000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    armv8.1m.main
+    SUFFIX hard_nofp_mve_pacret_bti
+    COMPILE_FLAGS "-mfloat-abi=hard -march=armv8.1m.main+mve -mfpu=none -mbranch-protection=standard"
+    MULTILIB_FLAGS "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+mve -mfpu=none -mbranch-protection=standard"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "mps3-an547"
+    QEMU_CPU "cortex-m55"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 512K
+    FLASH_ADDRESS 0x60000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x61000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
 
 
 configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1820,7 +1820,7 @@ add_library_variants_for_cpu(
 )
 # FIXME: qemu currently has no support for PACBTI-M, so the branch protection
 # variants below can't be fully tested in runtime. Since PACBTI-M instructions
-# are NOP-compatible we can use the cortext-m55 CPU for now, but these should be
+# are NOP-compatible we can use the cortex-m55 CPU for now, but these should be
 # updated to use a PACBTI-M enabled CPU once this is available.
 add_library_variants_for_cpu(
     armv8.1m.main

--- a/cmake/multilib.yaml.in
+++ b/cmake/multilib.yaml.in
@@ -138,3 +138,8 @@ Mappings:
 - Match: -march=thumbv8\.[1-9]m\.main(\+[^\+]+)*\+lob(\+[^\+]+)*
   Flags:
   - -march=thumbv8.1m.main+lob
+
+# -mbranch-protection options
+- Match: -mbranch-protection=(standard|pac-ret(\+leaf)?\+bti|bti\+pac-ret(\+leaf)?)
+  Flags:
+  - -mbranch-protection=pac-ret+bti


### PR DESCRIPTION
This adds the folowing library variants with support for the PACBTI-M
architecture extension:
* armv8.1m.main_soft_nofp_nomve_pacret_bti[_exn_rtti]
* armv8.1m.main_hard_fp_nomve_pacret_bti[_exn_rtti]
* armv8.1m.main_hard_fpdp_nomve_pacret_bti[_exn_rtti]
* armv8.1m.main_hard_nofp_mve_pacret_bti[_exn_rtti]

Unfortunately, qemu currently doesn't provide support for PACBTI-M,
which means these variants can't be fully tested at runtime level.
Since the PACBTI-M instructions are NOP-copatible, we can use an
arvm8.1m.main CPU as a workaround to ensure that the library code
still works correctly regardless of branch protecion.
