### PR TITLE
Add clang-cpp to the distribution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,7 @@ set(BUG_REPORT_URL "https://github.com/ARM-software/LLVM-embedded-toolchain-for-
 set(LLVM_DISTRIBUTION_COMPONENTS
     clang-resource-headers
     clang
+    clang-cpp
     dsymutil
     lld
     llvm-ar


### PR DESCRIPTION
This is a symlink to clang, which makes it act like the C preprocessor by default.