### PR TITLE
Fix path in build from source recipe

### DIFF
--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -63,9 +63,9 @@ If you check out repos manually then it is your responsibility to ensure that th
 ```
 mkdir repos
 git -C repos clone https://github.com/llvm/llvm-project.git
-git -C repos/llvm-project am -k "$PWD"/../patches/llvm-project/*.patch
+git -C repos/llvm-project am -k "$PWD"/patches/llvm-project/*.patch
 git -C repos clone https://github.com/picolibc/picolibc.git
-git -C repos/picolibc apply "$PWD"/../patches/picolibc.patch
+git -C repos/picolibc apply "$PWD"/patches/picolibc.patch
 mkdir build
 cd build
 cmake .. -GNinja -DFETCHCONTENT_SOURCE_DIR_LLVMPROJECT=../repos/llvm-project -DFETCHCONTENT_SOURCE_DIR_PICOLIBC=../repos/picolibc


### PR DESCRIPTION
In the `Building` section of building-from-source.md, twice we are trying to apply a patch with the following command:

    git -C repos/<repo> am -k "$PWD"/../patches/<repo>/*.patch

This command is executed from the root of the repo. The original thought for this must have been that because of the `-C`, our path at time of execution is `repos/<repo>`, and thus we need to move a level up from our current directory. However `$PWD` will be replaced by the shell before the command is executed. So we need to remove the spurious `../`.