### PR TITLE
Use FVP models to test v8.1-M libraries with PACBTI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,14 @@ __pycache__
 # IDEs
 .vscode
 compile_commands.json
+
+# Downloaded FVPs
+/fvp/AEMv8R_base_pkg/
+/fvp/Base_RevC_AEMvA_pkg/
+/fvp/Corstone-310/
+/fvp/FVP_Corstone_SSE-310.sh
+/fvp/FastModelsPortfolio_11.26/
+/fvp/FastModels_crypto_11.26.011_Linux64/
+/fvp/complete
+/fvp/download/
+/fvp/license_terms/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,13 @@ option(
     the tools every time you update llvm-project."
     ON
 )
-
+set(
+    FVP_INSTALL_DIR
+    "${CMAKE_CURRENT_SOURCE_DIR}/fvp" CACHE STRING
+    "The directory in which the FVP models are installed. These are not
+    included in this repository, but can be downloaded by the script
+    fvp/get_fvps.sh"
+)
 set(LLVM_TOOLCHAIN_C_LIBRARY
     "picolibc" CACHE STRING
     "Which C library to use."
@@ -644,7 +650,7 @@ set(LLVM_DEFAULT_EXTERNAL_LIT "${LLVM_BINARY_DIR}/bin/llvm-lit")
 
 add_custom_target(check-newlib) # FIXME: put things in this
 
-function(get_test_executor_params target_triple qemu_machine qemu_cpu qemu_params)
+function(get_qemu_params target_triple qemu_machine qemu_cpu qemu_params)
     if(target_triple MATCHES "^aarch64")
         set(qemu_command "qemu-system-aarch64")
     else()
@@ -665,6 +671,23 @@ function(get_test_executor_params target_triple qemu_machine qemu_cpu qemu_param
     if(qemu_params_list)
         list(APPEND test_executor_params "--qemu-params=${qemu_params_list}")
     endif()
+    set(test_executor_params "${test_executor_params}" PARENT_SCOPE)
+endfunction()
+
+function(get_fvp_params fvp_model fvp_config)
+    set(
+        test_executor_params
+        --fvp-root-dir ${FVP_INSTALL_DIR}
+        --fvp-model ${fvp_model}
+    )
+    string(REPLACE " " ";" fvp_config_list ${fvp_config})
+    foreach(cfg ${fvp_config_list})
+          set(
+              test_executor_params
+              ${test_executor_params}
+              --fvp-config ${cfg}
+          )
+    endforeach()
     set(test_executor_params "${test_executor_params}" PARENT_SCOPE)
 endfunction()
 
@@ -1328,9 +1351,12 @@ function(add_library_variant target_arch)
         COMPILE_FLAGS
         MULTILIB_FLAGS
         PICOLIBC_BUILD_TYPE
+        EXECUTOR
         QEMU_MACHINE
         QEMU_CPU
         QEMU_PARAMS
+        FVP_MODEL
+        FVP_CONFIG
         BOOT_FLASH_ADDRESS
         BOOT_FLASH_SIZE
         FLASH_ADDRESS
@@ -1376,19 +1402,40 @@ function(add_library_variant target_arch)
 
     set(directory "${TARGET_LIBRARIES_DIR}${library_subdir}/${parent_dir_name}/${variant}")
     set(VARIANT_COMPILE_FLAGS "--target=${target_triple} ${VARIANT_COMPILE_FLAGS}")
-    get_test_executor_params(
-        "${target_triple}"
-        "${VARIANT_QEMU_MACHINE}"
-        "${VARIANT_QEMU_CPU}"
-        "${VARIANT_QEMU_PARAMS}"
-    )
-    set(
-        lit_test_executor
-        ${CMAKE_CURRENT_SOURCE_DIR}/test-support/lit-exec-qemu.py
-        ${test_executor_params}
-    )
+
+    if(VARIANT_EXECUTOR STREQUAL "fvp")
+      if (EXISTS "${FVP_INSTALL_DIR}/complete")
+            get_fvp_params(
+              "${VARIANT_FVP_MODEL}"
+              "${VARIANT_FVP_CONFIG}"
+            )
+            set(
+                lit_test_executor
+                ${CMAKE_CURRENT_SOURCE_DIR}/test-support/lit-exec-fvp.py
+                ${test_executor_params}
+            )
+            set(have_executor TRUE)
+        else()
+            set(have_executor FALSE)
+        endif()
+    else()
+        get_qemu_params(
+            "${target_triple}"
+            "${VARIANT_QEMU_MACHINE}"
+            "${VARIANT_QEMU_CPU}"
+            "${VARIANT_QEMU_PARAMS}"
+        )
+        set(
+            lit_test_executor
+            ${CMAKE_CURRENT_SOURCE_DIR}/test-support/lit-exec-qemu.py
+            ${test_executor_params}
+        )
+        set(have_executor TRUE)
+    endif()
     list(JOIN lit_test_executor " " lit_test_executor)
-    if(NOT PREBUILT_TARGET_LIBRARIES)
+    if(NOT have_executor)
+        message("All library tests disabled for ${variant}, due to missing executor")
+    elseif(NOT PREBUILT_TARGET_LIBRARIES)
         add_libc(
             "${directory}"
             "${variant}"
@@ -1481,9 +1528,12 @@ function(add_library_variants_for_cpu target_arch)
         COMPILE_FLAGS
         MULTILIB_FLAGS
         PICOLIBC_BUILD_TYPE
+        EXECUTOR
         QEMU_MACHINE
         QEMU_CPU
         QEMU_PARAMS
+        FVP_MODEL
+        FVP_CONFIG
         BOOT_FLASH_ADDRESS
         BOOT_FLASH_SIZE
         FLASH_ADDRESS
@@ -1513,9 +1563,12 @@ function(add_library_variants_for_cpu target_arch)
             COMPILE_FLAGS "${VARIANT_COMPILE_FLAGS}"
             MULTILIB_FLAGS "${VARIANT_MULTILIB_FLAGS}"
             PICOLIBC_BUILD_TYPE "${VARIANT_PICOLIBC_BUILD_TYPE}"
+            EXECUTOR "${VARIANT_EXECUTOR}"
             QEMU_MACHINE "${VARIANT_QEMU_MACHINE}"
             QEMU_CPU "${VARIANT_QEMU_CPU}"
             QEMU_PARAMS "${VARIANT_QEMU_PARAMS}"
+            FVP_MODEL "${VARIANT_FVP_MODEL}"
+            FVP_CONFIG "${VARIANT_FVP_CONFIG}"
             BOOT_FLASH_ADDRESS "${VARIANT_BOOT_FLASH_ADDRESS}"
             BOOT_FLASH_SIZE "${VARIANT_BOOT_FLASH_SIZE}"
             FLASH_ADDRESS "${VARIANT_FLASH_ADDRESS}"
@@ -1898,20 +1951,17 @@ add_nonexistent_library_variant(
     MULTILIB_FLAGS "--target=thumbv8.1m.main-unknown-none-eabi -march=thumbv8.1m.main+mve"
     ERROR_MESSAGE "No library available for MVE with soft-float ABI. Try -mfloat-abi=hard."
 )
-# FIXME: qemu currently has no support for PACBTI-M, so the branch protection
-# variants below can't be fully tested in runtime. Since PACBTI-M instructions
-# are NOP-compatible we can use the cortex-m55 CPU for now, but these should be
-# updated to use a PACBTI-M enabled CPU once this is available.
 add_library_variants_for_cpu(
     armv8.1m.main
     SUFFIX soft_nofp_nomve_pacret_bti
     COMPILE_FLAGS "-mfloat-abi=soft -march=armv8.1m.main+nomve+pacbti -mfpu=none -mbranch-protection=pac-ret+bti"
     MULTILIB_FLAGS "--target=thumbv8.1m.main-unknown-none-eabi -mfpu=none -mbranch-protection=pac-ret+bti"
     PICOLIBC_BUILD_TYPE "release"
-    QEMU_MACHINE "mps3-an547"
-    QEMU_CPU "cortex-m55"
-    BOOT_FLASH_ADDRESS 0x00000000
-    BOOT_FLASH_SIZE 512K
+    EXECUTOR fvp
+    FVP_MODEL corstone-310
+    FVP_CONFIG "cortex-m85 m-pacbti m-nofp mve-none"
+    BOOT_FLASH_ADDRESS 0x01000000
+    BOOT_FLASH_SIZE 2M
     FLASH_ADDRESS 0x60000000
     FLASH_SIZE 0x1000000
     RAM_ADDRESS 0x61000000
@@ -1924,10 +1974,11 @@ add_library_variants_for_cpu(
     COMPILE_FLAGS "-mfloat-abi=hard -march=armv8.1m.main+nomve+pacbti -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti"
     MULTILIB_FLAGS "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti"
     PICOLIBC_BUILD_TYPE "release"
-    QEMU_MACHINE "mps3-an547"
-    QEMU_CPU "cortex-m55"
-    BOOT_FLASH_ADDRESS 0x00000000
-    BOOT_FLASH_SIZE 512K
+    EXECUTOR fvp
+    FVP_MODEL corstone-310
+    FVP_CONFIG "cortex-m85 m-pacbti m-fp mve-none"
+    BOOT_FLASH_ADDRESS 0x01000000
+    BOOT_FLASH_SIZE 2M
     FLASH_ADDRESS 0x60000000
     FLASH_SIZE 0x1000000
     RAM_ADDRESS 0x61000000
@@ -1940,10 +1991,11 @@ add_library_variants_for_cpu(
     COMPILE_FLAGS "-mfloat-abi=hard -march=armv8.1m.main+nomve+pacbti -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti"
     MULTILIB_FLAGS "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti"
     PICOLIBC_BUILD_TYPE "release"
-    QEMU_MACHINE "mps3-an547"
-    QEMU_CPU "cortex-m55"
-    BOOT_FLASH_ADDRESS 0x00000000
-    BOOT_FLASH_SIZE 512K
+    EXECUTOR fvp
+    FVP_MODEL corstone-310
+    FVP_CONFIG "cortex-m85 m-pacbti m-fp mve-none"
+    BOOT_FLASH_ADDRESS 0x01000000
+    BOOT_FLASH_SIZE 2M
     FLASH_ADDRESS 0x60000000
     FLASH_SIZE 0x1000000
     RAM_ADDRESS 0x61000000
@@ -1956,10 +2008,11 @@ add_library_variants_for_cpu(
     COMPILE_FLAGS "-mfloat-abi=hard -march=armv8.1m.main+mve+pacbti -mfpu=none -mbranch-protection=pac-ret+bti"
     MULTILIB_FLAGS "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+mve -mfpu=none -mbranch-protection=pac-ret+bti"
     PICOLIBC_BUILD_TYPE "release"
-    QEMU_MACHINE "mps3-an547"
-    QEMU_CPU "cortex-m55"
-    BOOT_FLASH_ADDRESS 0x00000000
-    BOOT_FLASH_SIZE 512K
+    EXECUTOR fvp
+    FVP_MODEL corstone-310
+    FVP_CONFIG "cortex-m85 m-pacbti m-nofp mve-int"
+    BOOT_FLASH_ADDRESS 0x01000000
+    BOOT_FLASH_SIZE 2M
     FLASH_ADDRESS 0x60000000
     FLASH_SIZE 0x1000000
     RAM_ADDRESS 0x61000000

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Content of this repository is licensed under Apache-2.0. See
 The resulting binaries are covered under their respective open source licenses,
 see component links above.
 
+Testing for some targets uses the freely-available but not open-source Arm FVP
+models, which have their own licenses. These are not used by default, see
+[Building from source](docs/building-from-source.md) for details.
+
 ## Host platforms
 
 LLVM Embedded Toolchain for Arm is built and tested on Ubuntu 18.04 LTS.

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -36,6 +36,26 @@ $ brew install llvm python3 git make ninja qemu cmake
 $ pip install meson
 ```
 
+Some recent targets are not supported by QEMU, for these the Arm FVP models are
+used instead. These models are available free-of-change but are not
+open-source, and come with their own licenses.
+
+These models can be downloaded and installed (into the source tree) with the
+`fvp/get_fvps.sh` script. This is currently only available for Linux. By
+default, `get_fvps.sh` will run the installers for packages which have them,
+which will prompt you to agree to their licenses. Some of the packages do not
+have installers, instead they place their license file into the
+`fvp/license_terms` directory, which you should read before continuing.
+
+For non-interactive use (for example in CI systems), `get_fvps.sh` can be run
+with the `--non-interactive` option, which causes it to implcitly accept all of
+the EULAs. If you have previously downloaded and installed the FVPs outside of
+the source tree, you can set the `-DFVP_INSTALL_DIR=...` cmake option to set
+the path to them.
+
+If the FVPs are not installed, tests which need them will be skipped, but QEMU
+tests will still be run, and all library variants will still be built.
+
 ## Customizing
 
 To build additional library variants, edit the `CMakeLists.txt` by adding

--- a/fvp/config/cortex-m85.cfg
+++ b/fvp/config/cortex-m85.cfg
@@ -1,0 +1,12 @@
+# Disable GUI visualisation.
+mps3_board.visualisation.disable-visualisation=1
+
+# Silence output about telnet ports.
+# Yes, the terminals are numbered 0, 1, 2 and 5
+mps3_board.telnetterminal0.quiet=1
+mps3_board.telnetterminal1.quiet=1
+mps3_board.telnetterminal2.quiet=1
+mps3_board.telnetterminal5.quiet=1
+
+# Enable semihosting
+cpu0.semihosting-enable=1

--- a/fvp/config/m-fp.cfg
+++ b/fvp/config/m-fp.cfg
@@ -1,0 +1,4 @@
+# Enable M-profile scalar FPU. This includes the double-precision extension, I
+# don't see a parameter to disable that in the Corstone-310 FVP, probably
+# because Cortex-M85 can't be configured with an SP-only FPU.
+cpu0.FPU=1

--- a/fvp/config/m-nofp.cfg
+++ b/fvp/config/m-nofp.cfg
@@ -1,0 +1,2 @@
+# Disable M-profile scalar FPU
+cpu0.FPU=0

--- a/fvp/config/m-pacbti.cfg
+++ b/fvp/config/m-pacbti.cfg
@@ -1,0 +1,3 @@
+# Enable M-profile PAC and BTI
+cpu0.CFGPACBTI=1
+cpu0.ID_ISAR5.PACBTI=1

--- a/fvp/config/mve-fp.cfg
+++ b/fvp/config/mve-fp.cfg
@@ -1,0 +1,2 @@
+# Enable integer and floating-point MVE
+cpu0.MVE=2

--- a/fvp/config/mve-int.cfg
+++ b/fvp/config/mve-int.cfg
@@ -1,0 +1,2 @@
+# Enable integer-only MVE
+cpu0.MVE=1

--- a/fvp/config/mve-none.cfg
+++ b/fvp/config/mve-none.cfg
@@ -1,0 +1,2 @@
+# Disable MVE
+cpu0.MVE=0

--- a/fvp/config/v8a-aarch32.cfg
+++ b/fvp/config/v8a-aarch32.cfg
@@ -1,0 +1,18 @@
+# Disable GUI visualisation.
+bp.vis.disable_visualisation=1
+
+# Silence output about telnet ports.
+bp.terminal_0.quiet=1
+bp.terminal_1.quiet=1
+bp.terminal_2.quiet=1
+bp.terminal_3.quiet=1
+
+# We only want a single core
+cluster0.NUM_CORES=1
+cluster1.NUM_CORES=0
+
+# All memory is non-secure, so we can boot straight into main DRAM.
+bp.secure_memory=0
+
+# Boot in AArch32 mode
+cluster0.cpu0.CONFIG64=0

--- a/fvp/config/v8a-aarch64.cfg
+++ b/fvp/config/v8a-aarch64.cfg
@@ -1,0 +1,18 @@
+# Disable GUI visualisation.
+bp.vis.disable_visualisation=1
+
+# Silence output about telnet ports.
+bp.terminal_0.quiet=1
+bp.terminal_1.quiet=1
+bp.terminal_2.quiet=1
+bp.terminal_3.quiet=1
+
+# We only want a single core
+cluster0.NUM_CORES=1
+cluster1.NUM_CORES=0
+
+# All memory is non-secure, so we can boot straight into main DRAM.
+bp.secure_memory=0
+
+# Boot in AArch64 mode
+cluster0.cpu0.CONFIG64=1

--- a/fvp/config/v8r-aarch32.cfg
+++ b/fvp/config/v8r-aarch32.cfg
@@ -1,0 +1,14 @@
+# Disable GUI visualisation.
+bp.vis.disable_visualisation=1
+
+# Silence output about telnet ports.
+bp.terminal_0.quiet=1
+bp.terminal_1.quiet=1
+bp.terminal_2.quiet=1
+bp.terminal_3.quiet=1
+
+# We only want a single core
+cluster0.NUM_CORES=1
+
+# AArch32 mode
+cluster0.has_aarch64=0

--- a/fvp/config/v8r-aarch64.cfg
+++ b/fvp/config/v8r-aarch64.cfg
@@ -1,0 +1,21 @@
+# Disable GUI visualisation.
+bp.vis.disable_visualisation=1
+
+# Silence output about telnet ports.
+bp.terminal_0.quiet=1
+bp.terminal_1.quiet=1
+bp.terminal_2.quiet=1
+bp.terminal_3.quiet=1
+
+# We only want a single core
+cluster0.NUM_CORES=1
+
+# AArch64 mode
+cluster0.has_aarch64=1
+
+# Suppress some warnings caused by defaults not valid for AArch64, these values
+# all come from the warning message if you leave them at the default.
+cluster0.gicv3.cpuintf-mmap-access-level=2
+cluster0.gicv3.SRE-enable-action-on-mmap=2
+cluster0.gicv3.SRE-EL2-enable-RAO=1
+cluster0.gicv3.extended-interrupt-range-support=1

--- a/fvp/get_fvps.sh
+++ b/fvp/get_fvps.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# This script downloads the FVP models which we use for testing the toolchain.
+# These are available at no cost, but come with EULAs which must be agreed to
+# before running them. When run with --non-interactive, this script assumes
+# that you agree to these EULAs. If run without that option, the installers for
+# some of the packages will present you with the license before installing. The
+# AEMv8A and AEMv8R packages do not have installers, instead they place their
+# license into the `fvps/license_terms' directory.
+
+args=$(getopt --options "" --longoptions "non-interactive" -- "${@}") || exit
+eval "set -- ${args}"
+
+INSTALLER_FLAGS_CORSTONE=""
+INSTALLER_FLAGS_CRYPTO=""
+
+while true; do
+    case "${1}" in
+        (--non-interactive)
+            INSTALLER_FLAGS_CORSTONE="--i-agree-to-the-contained-eula --no-interactive --force"
+            INSTALLER_FLAGS_CRYPTO="--i-accept-the-end-user-license-agreement --basepath \"$(dirname \"$0\")\""
+            shift 1
+        ;;
+        (--)
+            shift
+            break
+        (*)
+            exit 1
+        ;;
+    esac
+done
+
+URL_CORSONE_310='https://developer.arm.com/-/media/Arm%20Developer%20Community/Downloads/OSS/FVP/Corstone-310/FVP_Corstone_SSE-310_11.24_13_Linux64.tgz?rev=c370b571bdff42d3a0152471eca3d798&hash=1E388EE3B6E8F675D02D2832DBE61946DEC0386A'
+URL_BASE_AEM_A='https://developer.arm.com/-/cdn-downloads/permalink/Fixed-Virtual-Platforms/FM-11.26/FVP_Base_RevC-2xAEMvA_11.26_11_Linux64.tgz'
+URL_BASE_AEM_R='https://developer.arm.com/-/cdn-downloads/permalink/Fixed-Virtual-Platforms/FM-11.26/FVP_Base_AEMv8R_11.26_11_Linux64.tgz'
+URL_CRYPTO='https://developer.arm.com/-/cdn-downloads/permalink/Fast-Models-Crypto-Plug-in/FM-11.26/FastModels_crypto_11.26.011_Linux64.tgz'
+
+cd "$(dirname "$0")"
+
+mkdir -p download
+pushd download
+DOWNLOAD_DIR="$(pwd)"
+wget --content-disposition --no-clobber "${URL_CORSONE_310}"
+wget --content-disposition --no-clobber "${URL_BASE_AEM_A}"
+wget --content-disposition --no-clobber "${URL_BASE_AEM_R}"
+wget --content-disposition --no-clobber "${URL_CRYPTO}"
+popd
+
+if [ ! -d "Corstone-310" ]; then
+tar -xf ${DOWNLOAD_DIR}/FVP_Corstone_SSE-310_11.24_13_Linux64.tgz
+./FVP_Corstone_SSE-310.sh --destination ./Corstone-310 $INSTALLER_FLAGS_CORSTONE
+fi
+
+if [ ! -d "Base_RevC_AEMvA_pkg" ]; then
+tar -xf ${DOWNLOAD_DIR}/FVP_Base_RevC-2xAEMvA_11.26_11_Linux64.tgz
+# (Extracted directly into ./Base_RevC_AEMvA_pkg/, no installer)
+fi
+
+if [ ! -d "AEMv8R_base_pkg" ]; then
+tar -xf ${DOWNLOAD_DIR}/FVP_Base_AEMv8R_11.26_11_Linux64.tgz
+# (Extracted directly into ./AEMv8R_base_pkg/, no installer)
+fi
+
+if [ ! -d "FastModelsPortfolio_11.26" ]; then
+tar -xf ${DOWNLOAD_DIR}/FastModels_crypto_11.26.011_Linux64.tgz
+# SDDKW-93582: Non-interactive installation fails if cwd is different.
+pushd FastModels_crypto_11.26.011_Linux64
+# This installer doesn't allow providing a default path for interactive
+# installation.
+./setup.bin $INSTALLER_FLAGS_CRYPTO
+popd
+fi
+
+# Create a marker file the CMakeLists.txt can use to check if it can use the
+# FVPs or not.
+touch complete

--- a/test-support/lit-exec-fvp.py
+++ b/test-support/lit-exec-fvp.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2023-2024, Arm Limited and affiliates.
+
+# This script is a bridge between lit-based tests of LLVM C++ runtime libraries
+# (libc++abi, libunwind, libc++) and FVP models. It must handle the same
+# command-line arguments as llvm-project/libcxx/utils/run.py.
+
+from run_fvp import run_fvp
+import argparse
+import pathlib
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run a single test using qemu"
+    )
+    parser.add_argument(
+        "--fvp-root-dir",
+        help="Directory in which FVP models are installed",
+        required=True,
+    )
+    main_arg_group.add_argument(
+        "--fvp-model",
+        help="model name for FVP",
+        required=True,
+    )
+    parser.add_argument(
+        "--fvp-config",
+        action="append",
+        help="FVP config file(s) to use",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=900,
+        help="timeout, in seconds (default: 900)",
+    )
+    parser.add_argument(
+        "--execdir",
+        type=pathlib.Path,
+        default=pathlib.Path.cwd(),
+        help="directory to run the program from",
+    )
+    parser.add_argument(
+        "--codesign_identity",
+        type=str,
+        help="ignored, used for compatibility with libc++ tests",
+    )
+    parser.add_argument(
+        "--env",
+        type=str,
+        nargs="*",
+        help="ignored, used for compatibility with libc++ tests",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print verbose output. This may affect test result, as the output "
+        "will be added to the output of the test.",
+    )
+    parser.add_argument(
+        "--tarmac",
+        help="File to write tarmac trace to (slows execution significantly)",
+    )
+    parser.add_argument("image", help="image file to execute")
+    parser.add_argument(
+        "arguments",
+        nargs=argparse.REMAINDER,
+        default=[],
+        help="optional arguments for the image",
+    )
+    args = parser.parse_args()
+    return run_fvp(
+        args.fvp_root_dir,
+        args.fvp_model,
+        args.fvp_config,
+        args.image,
+        [args.image] + args.arguments,
+        args.timeout,
+        args.execdir,
+        args.verbose,
+        args.tarmac,
+    )
+    sys.exit(ret_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/test-support/picolibc-test-wrapper.py
+++ b/test-support/picolibc-test-wrapper.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2023, Arm Limited and affiliates.
+# Copyright (c) 2023-2024, Arm Limited and affiliates.
 
-# This is a wrapper script to run picolibc tests with QEMU.
+# This is a wrapper script to run picolibc tests with QEMU or FVPs.
 
 from run_qemu import run_qemu
+from run_fvp import run_fvp
 import argparse
 import pathlib
 import sys
@@ -38,37 +39,71 @@ disabled_tests = [
     "picolibc_armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti-build/test/math_errhandling",
 ]
 
+disabled_tests_fvp = [
+    # SDDKW-53824: ":semihosting-features" pseudo-file not implemented.
+    "test/semihost/semihost-exit-extended",
+    # SDDKW-25808: SYS_SEEK returns wrong value.
+    "test/semihost/semihost-seek",
+    "test/test-fread-fwrite",
+    "test/posix-io",
+    # SDDKW-94045: rateInHz port not connected in Corstone-310 FVP.
+    "test/semihost/semihost-gettimeofday",
+]
 
-def is_disabled(image):
-    return any([image.endswith(t) for t in disabled_tests])
+
+def is_disabled(image, use_fvp):
+    if any([image.endswith(t) for t in disabled_tests]):
+        return True
+    if use_fvp and any([image.endswith(t) for t in disabled_tests_fvp]):
+        return True
+    return False
 
 
 def run(args):
-    if is_disabled(args.image):
+    if is_disabled(args.image, args.qemu_command is None):
         return EXIT_CODE_SKIP
-    return run_qemu(
-        args.qemu_command,
-        args.qemu_machine,
-        args.qemu_cpu,
-        args.qemu_params.split(":") if args.qemu_params else [],
-        args.image,
-        ["program-name"] + args.arguments,
-        None,
-        pathlib.Path.cwd(),
-        args.verbose,
-    )
+    # Some picolibc tests expect argv[0] to be literally "program-name", not
+    # the actual program name.
+    argv = ["program-name"] + args.arguments
+    if args.qemu_command:
+        return run_qemu(
+            args.qemu_command,
+            args.qemu_machine,
+            args.qemu_cpu,
+            args.qemu_params.split(":") if args.qemu_params else [],
+            args.image,
+            argv,
+            None,
+            pathlib.Path.cwd(),
+            args.verbose,
+        )
+    else:
+        return run_fvp(
+            args.fvp_root_dir,
+            args.fvp_model,
+            args.fvp_config,
+            args.image,
+            argv,
+            None,
+            pathlib.Path.cwd(),
+            args.verbose,
+            args.tarmac,
+        )
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Run a single test using qemu"
+        description="Run a single test using either qemu or an FVP"
     )
-    parser.add_argument(
-        "--qemu-command", required=True, help="qemu-system-<arch> path"
+    main_arg_group = parser.add_mutually_exclusive_group(required=True)
+    main_arg_group.add_argument(
+        "--qemu-command", help="qemu-system-<arch> path"
+    )
+    main_arg_group.add_argument(
+        "--fvp-root-dir", help="Directory in which FVP models are installed"
     )
     parser.add_argument(
         "--qemu-machine",
-        required=True,
         help="name of the machine to pass to QEMU",
     )
     parser.add_argument(
@@ -76,8 +111,20 @@ def main():
     )
     parser.add_argument(
         "--qemu-params",
-        required=False,
         help='list of arguments to pass to qemu, separated with ":"',
+    )
+    parser.add_argument(
+        "--fvp-model",
+        help="model name for FVP",
+    )
+    parser.add_argument(
+        "--fvp-config",
+        action="append",
+        help="FVP config file(s) to use",
+    )
+    parser.add_argument(
+        "--tarmac",
+        help="file to wrote tarmac trace to (FVP only)",
     )
     parser.add_argument(
         "--verbose",

--- a/test-support/run_fvp.py
+++ b/test-support/run_fvp.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2023-2024, Arm Limited and affiliates.
+
+import subprocess
+import sys
+from os import path
+from dataclasses import dataclass
+import shlex
+
+@dataclass
+class FVP:
+    model_exe: str
+    tarmac_plugin: str
+    cmdline_param: str
+
+MODELS = {
+    "corstone-310": FVP(
+        "Corstone-310/models/Linux64_GCC-9.3/FVP_Corstone_SSE-310",
+        "Corstone-310/plugins/Linux64_GCC-9.3/TarmacTrace.so",
+        "cpu0.semihosting-cmd_line",
+    ),
+    "aem-a": FVP(
+        "Base_RevC_AEMvA_pkg/models/Linux64_GCC-9.3/FVP_Base_RevC-2xAEMvA",
+        "Base_RevC_AEMvA_pkg/plugins/Linux64_GCC-9.3/TarmacTrace.so",
+        "cluster0.cpu0.semihosting-cmd_line",
+    ),
+    "aem-r": FVP(
+        "AEMv8R_base_pkg/models/Linux64_GCC-9.3/FVP_BaseR_AEMv8R",
+        "AEMv8R_base_pkg/plugins/Linux64_GCC-9.3/TarmacTrace.so",
+        "cluster0.cpu0.semihosting-cmd_line",
+    ),
+}
+
+
+def run_fvp(
+    fvp_root_dir,
+    fvp_model,
+    fvp_configs,
+    image,
+    arguments,
+    timeout,
+    working_directory,
+    verbose,
+    tarmac_file,
+):
+    """Execute the program using an FVP and return the subprocess return code."""
+    if fvp_model not in MODELS:
+        raise Exception(f"{fvp_model} is not a recognised model name")
+    model = MODELS[fvp_model]
+
+    command = [path.join(fvp_root_dir, model.model_exe)]
+    command.extend(["--quiet"])
+    for config in fvp_configs:
+        command.extend(["--config-file", path.join(fvp_root_dir, "config", config + ".cfg")])
+    command.extend(["--application", image])
+    command.extend(["--parameter", f"{model.cmdline_param}={shlex.join(arguments)}"])
+    if tarmac_file is not None:
+        command.extend([
+            "--plugin",
+            path.join(fvp_root_dir, model.tarmac_plugin),
+            "--parameter",
+            "TRACE.TarmacTrace.trace-file=" + tarmac_file,
+        ])
+
+    if verbose:
+        print("running: {}".format(shlex.join(command)))
+
+    result = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=sys.stderr,
+        timeout=timeout,
+        cwd=working_directory,
+        check=False,
+    )
+    sys.stdout.buffer.write(result.stdout)
+    return result.returncode
+


### PR DESCRIPTION
QEMU doesn't currently support the M-profile PACBTI extension, so we need to use FVP models to test those libraries. There are also other targets not supported by QEMU, such as v8-R, which we will need these for.

These models are available free of cost (though not open source) from Arm, and the user must agree to a EULA before using them. I've added a script `fvp/get_fvps.sh' to download and extract them into the `fvp' directory.

These models are currently only used for the v8.1-M libraries with PACBTI, but the script also downloads the AEMv8A and AEMv8R models for future use. If the FVPs aren't installed, then the CMakeLists.txt will skip any tests which need them. I don't think it's worth preserving the ability to run these tests with QEMU, because we still have the non-PACBTI library variants which are run with QEMU. The two models also have different memory maps and require different scatter files, so if we wanted the ability to run tests for one library on both then we'd need to add a way to build multiple linker scripts.