### PR TITLE
[OmaxLTO] Fix the flag to be supplied to the LTO plugin

### DIFF
--- a/OmaxLTO.cfg
+++ b/OmaxLTO.cfg
@@ -1,4 +1,5 @@
 -flto=full \
 -fvirtual-function-elimination \
 -fwhole-program-vtables \
--mllvm -extra-LTO-loop-unroll=true
+-Wl,-plugin-opt=-extra-LTO-loop-unroll=true
+

--- a/docs/optimization-flags.md
+++ b/docs/optimization-flags.md
@@ -6,4 +6,4 @@ In some cases it is benefitial to perform an additional loop unroll pass so that
 Use cases where this could be beneficial - multiple (N>=4) nested loops.
 
 ### Usage: 
-    -mllvm -extra-LTO-loop-unroll=true/false
+    -Wl,-plugin-opt=-extra-LTO-loop-unroll=true/false


### PR DESCRIPTION
The flag to add the extra loop unroll pass was previously provided to opt and was not actually working, as it's supposed to be provided to the LTO plugin. 