### PR TITLE
Diagnose an unsupported multilib setup: MVE soft-float.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1441,6 +1441,26 @@ function(add_library_variant target_arch)
     set(multilib_yaml_content "${multilib_yaml_content}" PARENT_SCOPE)
 endfunction()
 
+function(add_nonexistent_library_variant)
+    set(
+        one_value_args
+        MULTILIB_FLAGS
+        ERROR_MESSAGE
+    )
+    cmake_parse_arguments(ERR "" "${one_value_args}" "" ${ARGN})
+
+    string(APPEND multilib_yaml_content "- FatalError: \"${ERR_ERROR_MESSAGE}\"\n")
+
+    string(APPEND multilib_yaml_content "  Flags:\n")
+    string(REPLACE " " ";" multilib_flags_list ${ERR_MULTILIB_FLAGS})
+    foreach(flag ${multilib_flags_list})
+        string(APPEND multilib_yaml_content "  - ${flag}\n")
+    endforeach()
+    string(APPEND multilib_yaml_content "  Group: stdlibs\n")
+
+    set(multilib_yaml_content "${multilib_yaml_content}" PARENT_SCOPE)
+endfunction()
+
 function(add_library_variants_for_cpu target_arch)
     set(
         one_value_args
@@ -1853,6 +1873,17 @@ add_library_variants_for_cpu(
     RAM_ADDRESS 0x61000000
     RAM_SIZE 0x1000000
     STACK_SIZE 4K
+)
+add_nonexistent_library_variant(
+    # We don't build any MVE-capable libraries with the soft-float ABI.
+    # We do have Armv7-M soft-float libraries, but you can't fall back to
+    # using those, because MVE requires the FPSCR to be set up specially
+    # at startup time, and our v7-M soft-float libraries don't do that.
+    #
+    # So, rather than select one of those libraries and silently generate
+    # wrong MVE code, we force an error report instead.
+    MULTILIB_FLAGS "--target=thumbv8.1m.main-unknown-none-eabi -march=thumbv8.1m.main+mve"
+    ERROR_MESSAGE "No library available for MVE with soft-float ABI. Try -mfloat-abi=hard."
 )
 # FIXME: qemu currently has no support for PACBTI-M, so the branch protection
 # variants below can't be fully tested in runtime. Since PACBTI-M instructions

--- a/test/multilib/armv8.1m.main.test
+++ b/test/multilib/armv8.1m.main.test
@@ -20,12 +20,15 @@
 # MVE: arm-none-eabi/armv8.1m.main_hard_nofp_mve_exn_rtti{{$}}
 # MVE-EMPTY:
 
-# TODO: We need to find a way to make this fail. For now it fallbacks to
-# arm-none-eabi/armv8.1m.main_soft_nofp, which will not initilize the
-# coprocessor nor will save/restore its registers in setjmp/longjmp.
-# DONT-RUN-YET: %clang -print-multi-directory --target=armv8.1m.main-none-eabi -march=armv8.1m.main+mve -mfpu=none | FileCheck --check-prefix=SOFTFP_MVE %s
-# SOFTFP_MVE: ?
-# SOFTFP_MVE-EMPTY:
+## This combination is not supported at all, because we don't provide any
+## MVE libraries with the soft-float ABI, and we can't fall back to Armv7-M
+## soft-float libraries because they won't initialize the FPSCR correctly
+## for MVE, or save and restore the vector registers in setjmp/longjmp.
+## So we expect this to fail, with a custom error message.
+# RUN: not %clang -print-multi-directory --target=armv8.1m.main-none-eabi -march=armv8.1m.main+mve -mfpu=none 2>%t | FileCheck --check-prefix=SOFTFP_MVE --allow-empty %s
+# RUN: FileCheck --check-prefix=SOFTFP_MVE_ERR %s < %t
+# SOFTFP_MVE-NOT: arm-none-eabi
+# SOFTFP_MVE_ERR: clang: error: multilib configuration error: No library available for MVE with soft-float ABI. Try -mfloat-abi=hard.
 
 # RUN: %clang -print-multi-flags-experimental --target=arm-none-eabihf -mcpu=cortex-m55 | FileCheck --check-prefix=CORTEXM55 %s
 # CORTEXM55: -march=thumbv8.1m.main+fp16


### PR DESCRIPTION
We don't build any MVE-capable libraries with the soft-float ABI. We do have Armv7-M soft-float libraries, but you can't fall back to using those, because MVE requires the FPSCR to be set up specially at startup time, and our v7-M soft-float libraries don't do that.

So, rather than select one of those libraries and silently generate wrong MVE code, we should force an error report instead. This commit arranges that, by using the new FatalError flag recently added to the multilib.yaml mechanism.

We already had a commented-out test for this case, so I've uncommented it and made it expect a compile failure with the custom error message.