### PR TITLE
Corrections to CMake changes to enable library sub-builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -572,6 +572,12 @@ if(NOT PREBUILT_TARGET_LIBRARIES)
         endif()
     endif()
 
+    # ENABLE_VARIANTS expects a semi-colon separated list.
+    # To prevent CMake expanding it automatically while passing it
+    # down, switch to comma separated. Enabling the ExternalProject
+    # LIST_SEPARATOR option will handle switching it back.
+    string(REPLACE ";" "," ENABLE_VARIANTS_PASSTHROUGH "${LLVM_TOOLCHAIN_LIBRARY_VARIANTS}")
+
     ExternalProject_Add(
         multilib-${LLVM_TOOLCHAIN_C_LIBRARY}
         PREFIX ${CMAKE_BINARY_DIR}/multilib-builds
@@ -583,7 +589,7 @@ if(NOT PREBUILT_TARGET_LIBRARIES)
         -DC_LIBRARY=${LLVM_TOOLCHAIN_C_LIBRARY}
         -DLLVM_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}/llvm
         -DMULTILIB_JSON=${LLVM_TOOLCHAIN_MULTILIB_JSON}
-        -DENABLE_VARIANTS=${LLVM_TOOLCHAIN_LIBRARY_VARIANTS}
+        -DENABLE_VARIANTS=${ENABLE_VARIANTS_PASSTHROUGH}
         -DLIBC_HDRGEN=${LIBC_HDRGEN}
         -DFVP_INSTALL_DIR=${FVP_INSTALL_DIR}
         -DFVP_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/fvp/config

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,6 +516,11 @@ add_dependencies(
     version_txt
 )
 
+# Set LLVM_DEFAULT_EXTERNAL_LIT to the directory of clang
+# which was build in previous step. This path is not exported
+# by add_subdirectory of llvm project
+set(LLVM_DEFAULT_EXTERNAL_LIT "${LLVM_BINARY_DIR}/bin/llvm-lit")
+
 if(LIBS_DEPEND_ON_TOOLS)
     set(lib_tool_dependencies
         clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,10 @@ option(
     "During checkout, apply optional downstream patches to
     llvm-project to improve performance."
 )
+option(
+    ENABLE_FVP_TESTING
+    "Tests using FVP need to be explictly enabled."
+)
 set(
     FVP_INSTALL_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/fvp/install" CACHE STRING
@@ -592,6 +596,7 @@ if(NOT PREBUILT_TARGET_LIBRARIES)
         -DENABLE_VARIANTS=${ENABLE_VARIANTS_PASSTHROUGH}
         -DLIBC_HDRGEN=${LIBC_HDRGEN}
         -DFVP_INSTALL_DIR=${FVP_INSTALL_DIR}
+        -DENABLE_FVP_TESTING=${ENABLE_FVP_TESTING}
         -DFVP_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/fvp/config
         -DFETCHCONTENT_SOURCE_DIR_LLVMPROJECT=${FETCHCONTENT_SOURCE_DIR_LLVMPROJECT}
         -DFETCHCONTENT_SOURCE_DIR_PICOLIBC=${FETCHCONTENT_SOURCE_DIR_PICOLIBC}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -521,18 +521,6 @@ add_dependencies(
 # by add_subdirectory of llvm project
 set(LLVM_DEFAULT_EXTERNAL_LIT "${LLVM_BINARY_DIR}/bin/llvm-lit")
 
-if(LIBS_DEPEND_ON_TOOLS)
-    set(lib_tool_dependencies
-        clang
-        lld
-        llvm-ar
-        llvm-config
-        llvm-nm
-        llvm-ranlib
-        llvm-strip
-    )
-endif()
-
 add_custom_target(check-llvm-toolchain-runtimes)
 add_custom_target(check-${LLVM_TOOLCHAIN_C_LIBRARY})
 add_custom_target(check-compiler-rt)
@@ -540,116 +528,131 @@ add_custom_target(check-cxx)
 add_custom_target(check-cxxabi)
 add_custom_target(check-unwind)
 
-add_dependencies(
-    check-llvm-toolchain-runtimes
-    check-${LLVM_TOOLCHAIN_C_LIBRARY}
-    check-compiler-rt
-    check-cxx
-    check-cxxabi
-    check-unwind
-)
-
-if(LLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL)
-    # If we're building a non-default libc with the intention of
-    # installing it as an overlay on the main package archive, then
-    # all of its includes, libraries and multilib.yaml go in a
-    # subdirectory of lib/clang-runtimes. Configuration files in the
-    # bin directory will make it easy to reset the sysroot to point at
-    # that subdir.
-    set(library_subdir "/${LLVM_TOOLCHAIN_C_LIBRARY}")
-else()
-    set(library_subdir "")
-endif()
-
-if(LIBS_USE_COMPILER_LAUNCHER)
-    if(CMAKE_C_COMPILER_LAUNCHER)
-        list(APPEND compiler_launcher_cmake_args "-DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}")
+if(NOT PREBUILT_TARGET_LIBRARIES)
+    if(LIBS_DEPEND_ON_TOOLS)
+        set(lib_tool_dependencies
+            clang
+            lld
+            llvm-ar
+            llvm-config
+            llvm-nm
+            llvm-ranlib
+            llvm-strip
+        )
     endif()
-    if(CMAKE_CXX_COMPILER_LAUNCHER)
-        list(APPEND compiler_launcher_cmake_args "-DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}")
-    endif()
-endif()
 
-ExternalProject_Add(
-    multilib-${LLVM_TOOLCHAIN_C_LIBRARY}
-    PREFIX ${CMAKE_BINARY_DIR}/multilib-builds
-    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/arm-multilib
-    INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/llvm/${TARGET_LIBRARIES_DIR}${library_subdir}
-    DEPENDS ${lib_tool_dependencies}
-    CMAKE_ARGS
-    ${compiler_launcher_cmake_args}
-    -DC_LIBRARY=${LLVM_TOOLCHAIN_C_LIBRARY}
-    -DLLVM_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}/llvm
-    -DMULTILIB_JSON=${LLVM_TOOLCHAIN_MULTILIB_JSON}
-    -DENABLE_VARIANTS=${LLVM_TOOLCHAIN_LIBRARY_VARIANTS}
-    -DLIBC_HDRGEN=${LIBC_HDRGEN}
-    -DFVP_INSTALL_DIR=${FVP_INSTALL_DIR}
-    -DFVP_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/fvp/config
-    -DFETCHCONTENT_SOURCE_DIR_LLVMPROJECT=${FETCHCONTENT_SOURCE_DIR_LLVMPROJECT}
-    -DFETCHCONTENT_SOURCE_DIR_PICOLIBC=${FETCHCONTENT_SOURCE_DIR_PICOLIBC}
-    -DFETCHCONTENT_SOURCE_DIR_NEWLIB=${FETCHCONTENT_SOURCE_DIR_NEWLIB}
-    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-    USES_TERMINAL_CONFIGURE FALSE
-    USES_TERMINAL_BUILD TRUE
-    USES_TERMINAL_TEST TRUE
-    LIST_SEPARATOR ,
-    CONFIGURE_HANDLED_BY_BUILD TRUE
-    TEST_EXCLUDE_FROM_MAIN TRUE
-    STEP_TARGETS build install
-)
 
-add_dependencies(
-    llvm-toolchain-runtimes
-    multilib-${LLVM_TOOLCHAIN_C_LIBRARY}-install
-)
-
-foreach(check_target check-${LLVM_TOOLCHAIN_C_LIBRARY} check-compiler-rt check-cxx check-cxxabi check-unwind)
-    ExternalProject_Add_Step(
-        multilib-${LLVM_TOOLCHAIN_C_LIBRARY}
-        ${check_target}
-        COMMAND "${CMAKE_COMMAND}" --build <BINARY_DIR> --target ${check_target}
-        USES_TERMINAL TRUE
-        EXCLUDE_FROM_MAIN TRUE
-        ALWAYS TRUE
+    add_dependencies(
+        check-llvm-toolchain-runtimes
+        check-${LLVM_TOOLCHAIN_C_LIBRARY}
+        check-compiler-rt
+        check-cxx
+        check-cxxabi
+        check-unwind
     )
-    ExternalProject_Add_StepTargets(multilib-${LLVM_TOOLCHAIN_C_LIBRARY} ${check_target})
-    ExternalProject_Add_StepDependencies(
+
+    if(LLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL)
+        # If we're building a non-default libc with the intention of
+        # installing it as an overlay on the main package archive, then
+        # all of its includes, libraries and multilib.yaml go in a
+        # subdirectory of lib/clang-runtimes. Configuration files in the
+        # bin directory will make it easy to reset the sysroot to point at
+        # that subdir.
+        set(library_subdir "/${LLVM_TOOLCHAIN_C_LIBRARY}")
+    else()
+        set(library_subdir "")
+    endif()
+
+    if(LIBS_USE_COMPILER_LAUNCHER)
+        if(CMAKE_C_COMPILER_LAUNCHER)
+            list(APPEND compiler_launcher_cmake_args "-DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}")
+        endif()
+        if(CMAKE_CXX_COMPILER_LAUNCHER)
+            list(APPEND compiler_launcher_cmake_args "-DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}")
+        endif()
+    endif()
+
+    ExternalProject_Add(
         multilib-${LLVM_TOOLCHAIN_C_LIBRARY}
-        ${check_target}
+        PREFIX ${CMAKE_BINARY_DIR}/multilib-builds
+        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/arm-multilib
+        INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/llvm/${TARGET_LIBRARIES_DIR}${library_subdir}
+        DEPENDS ${lib_tool_dependencies}
+        CMAKE_ARGS
+        ${compiler_launcher_cmake_args}
+        -DC_LIBRARY=${LLVM_TOOLCHAIN_C_LIBRARY}
+        -DLLVM_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}/llvm
+        -DMULTILIB_JSON=${LLVM_TOOLCHAIN_MULTILIB_JSON}
+        -DENABLE_VARIANTS=${LLVM_TOOLCHAIN_LIBRARY_VARIANTS}
+        -DLIBC_HDRGEN=${LIBC_HDRGEN}
+        -DFVP_INSTALL_DIR=${FVP_INSTALL_DIR}
+        -DFVP_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/fvp/config
+        -DFETCHCONTENT_SOURCE_DIR_LLVMPROJECT=${FETCHCONTENT_SOURCE_DIR_LLVMPROJECT}
+        -DFETCHCONTENT_SOURCE_DIR_PICOLIBC=${FETCHCONTENT_SOURCE_DIR_PICOLIBC}
+        -DFETCHCONTENT_SOURCE_DIR_NEWLIB=${FETCHCONTENT_SOURCE_DIR_NEWLIB}
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        USES_TERMINAL_CONFIGURE FALSE
+        USES_TERMINAL_BUILD TRUE
+        USES_TERMINAL_TEST TRUE
+        LIST_SEPARATOR ,
+        CONFIGURE_HANDLED_BY_BUILD TRUE
+        TEST_EXCLUDE_FROM_MAIN TRUE
+        STEP_TARGETS build install
+    )
+
+    add_dependencies(
+        llvm-toolchain-runtimes
         multilib-${LLVM_TOOLCHAIN_C_LIBRARY}-install
     )
-    add_dependencies(${check_target} multilib-${LLVM_TOOLCHAIN_C_LIBRARY}-${check_target})
-endforeach()
 
-# Read the json to generate variant specific target names for convenience.
-file(READ ${LLVM_TOOLCHAIN_MULTILIB_JSON} multilib_json_str)
-string(JSON multilib_defs GET ${multilib_json_str} "libs")
-
-string(JSON lib_count LENGTH ${multilib_defs})
-math(EXPR lib_count_dec "${lib_count} - 1")
-
-foreach(lib_idx RANGE ${lib_count_dec})
-    string(JSON lib_def GET ${multilib_defs} ${lib_idx})
-    string(JSON variant GET ${lib_def} "variant")
     foreach(check_target check-${LLVM_TOOLCHAIN_C_LIBRARY} check-compiler-rt check-cxx check-cxxabi check-unwind)
         ExternalProject_Add_Step(
             multilib-${LLVM_TOOLCHAIN_C_LIBRARY}
-            ${check_target}-${variant}
-            COMMAND "${CMAKE_COMMAND}" --build <BINARY_DIR> --target ${check_target}-${variant}
+            ${check_target}
+            COMMAND "${CMAKE_COMMAND}" --build <BINARY_DIR> --target ${check_target}
             USES_TERMINAL TRUE
             EXCLUDE_FROM_MAIN TRUE
             ALWAYS TRUE
         )
-        ExternalProject_Add_StepTargets(multilib-${LLVM_TOOLCHAIN_C_LIBRARY} ${check_target}-${variant})
+        ExternalProject_Add_StepTargets(multilib-${LLVM_TOOLCHAIN_C_LIBRARY} ${check_target})
         ExternalProject_Add_StepDependencies(
             multilib-${LLVM_TOOLCHAIN_C_LIBRARY}
-            ${check_target}-${variant}
+            ${check_target}
             multilib-${LLVM_TOOLCHAIN_C_LIBRARY}-install
         )
-        add_custom_target(${check_target}-${variant})
-        add_dependencies(${check_target}-${variant} multilib-${LLVM_TOOLCHAIN_C_LIBRARY}-${check_target}-${variant})
+        add_dependencies(${check_target} multilib-${LLVM_TOOLCHAIN_C_LIBRARY}-${check_target})
     endforeach()
-endforeach()
+
+    # Read the json to generate variant specific target names for convenience.
+    file(READ ${LLVM_TOOLCHAIN_MULTILIB_JSON} multilib_json_str)
+    string(JSON multilib_defs GET ${multilib_json_str} "libs")
+
+    string(JSON lib_count LENGTH ${multilib_defs})
+    math(EXPR lib_count_dec "${lib_count} - 1")
+
+    foreach(lib_idx RANGE ${lib_count_dec})
+        string(JSON lib_def GET ${multilib_defs} ${lib_idx})
+        string(JSON variant GET ${lib_def} "variant")
+        foreach(check_target check-${LLVM_TOOLCHAIN_C_LIBRARY} check-compiler-rt check-cxx check-cxxabi check-unwind)
+            ExternalProject_Add_Step(
+                multilib-${LLVM_TOOLCHAIN_C_LIBRARY}
+                ${check_target}-${variant}
+                COMMAND "${CMAKE_COMMAND}" --build <BINARY_DIR> --target ${check_target}-${variant}
+                USES_TERMINAL TRUE
+                EXCLUDE_FROM_MAIN TRUE
+                ALWAYS TRUE
+            )
+            ExternalProject_Add_StepTargets(multilib-${LLVM_TOOLCHAIN_C_LIBRARY} ${check_target}-${variant})
+            ExternalProject_Add_StepDependencies(
+                multilib-${LLVM_TOOLCHAIN_C_LIBRARY}
+                ${check_target}-${variant}
+                multilib-${LLVM_TOOLCHAIN_C_LIBRARY}-install
+            )
+            add_custom_target(${check_target}-${variant})
+            add_dependencies(${check_target}-${variant} multilib-${LLVM_TOOLCHAIN_C_LIBRARY}-${check_target}-${variant})
+        endforeach()
+    endforeach()
+endif()
 
 install(
     DIRECTORY ${LLVM_BINARY_DIR}/${TARGET_LIBRARIES_DIR}/.

--- a/arm-multilib/CMakeLists.txt
+++ b/arm-multilib/CMakeLists.txt
@@ -33,6 +33,10 @@ set(C_LIBRARY "picolibc" CACHE STRING "Which C library to use.")
 set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc newlib llvmlibc)
 set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM toolchain build or install root.")
 set(LIBC_HDRGEN "" CACHE PATH "Path to prebuilt lbc-hdrgen if not included in LLVM binaries set by LLVM_BINARY_DIR")
+option(
+    ENABLE_FVP_TESTING
+    "Tests using FVP need to be explictly enabled."
+)
 set(
     FVP_INSTALL_DIR
     "" CACHE STRING
@@ -151,6 +155,34 @@ foreach(lib_idx RANGE ${lib_count_dec})
             )
             set(variant_json_file ${CMAKE_CURRENT_SOURCE_DIR}/json/variants/${variant_json})
 
+            # Read info from the variant specific json.
+            file(READ ${variant_json_file} variant_json_str)
+            string(JSON test_executor GET ${variant_json_str} "args" "common" "TEST_EXECUTOR")
+
+            # FVP testing should default to off, so override any 
+            # settings from the JSON.
+            if(test_executor STREQUAL "fvp" AND NOT ${ENABLE_FVP_TESTING})
+                set(additional_cmake_args "-DENABLE_LIBC_TESTS=OFF" "-DENABLE_COMPILER_RT_TESTS=OFF" "-DENABLE_LIBCXX_TESTS=OFF")
+                set(read_ENABLE_LIBC_TESTS "OFF")
+                set(read_ENABLE_COMPILER_RT_TESTS "OFF")
+                set(read_ENABLE_LIBCXX_TESTS "OFF")
+            else()
+                # From the json, check which tests are enabled.
+                foreach(test_enable_var
+                    ENABLE_LIBC_TESTS
+                    ENABLE_COMPILER_RT_TESTS
+                    ENABLE_LIBCXX_TESTS
+                )
+                    string(JSON read_${test_enable_var} ERROR_VARIABLE json_error GET ${variant_json_str} "args" ${C_LIBRARY} ${test_enable_var})
+                    if(read_${test_enable_var} STREQUAL "json-NOTFOUND")
+                        string(JSON read_${test_enable_var} ERROR_VARIABLE json_error GET ${variant_json_str} "args" "common" ${test_enable_var})
+                        if(read_${test_enable_var} STREQUAL "json-NOTFOUND")
+                            set(read_${test_enable_var} "OFF")
+                        endif()
+                    endif()
+                endforeach()
+            endif()
+
             ExternalProject_Add(
                 runtimes-${variant}
                 PREFIX ${CMAKE_BINARY_DIR}/lib-builds
@@ -160,6 +192,7 @@ foreach(lib_idx RANGE ${lib_count_dec})
                 CMAKE_ARGS
                 ${compiler_launcher_cmake_args}
                 ${passthrough_dirs}
+                ${additional_cmake_args}
                 -DVARIANT_JSON=${variant_json_file}
                 -DC_LIBRARY=${C_LIBRARY}
                 -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
@@ -171,23 +204,6 @@ foreach(lib_idx RANGE ${lib_count_dec})
                 CONFIGURE_HANDLED_BY_BUILD TRUE
                 TEST_EXCLUDE_FROM_MAIN TRUE
             )
-
-            # Read info from the variant specific json.
-            # From the json, check which tests are enabled.
-            file(READ ${variant_json_file} variant_json_str)
-            foreach(test_enable_var
-                ENABLE_LIBC_TESTS
-                ENABLE_COMPILER_RT_TESTS
-                ENABLE_LIBCXX_TESTS
-            )
-                string(JSON read_${test_enable_var} ERROR_VARIABLE json_error GET ${variant_json_str} "args" ${C_LIBRARY} ${test_enable_var})
-                if(read_${test_enable_var} STREQUAL "json-NOTFOUND")
-                    string(JSON read_${test_enable_var} ERROR_VARIABLE json_error GET ${variant_json_str} "args" "common" ${test_enable_var})
-                    if(read_${test_enable_var} STREQUAL "json-NOTFOUND")
-                        set(read_${test_enable_var} "OFF")
-                    endif()
-                endif()
-            endforeach()
             set(check_targets "")
             if(read_ENABLE_LIBC_TESTS)
                 list(APPEND check_targets check-${C_LIBRARY})

--- a/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti.json
+++ b/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti.json
@@ -20,7 +20,7 @@
         "picolibc": {
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },

--- a/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti.json
+++ b/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti.json
@@ -20,7 +20,7 @@
         "picolibc": {
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },

--- a/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti.json
+++ b/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti.json
@@ -20,7 +20,7 @@
         "picolibc": {
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },

--- a/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti.json
+++ b/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti.json
@@ -20,7 +20,7 @@
         "picolibc": {
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },

--- a/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti.json
+++ b/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti.json
@@ -20,7 +20,7 @@
         "picolibc": {
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },

--- a/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti.json
+++ b/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti.json
@@ -20,7 +20,7 @@
         "picolibc": {
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },

--- a/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti.json
+++ b/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti.json
@@ -20,7 +20,7 @@
         "picolibc": {
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },

--- a/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti.json
+++ b/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti.json
@@ -20,7 +20,7 @@
         "picolibc": {
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },

--- a/arm-runtimes/CMakeLists.txt
+++ b/arm-runtimes/CMakeLists.txt
@@ -313,7 +313,7 @@ if(ENABLE_COMPILER_RT_TESTS)
         COMMAND "${CMAKE_COMMAND}" --build <BINARY_DIR> --target check-compiler-rt
         COMMAND ${Python3_EXECUTABLE}
         ${CMAKE_CURRENT_SOURCE_DIR}/test-support/modify-compiler-rt-xml.py
-        --compiler-rt-build-dir <BINARY_DIR>
+        --dir <BINARY_DIR>
         --variant ${VARIANT}
         USES_TERMINAL TRUE
         EXCLUDE_FROM_MAIN TRUE
@@ -431,7 +431,7 @@ if(C_LIBRARY STREQUAL picolibc)
             COMMAND ${MESON_EXECUTABLE} test -C <BINARY_DIR>
             COMMAND ${Python3_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/test-support/modify-picolibc-xml.py
-            --picolibc-build-dir <BINARY_DIR>
+            --dir <BINARY_DIR>
             --variant ${VARIANT}
             USES_TERMINAL TRUE
             EXCLUDE_FROM_MAIN TRUE

--- a/arm-runtimes/CMakeLists.txt
+++ b/arm-runtimes/CMakeLists.txt
@@ -676,10 +676,10 @@ if(ENABLE_CXX_LIBS)
             -DLIBCXX_ENABLE_THREADS=OFF
             -DLIBCXX_ENABLE_WIDE_CHARACTERS=OFF
             -DLIBUNWIND_ENABLE_THREADS=OFF
-            -DLIBCXXABI_ENABLE_EXCEPTIONS=${enable_exceptions}
-            -DLIBCXXABI_ENABLE_STATIC_UNWINDER=${enable_exceptions}
-            -DLIBCXX_ENABLE_EXCEPTIONS=${enable_exceptions}
-            -DLIBCXX_ENABLE_RTTI=${enable_rtti}
+            -DLIBCXXABI_ENABLE_EXCEPTIONS=${ENABLE_EXCEPTIONS}
+            -DLIBCXXABI_ENABLE_STATIC_UNWINDER=${ENABLE_EXCEPTIONS}
+            -DLIBCXX_ENABLE_EXCEPTIONS=${ENABLE_EXCEPTIONS}
+            -DLIBCXX_ENABLE_RTTI=${ENABLE_RTTI}
         )
         if(ENABLE_LIBCXX_TESTS)
             set(cxxlibs_lit_args "${LLVM_LIT_ARGS} --xunit-xml-output=results.junit.xml")


### PR DESCRIPTION
Two scripts arguments were renamed during review, but the cmake steps calling the script weren't updated.

Additionally the our downstream test targets such as check-package-llvm-toolchain target require the path to an external llvm-lit in order to run the tests.