### PR TITLE
Use latest HEAD from picolibc

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -12,8 +12,8 @@
       "tag": "main"
     },
     "picolibc": {
-      "tagType": "commithash",
-      "tag": "e434fa1f41a83a888d6498922ab7f140011933d1"
+      "tagType": "branch",
+      "tag": "main"
     },
     "newlib": {
       "tagType": "tag",


### PR DESCRIPTION
Now that the limits.h issue [^1] has been resolved in picolibc upstream [^2], we can go back to its latest HEAD.

[^1]: Commit hash cdc4fc3164cf8ac4c7ff6c4025822b792c7394f8
[^2]: https://github.com/picolibc/picolibc/pull/810