### PR TITLE
Add missing armv7 library variants

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1672,6 +1672,23 @@ add_library_variants_for_cpu(
     STACK_SIZE 4K
 )
 add_library_variants_for_cpu(
+    armv7r
+    SUFFIX soft_vfpv3_d16
+    COMPILE_FLAGS "-mfloat-abi=softfp -march=armv7r -mfpu=vfpv3-d16"
+    MULTILIB_FLAGS "--target=armv7r-unknown-none-eabi -mfpu=vfpv3-d16"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "cortex-r5f"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
     armv7m
     SUFFIX soft_fpv4_sp_d16
     COMPILE_FLAGS "-mfloat-abi=softfp -march=armv7m -mfpu=fpv4-sp-d16"

--- a/test/multilib/armv7r.test
+++ b/test/multilib/armv7r.test
@@ -10,6 +10,12 @@
 # VFPV3: arm-none-eabi/armv7r_hard_vfpv3_d16_exn_rtti{{$}}
 # VFPV3-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3-d16 -mfloat-abi=softfp   | FileCheck --check-prefix=SOFT-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3-d16 -marm -mfloat-abi=softfp  | FileCheck --check-prefix=SOFT-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3-d16 -mthumb -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-VFPV3 %s
+# SOFT-VFPV3: arm-none-eabi/armv7r_soft_vfpv3_d16_exn_rtti{{$}}
+# SOFT-VFPV3-EMPTY:
+
 # RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3xd         | FileCheck --check-prefix=VFPV3XD %s
 # RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3xd -marm   | FileCheck --check-prefix=VFPV3XD %s
 # RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3xd -mthumb | FileCheck --check-prefix=VFPV3XD %s


### PR DESCRIPTION
This patch adds the following library variant.

     1. armv7r soft_vfpv3_d16.

Adding tests in test/multilib to make sure that all the newly added library variants  get selected correctly..