### PR TITLE
clang-cpp does not need installing in distribution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,6 @@ set(BUG_REPORT_URL "https://github.com/ARM-software/LLVM-embedded-toolchain-for-
 set(LLVM_DISTRIBUTION_COMPONENTS
     clang-resource-headers
     clang
-    clang-cpp
     dsymutil
     lld
     llvm-ar


### PR DESCRIPTION
The clang-cpp symlink (or copy) is created with the ALWAYS_GENERATE flag in clang's cmake, so it always gets installed, meaning we don't need to add it to LLVM_DISTRIBUTION_COMPONENTS.

This was causing windows build failures because the install target was being called for it, but not created. I'm not sure why the Linux build was succeeding despite this, but I've checked that clang-cpp existed in both the Windows and Linux builds of the previous release (18.1.3), so clang-cpp doesn't need to be in this list.