### PR TITLE
Remove armv4t/armv5t from check-all targets

### DIFF
--- a/0001-Remove-armv4t-armv5t-from-check-all-targets.patch
+++ b/0001-Remove-armv4t-armv5t-from-check-all-targets.patch
@@ -1,0 +1,60 @@
+From 8e51f55289eef78b08edb845023c1a7c9c0191b5 Mon Sep 17 00:00:00 2001
+From: David Candler <david.candler@arm.com>
+Date: Wed, 23 Oct 2024 14:40:58 +0100
+Subject: [PATCH] Remove armv4t/armv5t from check-all targets
+
+The compiler-rt and libcxx tests for armv4t and armv5t variants
+currently hang until a timeout is reached. Rather than disable the
+tests, this patch removes them from the check-all targets. This
+allows the tests to still be run while investigating the issue, but
+does not interrupt overall testing of the toolchain.
+---
+ CMakeLists.txt | 18 +++++++++++++++---
+ 1 file changed, 15 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 60ec6c6..fa5b462 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1310,7 +1310,11 @@ function(add_compiler_rt_tests variant)
+     )
+     add_custom_target(check-compiler-rt-${variant})
+     add_dependencies(check-compiler-rt-${variant} compiler_rt_${variant}-check-compiler-rt)
+-    add_dependencies(check-compiler-rt check-compiler-rt-${variant})
++    # Do not add armv4 or armv5 tests to the check-all
++    # targets as they currently hang.
++    if(NOT VARIANT_COMPILE_FLAGS MATCHES "-march=armv4|5")
++        add_dependencies(check-compiler-rt check-compiler-rt-${variant})
++    endif()
+     add_dependencies(check-llvm-toolchain-runtimes-${variant} check-compiler-rt-${variant})
+ endfunction()
+ 
+@@ -1334,7 +1338,11 @@ function(add_libcxx_libcxxabi_libunwind_tests variant)
+         )
+         add_custom_target(${check_target}-${variant_with_extensions})
+         add_dependencies(${check_target}-${variant_with_extensions} ${target_name}-${check_target})
+-        add_dependencies(${check_target} ${target_name}-${check_target})
++        # Do not add armv4 or armv5 tests to the check-all
++        # targets as they currently hang.
++        if(NOT variant MATCHES "-march=armv4|5")
++            add_dependencies(${check_target} ${target_name}-${check_target})
++        endif()
+         add_dependencies(check-llvm-toolchain-runtimes-${variant} ${check_target}-${variant_with_extensions})
+     endforeach()
+ endfunction()
+@@ -1499,7 +1507,11 @@ function(add_library_variant target_arch)
+             message("C++ runtime libraries tests disabled for ${variant}")
+         else()
+             add_custom_target(check-llvm-toolchain-runtimes-${variant})
+-            add_dependencies(check-llvm-toolchain-runtimes check-llvm-toolchain-runtimes-${variant})
++            # Do not add armv4 or armv5 tests to the check-all
++            # targets as they currently hang.
++            if(NOT VARIANT_COMPILE_FLAGS MATCHES "-march=armv4|5")
++                add_dependencies(check-llvm-toolchain-runtimes check-llvm-toolchain-runtimes-${variant})
++            endif()
+             add_compiler_rt_tests("${variant}")
+             if(CXX_LIBS)
+                 add_libcxx_libcxxabi_libunwind_tests("${variant}")
+-- 
+2.34.1
+

--- a/0001-Update-picolibc-patch-file.patch
+++ b/0001-Update-picolibc-patch-file.patch
@@ -1,0 +1,46 @@
+From 2f9a405df7f3e211eab7bb44dcb3a5b3b88665d8 Mon Sep 17 00:00:00 2001
+From: David Candler <david.candler@arm.com>
+Date: Thu, 24 Oct 2024 10:07:57 +0100
+Subject: [PATCH] Update picolibc patch file
+
+Patch no longer cleanly applies, so this updates the diff.
+---
+ patches/picolibc.patch | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/patches/picolibc.patch b/patches/picolibc.patch
+index ba5b17a..a77d879 100644
+--- a/patches/picolibc.patch
++++ b/patches/picolibc.patch
+@@ -1,8 +1,8 @@
+ diff --git a/meson.build b/meson.build
+-index 0fdfa0412..8e679f166 100644
++index f90f5b818..2f8d63733 100644
+ --- a/meson.build
+ +++ b/meson.build
+-@@ -1224,6 +1224,18 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
++@@ -1310,6 +1310,18 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
+    error('newlib-retargetable-locking and newlib-multithread must be set to the same value')
+  endif
+  
+@@ -22,13 +22,13 @@ index 0fdfa0412..8e679f166 100644
+  	      cc.has_argument('-fno-tree-loop-distribute-patterns'),
+  	      description: 'Compiler flag to prevent detecting memcpy/memset patterns')
+ diff --git a/picolibc.ld.in b/picolibc.ld.in
+-index b97ea3300..04b94f35c 100644
++index 7b63ba172..cda5e1e7e 100644
+ --- a/picolibc.ld.in
+ +++ b/picolibc.ld.in
+ @@ -68,6 +68,9 @@ SECTIONS
+- 		*(.text.unlikely .text.unlikely.*)
+- 		*(.text.startup .text.startup.*)
+- 		*(.text .text.* .opd .opd.*)
++ 		*(.literal.unlikely .text.unlikely .literal.unlikely.* .text.unlikely.*)
++ 		*(.literal.startup .text.startup .literal.startup.* .text.startup.*)
++ 		*(.literal .text .literal.* .text.* .opd .opd.*)
+ +		PROVIDE (__start___lcxx_override = .);
+ +		*(__lcxx_override)
+ +		PROVIDE (__stop___lcxx_override = .);
+-- 
+2.34.1
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -804,8 +804,12 @@ function(
     if(run_tests)
         add_custom_target(check-picolibc-${variant})
         add_dependencies(check-picolibc-${variant} picolibc_${variant}-test)
-        add_dependencies(check-picolibc check-picolibc-${variant})
-        add_dependencies(llvm-toolchain-runtimes picolibc_${variant})
+        # Do not add armv4 or armv5 tests to the check-all
+        # targets as they currently hang.
+        if(NOT variant MATCHES "armv4|5")
+            add_dependencies(check-picolibc check-picolibc-${variant})
+            add_dependencies(llvm-toolchain-runtimes picolibc_${variant})
+        endif()
     endif()
 endfunction()
 
@@ -1312,7 +1316,7 @@ function(add_compiler_rt_tests variant)
     add_dependencies(check-compiler-rt-${variant} compiler_rt_${variant}-check-compiler-rt)
     # Do not add armv4 or armv5 tests to the check-all
     # targets as they currently hang.
-    if(NOT VARIANT_COMPILE_FLAGS MATCHES "-march=armv4|5")
+    if(NOT variant MATCHES "armv4|5")
         add_dependencies(check-compiler-rt check-compiler-rt-${variant})
     endif()
     add_dependencies(check-llvm-toolchain-runtimes-${variant} check-compiler-rt-${variant})
@@ -1340,7 +1344,7 @@ function(add_libcxx_libcxxabi_libunwind_tests variant)
         add_dependencies(${check_target}-${variant_with_extensions} ${target_name}-${check_target})
         # Do not add armv4 or armv5 tests to the check-all
         # targets as they currently hang.
-        if(NOT variant MATCHES "-march=armv4|5")
+        if(NOT variant MATCHES "armv4|5")
             add_dependencies(${check_target} ${target_name}-${check_target})
         endif()
         add_dependencies(check-llvm-toolchain-runtimes-${variant} ${check_target}-${variant_with_extensions})
@@ -1509,7 +1513,7 @@ function(add_library_variant target_arch)
             add_custom_target(check-llvm-toolchain-runtimes-${variant})
             # Do not add armv4 or armv5 tests to the check-all
             # targets as they currently hang.
-            if(NOT VARIANT_COMPILE_FLAGS MATCHES "-march=armv4|5")
+            if(NOT variant MATCHES "armv4|5")
                 add_dependencies(check-llvm-toolchain-runtimes check-llvm-toolchain-runtimes-${variant})
             endif()
             add_compiler_rt_tests("${variant}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1310,7 +1310,11 @@ function(add_compiler_rt_tests variant)
     )
     add_custom_target(check-compiler-rt-${variant})
     add_dependencies(check-compiler-rt-${variant} compiler_rt_${variant}-check-compiler-rt)
-    add_dependencies(check-compiler-rt check-compiler-rt-${variant})
+    # Do not add armv4 or armv5 tests to the check-all
+    # targets as they currently hang.
+    if(NOT VARIANT_COMPILE_FLAGS MATCHES "-march=armv4|5")
+        add_dependencies(check-compiler-rt check-compiler-rt-${variant})
+    endif()
     add_dependencies(check-llvm-toolchain-runtimes-${variant} check-compiler-rt-${variant})
 endfunction()
 
@@ -1334,7 +1338,11 @@ function(add_libcxx_libcxxabi_libunwind_tests variant)
         )
         add_custom_target(${check_target}-${variant_with_extensions})
         add_dependencies(${check_target}-${variant_with_extensions} ${target_name}-${check_target})
-        add_dependencies(${check_target} ${target_name}-${check_target})
+        # Do not add armv4 or armv5 tests to the check-all
+        # targets as they currently hang.
+        if(NOT variant MATCHES "-march=armv4|5")
+            add_dependencies(${check_target} ${target_name}-${check_target})
+        endif()
         add_dependencies(check-llvm-toolchain-runtimes-${variant} ${check_target}-${variant_with_extensions})
     endforeach()
 endfunction()
@@ -1499,7 +1507,11 @@ function(add_library_variant target_arch)
             message("C++ runtime libraries tests disabled for ${variant}")
         else()
             add_custom_target(check-llvm-toolchain-runtimes-${variant})
-            add_dependencies(check-llvm-toolchain-runtimes check-llvm-toolchain-runtimes-${variant})
+            # Do not add armv4 or armv5 tests to the check-all
+            # targets as they currently hang.
+            if(NOT VARIANT_COMPILE_FLAGS MATCHES "-march=armv4|5")
+                add_dependencies(check-llvm-toolchain-runtimes check-llvm-toolchain-runtimes-${variant})
+            endif()
             add_compiler_rt_tests("${variant}")
             if(CXX_LIBS)
                 add_libcxx_libcxxabi_libunwind_tests("${variant}")


### PR DESCRIPTION
The compiler-rt and libcxx tests for armv4t and armv5t variants currently hang until a timeout is reached. Rather than disable the tests, this patch removes them from the check-all targets. This allows the tests to still be run while investigating the issue, but does not interrupt overall testing of the toolchain.