### PR TITLE
Add -enable-dfa-jump-thread to Omax.cfg

### DIFF
--- a/Omax.cfg
+++ b/Omax.cfg
@@ -5,3 +5,4 @@
 -mllvm -unroll-max-iteration-count-to-analyze=20 \
 -mllvm -lsr-complexity-limit=1073741823 \
 -mllvm -force-attribute=main:norecurse \
+-mllvm -enable-dfa-jump-thread \


### PR DESCRIPTION
This optimization sees some good improvements and the downstream equivalent is enabled for -Omax on Arm Compiler 6.