### PR TITLE
Add multilib mappings for armv7ve

### DIFF
--- a/cmake/multilib.yaml.in
+++ b/cmake/multilib.yaml.in
@@ -135,6 +135,21 @@ Mappings:
   Flags:
   - --target=armv5e-unknown-none-eabihf
 
+# armv7ve is a GCC name for v7-A with the virtualisation extension, for library
+# selection we treat it the same as v7-A.
+- Match: --target=armv7ve-unknown-none-eabi
+  Flags:
+  - --target=armv7-unknown-none-eabi
+- Match: --target=armv7ve-unknown-none-eabihf
+  Flags:
+  - --target=armv7-unknown-none-eabihf
+- Match: --target=thumbv7ve-unknown-none-eabi
+  Flags:
+  - --target=armv7-unknown-none-eabi
+- Match: --target=thumbv7ve-unknown-none-eabihf
+  Flags:
+  - --target=armv7-unknown-none-eabihf
+
 # Higher versions of v8-A, and v9-A, are all supersets of v8-A. (And
 # of each other, in the obvious way, but we don't have any libraries
 # for those at present, so there's no need to generate all their

--- a/cmake/multilib.yaml.in
+++ b/cmake/multilib.yaml.in
@@ -137,16 +137,10 @@ Mappings:
 
 # armv7ve is a GCC name for v7-A with the virtualisation extension, for library
 # selection we treat it the same as v7-A.
-- Match: --target=armv7ve-unknown-none-eabi
+- Match: --target=(arm|thumb)v7ve-unknown-none-eabi
   Flags:
   - --target=armv7-unknown-none-eabi
-- Match: --target=armv7ve-unknown-none-eabihf
-  Flags:
-  - --target=armv7-unknown-none-eabihf
-- Match: --target=thumbv7ve-unknown-none-eabi
-  Flags:
-  - --target=armv7-unknown-none-eabi
-- Match: --target=thumbv7ve-unknown-none-eabihf
+- Match: --target=(arm|thumb)v7ve-unknown-none-eabihf
   Flags:
   - --target=armv7-unknown-none-eabihf
 

--- a/test/multilib/armv7a.test
+++ b/test/multilib/armv7a.test
@@ -1,6 +1,9 @@
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=none        | FileCheck %s
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=none -marm  | FileCheck %s
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=none -mthumb| FileCheck %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mfpu=none        | FileCheck %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mfpu=none -marm  | FileCheck %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mfpu=none -mthumb| FileCheck %s
 # CHECK: arm-none-eabi/armv7a_soft_nofp_exn_rtti{{$}}
 # CHECK-EMPTY:
 
@@ -15,6 +18,8 @@
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=neon-vfpv4 | FileCheck --check-prefix=VFPV3 %s
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv3-d16 -marm | FileCheck --check-prefix=VFPV3 %s
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv3-d16 -mthumb | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mfpu=vfpv3-d16 | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mfpu=vfpv3-d16 -mthumb | FileCheck --check-prefix=VFPV3 %s
 # VFPV3: arm-none-eabi/armv7a_hard_vfpv3_d16_exn_rtti{{$}}
 # VFPV3-EMPTY:
 


### PR DESCRIPTION
This is a GCC name for v7-A with the virtualisation extension, so for library selection we can treat it the same as v7-A.