### PR TITLE
Adjust clang's multilib flags test to cope with missing variant

### DIFF
--- a/patches/llvm-project/0001-libc-tests-with-picolibc-xfail-one-remaining-test.patch
+++ b/patches/llvm-project/0001-libc-tests-with-picolibc-xfail-one-remaining-test.patch
@@ -1,14 +1,14 @@
-From 1db48238bfbc5324dadf828532a4c67524dc471b Mon Sep 17 00:00:00 2001
+From fd26b5fd6a882677062a7c495660f22ca2b13cd5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Mon, 16 Oct 2023 11:35:48 +0200
-Subject: [PATCH] [libc++] tests with picolibc: xfail one remaining test
+Subject: [libc++] tests with picolibc: xfail one remaining test
 
 ---
  .../language.support/support.start.term/quick_exit.pass.cpp    | 3 +++
  1 file changed, 3 insertions(+)
 
 diff --git a/libcxx/test/std/language.support/support.start.term/quick_exit.pass.cpp b/libcxx/test/std/language.support/support.start.term/quick_exit.pass.cpp
-index d8eff69cb5..e16048df72 100644
+index d8eff69cb53f..e16048df722e 100644
 --- a/libcxx/test/std/language.support/support.start.term/quick_exit.pass.cpp
 +++ b/libcxx/test/std/language.support/support.start.term/quick_exit.pass.cpp
 @@ -17,6 +17,9 @@
@@ -22,5 +22,5 @@ index d8eff69cb5..e16048df72 100644
  
  void f() {}
 -- 
-2.34.1
+2.39.5 (Apple Git-154)
 

--- a/patches/llvm-project/0002-libc-tests-with-picolibc-disable-large-tests.patch
+++ b/patches/llvm-project/0002-libc-tests-with-picolibc-disable-large-tests.patch
@@ -1,4 +1,4 @@
-From 80000ddfade0f706ad1ebb488a51132a88cbe61d Mon Sep 17 00:00:00 2001
+From 02175d0f237e5d14c6b59ce6b16818927f10368f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Wed, 15 Nov 2023 12:18:35 +0100
 Subject: [libc++] tests with picolibc: disable large tests
@@ -41,7 +41,7 @@ index b5f9089308d2..0a83e75ceceb 100644
  set(LIBUNWIND_USE_COMPILER_RT ON CACHE BOOL "")
  find_program(QEMU_SYSTEM_ARM qemu-system-arm REQUIRED)
 diff --git a/libcxxabi/test/test_demangle.pass.cpp b/libcxxabi/test/test_demangle.pass.cpp
-index fe5598991b83..65d30a352814 100644
+index 77f79e0d40e8..4b69df08ea28 100644
 --- a/libcxxabi/test/test_demangle.pass.cpp
 +++ b/libcxxabi/test/test_demangle.pass.cpp
 @@ -7,7 +7,7 @@
@@ -54,5 +54,5 @@ index fe5598991b83..65d30a352814 100644
  // https://llvm.org/PR51407 was not fixed in some previously-released
  // demanglers, which causes them to run into the infinite loop.
 -- 
-2.34.1
+2.39.5 (Apple Git-154)
 

--- a/patches/llvm-project/0003-Disable-failing-compiler-rt-test.patch
+++ b/patches/llvm-project/0003-Disable-failing-compiler-rt-test.patch
@@ -1,4 +1,4 @@
-From c4837fa13ec89cc06b07af8cba8494189520e546 Mon Sep 17 00:00:00 2001
+From d1d619643bedea5759ef56ed42c4d97846f3c789 Mon Sep 17 00:00:00 2001
 From: Piotr Przybyla <piotr.przybyla@arm.com>
 Date: Wed, 15 Nov 2023 16:04:24 +0000
 Subject: Disable failing compiler-rt test
@@ -18,5 +18,5 @@ index 2ff65a8b9ec3..98611a75e85f 100644
  // RUN: %clang_builtins %s %librt -o %t && %run %t
  
 -- 
-2.34.1
+2.39.5 (Apple Git-154)
 

--- a/patches/llvm-project/0004-libc-tests-with-picolibc-XFAIL-uses-of-atomics.patch
+++ b/patches/llvm-project/0004-libc-tests-with-picolibc-XFAIL-uses-of-atomics.patch
@@ -1,4 +1,4 @@
-From 3b7ada947d511fe0edb7cca0dbdb640d8e1ecd2b Mon Sep 17 00:00:00 2001
+From 46019866b66f8859e7dff666c519c35d5b921291 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Thu, 9 Nov 2023 15:25:14 +0100
 Subject: [libc++] tests with picolibc: XFAIL uses of atomics
@@ -88,10 +88,10 @@ index 000000000000..5ecc58f3e385
 +if "has-no-atomics" in config.available_features:
 +    config.unsupported = True
 diff --git a/libcxx/utils/libcxx/test/features.py b/libcxx/utils/libcxx/test/features.py
-index 6ef40755c59d..6c2960260189 100644
+index 15456171b548..ddd44a63c618 100644
 --- a/libcxx/utils/libcxx/test/features.py
 +++ b/libcxx/utils/libcxx/test/features.py
-@@ -206,6 +206,21 @@ DEFAULT_FEATURES = [
+@@ -215,6 +215,21 @@ DEFAULT_FEATURES = [
            """,
          ),
      ),
@@ -114,5 +114,5 @@ index 6ef40755c59d..6c2960260189 100644
      Feature(
          name="32-bit-pointer",
 -- 
-2.34.1
+2.39.5 (Apple Git-154)
 

--- a/patches/llvm-project/0005-libc-tests-with-picolibc-mark-two-more-large-tests.patch
+++ b/patches/llvm-project/0005-libc-tests-with-picolibc-mark-two-more-large-tests.patch
@@ -1,4 +1,4 @@
-From 8eb9344a4ba97b45cea1a6adec98aff6c6149359 Mon Sep 17 00:00:00 2001
+From e3d01a7a6d51fe1f2d605a49123e72e2f493a532 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Wed, 22 Nov 2023 16:12:39 +0100
 Subject: [libc++] tests with picolibc: mark two more large tests
@@ -37,5 +37,5 @@ index 64a6a135adda..057301e6f868 100644
  //     bool
  //     regex_search(BidirectionalIterator first, BidirectionalIterator last,
 -- 
-2.34.1
+2.39.5 (Apple Git-154)
 

--- a/patches/llvm-project/0006-Clang-Driver-Adjust-test-to-cope-with-unsupported-mu.patch
+++ b/patches/llvm-project/0006-Clang-Driver-Adjust-test-to-cope-with-unsupported-mu.patch
@@ -1,0 +1,25 @@
+From 226969b13351bc60ac0e6776dedf3b8396747ced Mon Sep 17 00:00:00 2001
+From: Lucas Prates <lucas.prates@arm.com>
+Date: Wed, 18 Sep 2024 11:43:03 +0100
+Subject: [Clang][Driver] Adjust test to cope with unsupported multilib variant
+
+---
+ clang/test/Driver/print-multi-selection-flags.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/clang/test/Driver/print-multi-selection-flags.c b/clang/test/Driver/print-multi-selection-flags.c
+index 0116c7f5a03b..e2c89a083e2c 100644
+--- a/clang/test/Driver/print-multi-selection-flags.c
++++ b/clang/test/Driver/print-multi-selection-flags.c
+@@ -30,7 +30,7 @@
+ // CHECK-MVE: -mfloat-abi=hard
+ // CHECK-MVE: -mfpu=fp-armv8-fullfp16-sp-d16
+ 
+-// RUN: %clang -print-multi-flags-experimental --target=arm-none-eabi -march=armv8.1m.main+mve+nofp | FileCheck --check-prefix=CHECK-MVENOFP %s
++// RUN: not %clang -print-multi-flags-experimental --target=arm-none-eabi -march=armv8.1m.main+mve+nofp | FileCheck --check-prefix=CHECK-MVENOFP %s
+ // CHECK-MVENOFP: -march=thumbv8.1m.main{{.*}}+mve{{.*}}
+ // CHECK-MVENOFP-NOT: -march=thumbv8.1m.main{{.*}}+mve.fp{{.*}}
+ // CHECK-MVENOFP: -mfpu=none
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
The clang driver's `print-multi-selection-flags.c` test uses a
combination of command line options in one of its RUN lines for which we
don't have a valid library variant available.
Since the merging of PR #500, this combination of options now trigger an
error to inform the user of an unsupported setup, but this error also
causes the test to fail.
This adds a new patch file for llvm-project to adjust the test
accordingly.
