### PR TITLE
Fix multilib PACBTI mapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1874,8 +1874,8 @@ add_library_variants_for_cpu(
 add_library_variants_for_cpu(
     armv8.1m.main
     SUFFIX soft_nofp_nomve_pacret_bti
-    COMPILE_FLAGS "-mfloat-abi=soft -march=armv8.1m.main+nomve+pacbti -mfpu=none -mbranch-protection=standard"
-    MULTILIB_FLAGS "--target=thumbv8.1m.main-unknown-none-eabi -mfpu=none -mbranch-protection=standard"
+    COMPILE_FLAGS "-mfloat-abi=soft -march=armv8.1m.main+nomve+pacbti -mfpu=none -mbranch-protection=pac-ret+bti"
+    MULTILIB_FLAGS "--target=thumbv8.1m.main-unknown-none-eabi -mfpu=none -mbranch-protection=pac-ret+bti"
     PICOLIBC_BUILD_TYPE "release"
     QEMU_MACHINE "mps3-an547"
     QEMU_CPU "cortex-m55"
@@ -1890,8 +1890,8 @@ add_library_variants_for_cpu(
 add_library_variants_for_cpu(
     armv8.1m.main
     SUFFIX hard_fp_nomve_pacret_bti
-    COMPILE_FLAGS "-mfloat-abi=hard -march=armv8.1m.main+nomve+pacbti -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=standard"
-    MULTILIB_FLAGS "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=standard"
+    COMPILE_FLAGS "-mfloat-abi=hard -march=armv8.1m.main+nomve+pacbti -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti"
+    MULTILIB_FLAGS "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti"
     PICOLIBC_BUILD_TYPE "release"
     QEMU_MACHINE "mps3-an547"
     QEMU_CPU "cortex-m55"
@@ -1906,8 +1906,8 @@ add_library_variants_for_cpu(
 add_library_variants_for_cpu(
     armv8.1m.main
     SUFFIX hard_fpdp_nomve_pacret_bti
-    COMPILE_FLAGS "-mfloat-abi=hard -march=armv8.1m.main+nomve+pacbti -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=standard"
-    MULTILIB_FLAGS "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=standard"
+    COMPILE_FLAGS "-mfloat-abi=hard -march=armv8.1m.main+nomve+pacbti -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti"
+    MULTILIB_FLAGS "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti"
     PICOLIBC_BUILD_TYPE "release"
     QEMU_MACHINE "mps3-an547"
     QEMU_CPU "cortex-m55"
@@ -1922,8 +1922,8 @@ add_library_variants_for_cpu(
 add_library_variants_for_cpu(
     armv8.1m.main
     SUFFIX hard_nofp_mve_pacret_bti
-    COMPILE_FLAGS "-mfloat-abi=hard -march=armv8.1m.main+mve+pacbti -mfpu=none -mbranch-protection=standard"
-    MULTILIB_FLAGS "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+mve -mfpu=none -mbranch-protection=standard"
+    COMPILE_FLAGS "-mfloat-abi=hard -march=armv8.1m.main+mve+pacbti -mfpu=none -mbranch-protection=pac-ret+bti"
+    MULTILIB_FLAGS "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+mve -mfpu=none -mbranch-protection=pac-ret+bti"
     PICOLIBC_BUILD_TYPE "release"
     QEMU_MACHINE "mps3-an547"
     QEMU_CPU "cortex-m55"

--- a/cmake/multilib.yaml.in
+++ b/cmake/multilib.yaml.in
@@ -174,6 +174,6 @@ Mappings:
   - -march=thumbv8.1m.main+lob
 
 # -mbranch-protection options
-- Match: -mbranch-protection=(standard|pac-ret(\+leaf)?\+bti|bti\+pac-ret(\+leaf)?)
+- Match: -mbranch-protection=(standard|pac-ret(\+leaf)?(\+bti)?|bti(\+pac-ret(\+leaf)?)?)
   Flags:
   - -mbranch-protection=pac-ret+bti


### PR DESCRIPTION
Follow up to [#467](https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/pull/467).

This patch fixes the multilib mapping for `-mbranch-protection`.

Firstly, the multilib flag to be inserted should be `-mbranch-protection=standard` as it is the flag expected by the PACBTI-M multilib variants.

Secondly, the PACBTI-M variant should also match to configurations where the branch protection is restricted to only one of PAC or BTI, like in `-mbranch-protection=bti` or `-mbranch-protection=pac-ret`. Before this patch, the variant would only match if both features were requested at the same time. This is safe to do because instructions from either feature have no effect if that feature is disabled at runtime.