### PR TITLE
Update llvm-project patch files to apply cleanly on more recent commits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,7 +283,7 @@ endif()
 # The patches are generated from custom branch, with followin command:
 #   git format-patch -k origin/main
 # The patches apply cleanly against llvm-project commit
-# ed551e0778a35f00ab60f1c80d83ea8274d8d400.
+# 327124ece7d59de56ca0f9faa2cd82af68c011b9.
 set(
     llvm_project_patches
     ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm-project/0001-libc-tests-with-picolibc-xfail-one-remaining-test.patch

--- a/patches/llvm-project/0001-libc-tests-with-picolibc-xfail-one-remaining-test.patch
+++ b/patches/llvm-project/0001-libc-tests-with-picolibc-xfail-one-remaining-test.patch
@@ -1,14 +1,14 @@
-From 1db48238bfbc5324dadf828532a4c67524dc471b Mon Sep 17 00:00:00 2001
+From 623881f1ea465f9c1837981db143f7225108580a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Mon, 16 Oct 2023 11:35:48 +0200
-Subject: [PATCH] [libc++] tests with picolibc: xfail one remaining test
+Subject: [libc++] tests with picolibc: xfail one remaining test
 
 ---
  .../language.support/support.start.term/quick_exit.pass.cpp    | 3 +++
  1 file changed, 3 insertions(+)
 
 diff --git a/libcxx/test/std/language.support/support.start.term/quick_exit.pass.cpp b/libcxx/test/std/language.support/support.start.term/quick_exit.pass.cpp
-index d8eff69cb5..e16048df72 100644
+index d8eff69cb53f..e16048df722e 100644
 --- a/libcxx/test/std/language.support/support.start.term/quick_exit.pass.cpp
 +++ b/libcxx/test/std/language.support/support.start.term/quick_exit.pass.cpp
 @@ -17,6 +17,9 @@
@@ -22,5 +22,5 @@ index d8eff69cb5..e16048df72 100644
  
  void f() {}
 -- 
-2.34.1
+2.39.5 (Apple Git-154)
 

--- a/patches/llvm-project/0002-libc-tests-with-picolibc-disable-large-tests.patch
+++ b/patches/llvm-project/0002-libc-tests-with-picolibc-disable-large-tests.patch
@@ -1,4 +1,4 @@
-From 80000ddfade0f706ad1ebb488a51132a88cbe61d Mon Sep 17 00:00:00 2001
+From 8a0f8650d58f27ca32948554188b98c8978d1eb6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Wed, 15 Nov 2023 12:18:35 +0100
 Subject: [libc++] tests with picolibc: disable large tests
@@ -41,7 +41,7 @@ index b5f9089308d2..0a83e75ceceb 100644
  set(LIBUNWIND_USE_COMPILER_RT ON CACHE BOOL "")
  find_program(QEMU_SYSTEM_ARM qemu-system-arm REQUIRED)
 diff --git a/libcxxabi/test/test_demangle.pass.cpp b/libcxxabi/test/test_demangle.pass.cpp
-index fe5598991b83..65d30a352814 100644
+index ad131bb3a8a7..ac612c79f71c 100644
 --- a/libcxxabi/test/test_demangle.pass.cpp
 +++ b/libcxxabi/test/test_demangle.pass.cpp
 @@ -7,7 +7,7 @@
@@ -51,8 +51,8 @@ index fe5598991b83..65d30a352814 100644
 -// XFAIL: LIBCXX-PICOLIBC-FIXME
 +// REQUIRES: large_tests
  
- // https://llvm.org/PR51407 was not fixed in some previously-released
- // demanglers, which causes them to run into the infinite loop.
+ // This test exercises support for char array initializer lists added in dd8b266ef.
+ // UNSUPPORTED: using-built-library-before-llvm-20
 -- 
-2.34.1
+2.39.5 (Apple Git-154)
 

--- a/patches/llvm-project/0003-Disable-failing-compiler-rt-test.patch
+++ b/patches/llvm-project/0003-Disable-failing-compiler-rt-test.patch
@@ -1,4 +1,4 @@
-From c4837fa13ec89cc06b07af8cba8494189520e546 Mon Sep 17 00:00:00 2001
+From 0f8dc80a7642430c8d02c36283766aeb5a59a331 Mon Sep 17 00:00:00 2001
 From: Piotr Przybyla <piotr.przybyla@arm.com>
 Date: Wed, 15 Nov 2023 16:04:24 +0000
 Subject: Disable failing compiler-rt test
@@ -18,5 +18,5 @@ index 2ff65a8b9ec3..98611a75e85f 100644
  // RUN: %clang_builtins %s %librt -o %t && %run %t
  
 -- 
-2.34.1
+2.39.5 (Apple Git-154)
 

--- a/patches/llvm-project/0004-libc-tests-with-picolibc-XFAIL-uses-of-atomics.patch
+++ b/patches/llvm-project/0004-libc-tests-with-picolibc-XFAIL-uses-of-atomics.patch
@@ -1,4 +1,4 @@
-From 3b7ada947d511fe0edb7cca0dbdb640d8e1ecd2b Mon Sep 17 00:00:00 2001
+From f5b5a95bd02f6d5bc6e80c238c2e8f7e08985d80 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Thu, 9 Nov 2023 15:25:14 +0100
 Subject: [libc++] tests with picolibc: XFAIL uses of atomics
@@ -88,10 +88,10 @@ index 000000000000..5ecc58f3e385
 +if "has-no-atomics" in config.available_features:
 +    config.unsupported = True
 diff --git a/libcxx/utils/libcxx/test/features.py b/libcxx/utils/libcxx/test/features.py
-index 6ef40755c59d..6c2960260189 100644
+index 735eb5ac949d..6ca4e8acb3f4 100644
 --- a/libcxx/utils/libcxx/test/features.py
 +++ b/libcxx/utils/libcxx/test/features.py
-@@ -206,6 +206,21 @@ DEFAULT_FEATURES = [
+@@ -215,6 +215,21 @@ DEFAULT_FEATURES = [
            """,
          ),
      ),
@@ -114,5 +114,5 @@ index 6ef40755c59d..6c2960260189 100644
      Feature(
          name="32-bit-pointer",
 -- 
-2.34.1
+2.39.5 (Apple Git-154)
 

--- a/patches/llvm-project/0005-libc-tests-with-picolibc-mark-two-more-large-tests.patch
+++ b/patches/llvm-project/0005-libc-tests-with-picolibc-mark-two-more-large-tests.patch
@@ -1,4 +1,4 @@
-From 8eb9344a4ba97b45cea1a6adec98aff6c6149359 Mon Sep 17 00:00:00 2001
+From 0961af52ac015c26829b4dae7fd6879a0b633f44 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Wed, 22 Nov 2023 16:12:39 +0100
 Subject: [libc++] tests with picolibc: mark two more large tests
@@ -37,5 +37,5 @@ index 64a6a135adda..057301e6f868 100644
  //     bool
  //     regex_search(BidirectionalIterator first, BidirectionalIterator last,
 -- 
-2.34.1
+2.39.5 (Apple Git-154)
 


### PR DESCRIPTION
Due to a recent commit in upstream LLVM, the patch for the
`libcxxabi/test/test_demangle.pass.cpp` test now only applies when using
3-way merge.
This patch rebases the set of patch files in `patches/llvm-project/*` to
apply cleanly on recent commits from llvm/llvm-project.
