### PR TITLE
Reorder the add_library_variant calls for the armv7r_hard_vfpv3_d16 to win

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1639,9 +1639,9 @@ add_library_variants_for_cpu(
 )
 add_library_variants_for_cpu(
     armv7r
-    SUFFIX hard_vfpv3_d16
-    COMPILE_FLAGS "-mfloat-abi=hard -march=armv7r -mfpu=vfpv3-d16"
-    MULTILIB_FLAGS "--target=armv7r-unknown-none-eabihf -mfpu=vfpv3-d16"
+    SUFFIX hard_vfpv3xd
+    COMPILE_FLAGS "-mfloat-abi=hard -march=armv7r -mfpu=vfpv3xd"
+    MULTILIB_FLAGS "--target=armv7r-unknown-none-eabihf -mfpu=vfpv3xd"
     PICOLIBC_BUILD_TYPE "release"
     QEMU_MACHINE "none"
     QEMU_CPU "cortex-r5f"
@@ -1656,9 +1656,9 @@ add_library_variants_for_cpu(
 )
 add_library_variants_for_cpu(
     armv7r
-    SUFFIX hard_vfpv3xd
-    COMPILE_FLAGS "-mfloat-abi=hard -march=armv7r -mfpu=vfpv3xd"
-    MULTILIB_FLAGS "--target=armv7r-unknown-none-eabihf -mfpu=vfpv3xd"
+    SUFFIX hard_vfpv3_d16
+    COMPILE_FLAGS "-mfloat-abi=hard -march=armv7r -mfpu=vfpv3-d16"
+    MULTILIB_FLAGS "--target=armv7r-unknown-none-eabihf -mfpu=vfpv3-d16"
     PICOLIBC_BUILD_TYPE "release"
     QEMU_MACHINE "none"
     QEMU_CPU "cortex-r5f"


### PR DESCRIPTION
The order in multilib.yaml matches the order of the libraries in CMakeLists.txt.

At the moment both the below commandline options selecting the same library variant.
```
$ clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3-d16
arm-none-eabi/armv7r_hard_vfpv3xd_exn_rtti
$ clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3xd
arm-none-eabi/armv7r_hard_vfpv3xd_exn_rtti
``` 
We need to reorder the the add_library_variant calls so that armv7r_hard_vfpv3_d16 gets selected appropriately.