### PR TITLE
Generate multilib.yaml for compatible architecture versions and features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2037,7 +2037,7 @@ configure_file(
 )
 
 set(multilib_yaml_depends
-    "${CMAKE_CURRENT_SOURCE_DIR}/multilib-fpus.py"
+    "${CMAKE_CURRENT_SOURCE_DIR}/multilib-generate.py"
     "${CMAKE_CURRENT_BINARY_DIR}/multilib-without-fpus.yaml"
 )
 if(LIBS_DEPEND_ON_TOOLS)
@@ -2049,7 +2049,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E copy
     ${CMAKE_CURRENT_BINARY_DIR}/multilib-without-fpus.yaml
     ${CMAKE_CURRENT_BINARY_DIR}/llvm/${TARGET_LIBRARIES_DIR}${library_subdir}/multilib.yaml
-  COMMAND ${Python3_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/multilib-fpus.py"
+  COMMAND ${Python3_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/multilib-generate.py"
     "--clang=${LLVM_BINARY_DIR}/bin/clang${CMAKE_EXECUTABLE_SUFFIX}"
     "--llvm-source=${llvmproject_SOURCE_DIR}"
     >> "${CMAKE_CURRENT_BINARY_DIR}/llvm/${TARGET_LIBRARIES_DIR}${library_subdir}/multilib.yaml"

--- a/test/multilib/aarch64.test
+++ b/test/multilib/aarch64.test
@@ -1,3 +1,21 @@
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf | FileCheck %s
-# CHECK: aarch64-none-elf/aarch64a_exn_rtti{{$}}
-# CHECK-EMPTY:
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf | FileCheck %s --check-prefix=AARCH64-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8-a | FileCheck %s --check-prefix=AARCH64-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8-a+fp16 | FileCheck %s --check-prefix=AARCH64-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.1-a | FileCheck %s --check-prefix=AARCH64-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5-a+nodotprod | FileCheck %s --check-prefix=AARCH64-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.9-a | FileCheck %s --check-prefix=AARCH64-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv9.5-a | FileCheck %s --check-prefix=AARCH64-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv9.5-a+sve2+sme2 | FileCheck %s --check-prefix=AARCH64-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a57 | FileCheck %s --check-prefix=AARCH64-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a57+fp16 | FileCheck %s --check-prefix=AARCH64-EXNRTTI
+
+# AARCH64-EXNRTTI: aarch64-none-elf/aarch64a_exn_rtti{{$}}
+# AARCH64-EXNRTTI-EMPTY:
+#
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -fno-exceptions -fno-rtti | FileCheck %s --check-prefix=AARCH64
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5-a+nodotprod -fno-exceptions -fno-rtti | FileCheck %s --check-prefix=AARCH64
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv9.5-a+sve2+sme2 -fno-exceptions -fno-rtti | FileCheck %s --check-prefix=AARCH64
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a57+fp16 -fno-exceptions -fno-rtti | FileCheck %s --check-prefix=AARCH64
+#
+# AARCH64: aarch64-none-elf/aarch64a{{$}}
+# AARCH64-EMPTY:

--- a/test/multilib/armv8a.test
+++ b/test/multilib/armv8a.test
@@ -1,6 +1,9 @@
 # RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none         | FileCheck %s
 # RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -marm   | FileCheck %s
 # RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -mthumb | FileCheck %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -march=armv9.5-a | FileCheck %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -march=armv8.2-a+fp16 | FileCheck %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -march=armv8.5-a+nodotprod | FileCheck %s
 # CHECK: arm-none-eabi/armv7a_soft_nofp_exn_rtti{{$}}
 # CHECK-EMPTY:
 
@@ -15,5 +18,8 @@
 # RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=neon-vfpv4 | FileCheck --check-prefix=VFPV3 %s
 # RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=vfpv3-d16 -marm | FileCheck --check-prefix=VFPV3 %s
 # RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=vfpv3-d16 -mthumb | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=fp-armv8 -march=armv9.5-a | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=fp-armv8 -march=armv8.2-a+fp16 | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=fp-armv8 -march=armv8.5-a+nodotprod | FileCheck --check-prefix=VFPV3 %s
 # VFPV3: arm-none-eabi/armv7a_hard_vfpv3_d16_exn_rtti{{$}}
 # VFPV3-EMPTY:

--- a/test/multilib/armv8r.test
+++ b/test/multilib/armv8r.test
@@ -1,6 +1,8 @@
 # RUN: %clang -print-multi-directory --target=armv8r-none-eabi -mfpu=none         | FileCheck %s
 # RUN: %clang -print-multi-directory --target=armv8r-none-eabi -mfpu=none -marm   | FileCheck %s
 # RUN: %clang -print-multi-directory --target=armv8r-none-eabi -mfpu=none -mthumb | FileCheck %s
+# RUN: %clang -print-multi-directory --target=armv8r-none-eabi -mfpu=none -march=armv8-r+ras | FileCheck %s
+# RUN: %clang -print-multi-directory --target=armv8r-none-eabi -mfpu=none -mcpu=cortex-r52 | FileCheck %s
 # CHECK: arm-none-eabi/armv7r_soft_nofp_exn_rtti{{$}}
 # CHECK-EMPTY:
 
@@ -15,5 +17,6 @@
 # RUN: %clang -print-multi-directory --target=armv8r-none-eabihf -mfpu=neon-vfpv4 | FileCheck --check-prefix=VFPV3 %s
 # RUN: %clang -print-multi-directory --target=armv8r-none-eabihf -mfpu=vfpv3-d16 -marm | FileCheck --check-prefix=VFPV3 %s
 # RUN: %clang -print-multi-directory --target=armv8r-none-eabihf -mfpu=vfpv3-d16 -mthumb | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv8r-none-eabihf -mcpu=cortex-r52 | FileCheck --check-prefix=VFPV3 %s
 # VFPV3: arm-none-eabi/armv7r_hard_vfpv3_d16_exn_rtti{{$}}
 # VFPV3-EMPTY:


### PR DESCRIPTION
This expands multilib-fpus.py (renaming it) to add Match blocks to split the -march options into two sets of options, which will be more useful for libray matching:
* A -march= option for each minor version less than or equal to the selected one, so that it will be possible to mark a library as requiring one architecture version, and allowing it to be used for any later version. This strips any feature modifiers off the option, so that they can be matched independently of base architecture version.
* A -march option for every feature modifier which is enabled or disabled. This uses the made-up architecture name "armvX", which isn't a valid option, but that doesn't matter to multilib, and this allows matching features independently of the base architecture version.