### PR TITLE
Add multilib mappings for thumb triples

### DIFF
--- a/cmake/multilib.yaml.in
+++ b/cmake/multilib.yaml.in
@@ -107,15 +107,33 @@ Mappings:
 - Match: --target=thumbv7em-unknown-none-eabihf
   Flags:
   - --target=thumbv7m-unknown-none-eabihf
+
+# v7-A and v7-R include the ISA in the triple, but that doesn't matter for
+# library selection, so canonicalise Thumb triples to ARM ones.
 - Match: --target=thumbv7r-unknown-none-eabi
   Flags:
   - --target=armv7r-unknown-none-eabi
+- Match: --target=thumbv7r-unknown-none-eabihf
+  Flags:
+  - --target=armv7r-unknown-none-eabihf
+- Match: --target=thumbv7-unknown-none-eabi
+  Flags:
+  - --target=armv7-unknown-none-eabi
+- Match: --target=thumbv7-unknown-none-eabihf
+  Flags:
+  - --target=armv7-unknown-none-eabihf
 - Match: --target=thumbv4t-unknown-none-eabi
   Flags:
   - --target=armv4t-unknown-none-eabi
+- Match: --target=thumbv4t-unknown-none-eabihf
+  Flags:
+  - --target=armv4t-unknown-none-eabihf
 - Match: --target=thumbv5e-unknown-none-eabi
   Flags:
   - --target=armv5e-unknown-none-eabi
+- Match: --target=thumbv5e-unknown-none-eabihf
+  Flags:
+  - --target=armv5e-unknown-none-eabihf
 
 # Higher versions of v8-A, and v9-A, are all supersets of v8-A. (And
 # of each other, in the obvious way, but we don't have any libraries

--- a/test/multilib/armv7a.test
+++ b/test/multilib/armv7a.test
@@ -1,4 +1,6 @@
-# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=none | FileCheck %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=none        | FileCheck %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=none -marm  | FileCheck %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=none -mthumb| FileCheck %s
 # CHECK: arm-none-eabi/armv7a_soft_nofp_exn_rtti{{$}}
 # CHECK-EMPTY:
 
@@ -11,6 +13,8 @@
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv4 | FileCheck --check-prefix=VFPV3 %s
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=neon-fp16 | FileCheck --check-prefix=VFPV3 %s
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=neon-vfpv4 | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv3-d16 -marm | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv3-d16 -mthumb | FileCheck --check-prefix=VFPV3 %s
 # VFPV3: arm-none-eabi/armv7a_hard_vfpv3_d16_exn_rtti{{$}}
 # VFPV3-EMPTY:
 

--- a/test/multilib/armv7r.test
+++ b/test/multilib/armv7r.test
@@ -1,7 +1,11 @@
-# RUN: %clang -print-multi-directory --target=armv7r-none-eabi -mfpu=none | FileCheck %s
+# RUN: %clang -print-multi-directory --target=armv7r-none-eabi -mfpu=none         | FileCheck %s
+# RUN: %clang -print-multi-directory --target=armv7r-none-eabi -mfpu=none -marm   | FileCheck %s
+# RUN: %clang -print-multi-directory --target=armv7r-none-eabi -mfpu=none -mthumb | FileCheck %s
 # CHECK: arm-none-eabi/armv7r_soft_nofp_exn_rtti{{$}}
 # CHECK-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3-d16 | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3-d16         | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3-d16 -marm   | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3-d16 -mthumb | FileCheck --check-prefix=VFPV3 %s
 # VFPV3: arm-none-eabi/armv7r_hard_vfpv3_d16_exn_rtti{{$}}
 # VFPV3-EMPTY:


### PR DESCRIPTION
The instruction set (ARM/Thumb) is included in the triple, but doesn't matter for library selection because the ISA can be switched on any function call. This adds match blocks to multilib.yaml to treat thumb triples as if they were arm triples for library selection.

This will also be needed for AArch32 v8-A and v8-R, but we don't have any libraries for them yet.