### PR TITLE
Add llvm-strings and clang-cpp to the distribution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,7 @@ set(LLVM_DISTRIBUTION_COMPONENTS
     llvm-readelf
     llvm-readobj
     llvm-size
+    llvm-strings
     llvm-strip
     llvm-symbolizer
     LTO

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ set(BUG_REPORT_URL "https://github.com/ARM-software/LLVM-embedded-toolchain-for-
 set(LLVM_DISTRIBUTION_COMPONENTS
     clang-resource-headers
     clang
+    clang-cpp
     dsymutil
     lld
     llvm-ar


### PR DESCRIPTION
This is a cherry-pick of #511 and #512 to the llvm-19 branch.