### PR TITLE
Update version tag for LLVM 19 release

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -9,7 +9,7 @@
     "llvm-project": {
       "comment": "tagType can be branch, tag or commithash",
       "tagType": "tag",
-      "tag": "llvmorg-19.1.0-rc4"
+      "tag": "llvmorg-19.1.0"
     },
     "picolibc": {
       "tagType": "commithash",


### PR DESCRIPTION
LLVM 19 has now been released and tagged as llvmorg-19.1.0