### PR TITLE
Add additional patch folder for performance patches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,11 @@ option(
     the tools every time you update llvm-project."
     ON
 )
+option(
+    APPLY_LLVM_PERFORMANCE_PATCHES
+    "During checkout, apply optional downstream patches to
+    llvm-project to improve performance."
+)
 set(
     FVP_INSTALL_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/fvp/install" CACHE STRING
@@ -280,24 +285,17 @@ if(NOT (LLVM_TOOLCHAIN_C_LIBRARY STREQUAL llvmlibc)) # libc in a separate repo?
   read_repo_version(${LLVM_TOOLCHAIN_C_LIBRARY} ${LLVM_TOOLCHAIN_C_LIBRARY})
 endif()
 
-# The patches are generated from custom branch, with followin command:
-#   git format-patch -k origin/main
-# The patches apply cleanly against llvm-project commit
-# 327124ece7d59de56ca0f9faa2cd82af68c011b9.
-set(
-    llvm_project_patches
-    ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project/0001-libc-tests-with-picolibc-xfail-one-remaining-test.patch
-    ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project/0002-libc-tests-with-picolibc-disable-large-tests.patch
-    ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project/0003-Disable-failing-compiler-rt-test.patch
-    ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project/0004-libc-tests-with-picolibc-XFAIL-uses-of-atomics.patch
-    ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project/0005-libc-tests-with-picolibc-mark-two-more-large-tests.patch
-)
+set(LLVM_PATCH_COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/patch_llvm.py ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project)
+if(APPLY_LLVM_PERFORMANCE_PATCHES)
+    set(LLVM_PATCH_COMMAND ${LLVM_PATCH_COMMAND} && ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/patch_llvm.py ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project-perf)
+endif()
+
 FetchContent_Declare(llvmproject
     GIT_REPOSITORY https://github.com/llvm/llvm-project.git
     GIT_TAG "${llvmproject_TAG}"
     GIT_SHALLOW "${llvmproject_SHALLOW}"
     GIT_PROGRESS TRUE
-    PATCH_COMMAND git reset --quiet --hard && git clean --quiet --force -dx && git am -k --ignore-whitespace --3way ${llvm_project_patches}
+    PATCH_COMMAND ${LLVM_PATCH_COMMAND}
     # Add the llvm subdirectory later to ensure that
     # LLVMEmbeddedToolchainForArm is the first project declared.
     # Otherwise CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT

--- a/cmake/patch_llvm.py
+++ b/cmake/patch_llvm.py
@@ -69,7 +69,7 @@ def main():
             sys.exit(0)
         if args.restore_on_fail:
             # Check that the operation can be aborted.
-            # git am does give any specific return codes,
+            # git am doesn't give any specific return codes,
             # so check for unresolved working files.
             rebase_apply_path = os.path.join(".git", "rebase-apply")
             if args.llvm_dir:

--- a/cmake/patch_llvm.py
+++ b/cmake/patch_llvm.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+"""
+Script to apply a set of patches to llvm-project sources.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "patchdir",
+        help="Set of patches to apply. This should be a directory containing one or more ordered *.patch files.",
+    )
+    parser.add_argument(
+        "--llvm_dir",
+        help="Directory of the llvm-project git checkout, if not the current directory.",
+    )
+    parser.add_argument(
+        "--method",
+        choices=["am", "apply"],
+        default="apply",
+        help="Git command to use. git am will add each patch as a commit, whereas git apply will leave patched changes staged.",
+    )
+    parser.add_argument(
+        "--reset",
+        help="Clean and reset the repo to a specified commit before patching.",
+    )
+    parser.add_argument(
+        "--restore_on_fail",
+        action="store_true",
+        help="If a patch in a series cannot be applied, restore the original state instead of leaving patches missing. Return code will be 2 instead of 1.",
+    )
+    args = parser.parse_args()
+
+    if args.reset:
+        reset_args = ["git", "reset", "--quiet", "--hard"]
+        subprocess.check_output(reset_args, cwd=args.llvm_dir)
+        clean_args = ["git", "clean", "--quiet", "--force", "-dx"]
+        subprocess.check_output(clean_args, cwd=args.llvm_dir)
+
+    patch_names = []
+    for patch_name in os.listdir(args.patchdir):
+        if patch_name.endswith(".patch"):
+            patch_names.append(patch_name)
+    patch_names.sort()
+
+    print(f"Found {len(patch_names)} patches to apply:")
+    for patch_name in patch_names:
+        print(patch_name)
+
+    if args.method == "am":
+        merge_args = ["git", "am", "-k", "--ignore-whitespace", "--3way"]
+        for patch_name in patch_names:
+            merge_args.append(os.path.join(args.patchdir, patch_name))
+        p = subprocess.run(
+            merge_args, cwd=args.llvm_dir, capture_output=True, text=True
+        )
+        print(p.stdout)
+        print(p.stderr)
+
+        if p.returncode == 0:
+            print(f"All patches applied.")
+            sys.exit(0)
+        if args.restore_on_fail:
+            # Check that the operation can be aborted.
+            if (
+                'To restore the original branch and stop patching, run "git am --abort".'
+                in p.stdout
+            ):
+                print("Aborting git am...")
+                subprocess.run(["git", "am", "--abort"], cwd=args.llvm_dir, check=True)
+                sys.exit(2)
+        sys.exit(1)
+    else:
+        applied_patches = []
+        for patch_name in patch_names:
+            patch_file = os.path.join(args.patchdir, patch_name)
+            print(f"Checking {patch_file}...")
+            # Check that the patch applies before trying to apply it.
+            apply_check_args = [
+                "git",
+                "apply",
+                "--ignore-whitespace",
+                "--3way",
+                "--check",
+                patch_file,
+            ]
+            p_check = subprocess.run(apply_check_args, cwd=args.llvm_dir)
+
+            if p_check.returncode == 0:
+                # Patch will apply.
+                print(f"Applying {patch_file}...")
+                apply_args = [
+                    "git",
+                    "apply",
+                    "--ignore-whitespace",
+                    "--3way",
+                    patch_file,
+                ]
+                apply_args = subprocess.run(apply_args, cwd=args.llvm_dir, check=True)
+                applied_patches.append(patch_file)
+            else:
+                # Patch won't apply.
+                print(f"Unable to apply {patch_file}")
+                if args.restore_on_fail:
+                    # Remove any patches that have already been applied.
+                    while len(applied_patches) > 0:
+                        r_patch = applied_patches.pop()
+                        print(f"Reversing {r_patch}...")
+                        reverse_args = [
+                            "git",
+                            "apply",
+                            "--ignore-whitespace",
+                            "--3way",
+                            "--reverse",
+                            r_patch,
+                        ]
+                        p_check = subprocess.run(
+                            reverse_args, cwd=args.llvm_dir, check=True
+                        )
+                    print(f"Rollback successful, failure occured on {patch_file}")
+                    sys.exit(2)
+                sys.exit(1)
+        print(f"All patches applied.")
+
+
+main()

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -148,3 +148,12 @@ The same build directory can be used for both native and MinGW toolchains.
 
 See [patches](https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/tree/main/patches)
 directory for the current set of differences from upstream.
+
+The patches for llvm-project are split between two folders, llvm-project and
+llvm-project-perf. The former are generally required for building and
+successfully running all tests. The patches in llvm-project-perf are optional,
+and designed to improve performance in certain circumstances.
+
+To reduce divergence from upstream and potential patch conflicts, the
+performance patches are not applied by default, but can be enabled for an
+automatic checkout with the APPLY_LLVM_PERFORMANCE_PATCHES option.

--- a/patches/llvm-project-perf/0000-Placeholder-commit.patch
+++ b/patches/llvm-project-perf/0000-Placeholder-commit.patch
@@ -1,0 +1,22 @@
+From e79697a54cba9bfc1a755ed048e42054d679de61 Mon Sep 17 00:00:00 2001
+From: David Candler <david.candler@arm.com>
+Date: Wed, 2 Oct 2024 14:13:31 +0100
+Subject: [PATCH] Placeholder commit
+
+---
+ .gitignore | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/.gitignore b/.gitignore
+index 0e7c6c790013..dfa0b8da0ccd 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -1,4 +1,4 @@
+-#==============================================================================#
++#==============================================================================#
+ # This file specifies intentionally untracked files that git should ignore.
+ # See: http://www.kernel.org/pub/software/scm/git/docs/gitignore.html
+ #
+-- 
+2.34.1
+


### PR DESCRIPTION
This adds a second llvm-project patch directory, intended for performance enhancement patches which can be kept optional to avoid blocking builds if they become out of date with the main branch. A new CMake option controls whether or not to apply the patches, and a new script is included to manage the patching process to make it easier to identify when there is a problem with a patch.