### PR TITLE
Fix library variants for v7-R soft-float ABI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1768,9 +1768,9 @@ add_library_variants_for_cpu(
 )
 add_library_variants_for_cpu(
     armv7r
-    SUFFIX soft_vfpv3_d16
-    COMPILE_FLAGS "-mfloat-abi=softfp -march=armv7r -mfpu=vfpv3-d16"
-    MULTILIB_FLAGS "--target=armv7r-unknown-none-eabi -mfpu=vfpv3-d16"
+    SUFFIX soft_vfpv3xd
+    COMPILE_FLAGS "-mfloat-abi=softfp -march=armv7r -mfpu=vfpv3xd"
+    MULTILIB_FLAGS "--target=armv7r-unknown-none-eabi -mfpu=vfpv3xd"
     PICOLIBC_BUILD_TYPE "release"
     QEMU_MACHINE "none"
     QEMU_CPU "cortex-r5f"

--- a/test/multilib/armv7r.test
+++ b/test/multilib/armv7r.test
@@ -13,7 +13,7 @@
 # RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3-d16 -mfloat-abi=softfp   | FileCheck --check-prefix=SOFT-VFPV3 %s
 # RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3-d16 -marm -mfloat-abi=softfp  | FileCheck --check-prefix=SOFT-VFPV3 %s
 # RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3-d16 -mthumb -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-VFPV3 %s
-# SOFT-VFPV3: arm-none-eabi/armv7r_soft_vfpv3_d16_exn_rtti{{$}}
+# SOFT-VFPV3: arm-none-eabi/armv7r_soft_vfpv3xd_exn_rtti{{$}}
 # SOFT-VFPV3-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=armv7r-none-eabihf -mfpu=vfpv3xd         | FileCheck --check-prefix=VFPV3XD %s

--- a/test/multilib/armv8r.test
+++ b/test/multilib/armv8r.test
@@ -6,6 +6,16 @@
 # CHECK: arm-none-eabi/armv7r_soft_nofp_exn_rtti{{$}}
 # CHECK-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=armv8r-none-eabi | FileCheck --check-prefix=SOFT-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8-r | FileCheck --check-prefix=SOFT-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv8r-none-eabihf -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=arm-none-eabihf -mfloat-abi=softfp -march=armv8-r | FileCheck --check-prefix=SOFT-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8-r -marm | FileCheck --check-prefix=SOFT-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8-r -mthumb | FileCheck --check-prefix=SOFT-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8-r -mfpu=fpv5-d16 | FileCheck --check-prefix=SOFT-VFPV3 %s
+# SOFT-VFPV3: arm-none-eabi/armv7r_soft_vfpv3xd_exn_rtti{{$}}
+# SOFT-VFPV3-EMPTY:
+
 # RUN: %clang -print-multi-directory --target=armv8r-none-eabihf -mfpu=vfpv3-d16 | FileCheck --check-prefix=VFPV3 %s
 # RUN: %clang -print-multi-directory --target=armv8r-none-eabihf -mfpu=neon-vfpv3 | FileCheck --check-prefix=VFPV3 %s
 # RUN: %clang -print-multi-directory --target=armv8r-none-eabihf -mfpu=vfpv3 | FileCheck --check-prefix=VFPV3 %s
@@ -18,5 +28,16 @@
 # RUN: %clang -print-multi-directory --target=armv8r-none-eabihf -mfpu=vfpv3-d16 -marm | FileCheck --check-prefix=VFPV3 %s
 # RUN: %clang -print-multi-directory --target=armv8r-none-eabihf -mfpu=vfpv3-d16 -mthumb | FileCheck --check-prefix=VFPV3 %s
 # RUN: %clang -print-multi-directory --target=armv8r-none-eabihf -mcpu=cortex-r52 | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=arm-none-eabihf -march=armv8-r -mfpu=fpv5-d16 | FileCheck --check-prefix=VFPV3 %s
+# RUN: %clang -print-multi-directory --target=arm-none-eabihf -march=armv8-r -mfpu=fp-armv8 | FileCheck --check-prefix=VFPV3 %s
 # VFPV3: arm-none-eabi/armv7r_hard_vfpv3_d16_exn_rtti{{$}}
 # VFPV3-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8r-none-eabihf                       | FileCheck --check-prefix=VFPV3XD %s
+# RUN: %clang -print-multi-directory --target=arm-none-eabihf   -march=armv8-r         | FileCheck --check-prefix=VFPV3XD %s
+# RUN: %clang -print-multi-directory --target=arm-none-eabihf   -march=armv8-r -marm   | FileCheck --check-prefix=VFPV3XD %s
+# RUN: %clang -print-multi-directory --target=arm-none-eabihf   -march=armv8-r -mthumb | FileCheck --check-prefix=VFPV3XD %s
+# RUN: %clang -print-multi-directory --target=arm-none-eabihf -march=armv8-r -mfpu=fpv4-sp-d16 | FileCheck --check-prefix=VFPV3XD %s
+# RUN: %clang -print-multi-directory --target=arm-none-eabihf -march=armv8-r -mfpu=fpv5-sp-d16 | FileCheck --check-prefix=VFPV3XD %s
+# VFPV3XD: arm-none-eabi/armv7r_hard_vfpv3xd_exn_rtti{{$}}
+# VFPV3XD-EMPTY:


### PR DESCRIPTION
We currently build these two library variants for v7-R with the soft-float ABI:
* armv7r_soft_nofp
* armv7r_soft_vfpv3_d16

The first variant can only be used when the target does not have an FPU, because it does not include bootcode to enable the FPU. This means that we don't have any library variants which can be selected for the single-precision-only FPUs when using the soft-float ABI. For the hard-float ABI, we solve this by having separate library variants for vfpv3xd (SP-only) and vfpv3_d16 (SP+DP). This is important for performance, as it allows the math library to use DP instructions where available.

We could do the same thing for the soft-float libraries, however these variants with an FPU are included for completeness, their performance is less important because a user interested in performance would use the hard-float ABI. Thesefore I think we should only include the variant for the minimal FPU, which is vfpv3xd.

These libraries are also used for v8-R AArch32, where this change is important because -march=armv8-r implies -mfpu=fpv5-sp-d16 by default, which currently fails to find a library.