### PR TITLE
Fix Python SyntaxWarning in two f-string literals.

### DIFF
--- a/multilib-generate.py
+++ b/multilib-generate.py
@@ -247,10 +247,10 @@ def generate_extensions(args):
     print("# original option to check that.")
 
     for feature in all_features:
-        print(f"- Match: -march=armv.*\\+{feature}($|\+.*)")
+        print(f"- Match: -march=armv.*\\+{feature}($|\\+.*)")
         print(f"  Flags:")
         print(f"  - -march=armvX+{feature}")
-        print(f"- Match: -march=armv.*\\+no{feature}($|\+.*)")
+        print(f"- Match: -march=armv.*\\+no{feature}($|\\+.*)")
         print(f"  Flags:")
         print(f"  - -march=armvX+no{feature}")
     print()


### PR DESCRIPTION
Building on Ubuntu 24.04, multilib-generate.py provokes some SyntaxWarning messages from Python 3.12, because of cases where we'd written `\+` in a string, intended to be emitted literally. 3.12 still _does_ emit it literally, but prints a warning pointing out that we should properly escape the backslash, writing it as `\\+`.