### PR TITLE
Add missing set of disabled tests for PACBTI-M variants

### DIFF
--- a/test-support/picolibc-test-wrapper.py
+++ b/test-support/picolibc-test-wrapper.py
@@ -28,6 +28,12 @@ disabled_tests = [
     "picolibc_armv8.1m.main_hard_nofp_mve_exn_rtti-build/test/fenv",
     "picolibc_armv8.1m.main_hard_nofp_mve_exn_rtti-build/test/math_errhandling",
     "picolibc_armv8m.main_hard_fp_exn_rtti-build/test/math_errhandling",
+    "picolibc_armv8.1m.main_hard_nofp_mve_pacret_bti-build/test/fenv",
+    "picolibc_armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti-build/test/fenv",
+    "picolibc_armv8.1m.main_hard_fp_nomve_pacret_bti-build/test/math_errhandling",
+    "picolibc_armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti-build/test/math_errhandling",
+    "picolibc_armv8.1m.main_hard_nofp_mve_pacret_bti-build/test/math_errhandling",
+    "picolibc_armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti-build/test/math_errhandling",
 ]
 
 


### PR DESCRIPTION
This adds the `fenv` and `math_errhandling` tests to the set of disabled
tests for the PACBTI-M library variants, introduced by #467.

These tests were already disabled for the previously existing variants,
due to a known issue in compiler-rt where the floating point exceptions
are not set correctly for computations on types implemented in software.
