### PR TITLE
CMakeLists.txt: tiny fix to instructions comment.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@
 #   git -C repos clone https://github.com/llvm/llvm-project.git
 #   git -C repos/llvm-project am -k $PWD/patches/llvm-project/*.patch
 #   git -C repos clone https://github.com/picolibc/picolibc.git
-#   git -C repos/picolibc apply $PWD/patches/picolibc/*.patch
+#   git -C repos/picolibc am -k $PWD/patches/picolibc/*.patch
 #   mkdir build
 #   cd build
 #   cmake .. -GNinja -DFETCHCONTENT_SOURCE_DIR_LLVMPROJECT=../repos/llvm-project -DFETCHCONTENT_SOURCE_DIR_PICOLIBC=../repos/picolibc

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -89,7 +89,7 @@ mkdir repos
 git -C repos clone https://github.com/llvm/llvm-project.git
 git -C repos/llvm-project am -k "$PWD"/patches/llvm-project/*.patch
 git -C repos clone https://github.com/picolibc/picolibc.git
-git -C repos/picolibc apply "$PWD"/patches/picolibc/*.patch
+git -C repos/picolibc am -k "$PWD"/patches/picolibc/*.patch
 mkdir build
 cd build
 cmake .. -GNinja -DFETCHCONTENT_SOURCE_DIR_LLVMPROJECT=../repos/llvm-project -DFETCHCONTENT_SOURCE_DIR_PICOLIBC=../repos/picolibc


### PR DESCRIPTION
Now that our downstream picolibc changes are in the form of multiple patches in a subdirectory, it's better to apply them with 'git am' so they turn into separate commits, instead of 'git apply', the same way we do it for llvm-project.