### PR TITLE
Permit FVP tests to return a useful exit status.

### DIFF
--- a/arm-runtimes/test-support/picolibc-test-wrapper.py
+++ b/arm-runtimes/test-support/picolibc-test-wrapper.py
@@ -40,8 +40,6 @@ disabled_tests = [
 ]
 
 disabled_tests_fvp = [
-    # SDDKW-53824: ":semihosting-features" pseudo-file not implemented.
-    "test/semihost/semihost-exit-extended",
     # SDDKW-25808: SYS_SEEK returns wrong value.
     "test/semihost/semihost-seek",
     "test/test-fread-fwrite",

--- a/arm-runtimes/test-support/run_fvp.py
+++ b/arm-runtimes/test-support/run_fvp.py
@@ -67,6 +67,18 @@ def run_fvp(
     if verbose:
         print("running: {}".format(shlex.join(command)))
 
+    # SDDKW-53824: the ":semihosting-features" pseudo-file isn't simulated
+    # by these models. To work around that, we create one ourselves in the
+    # test process's working directory, containing the single feature flag
+    # SH_EXT_EXIT_EXTENDED, meaning that the SYS_EXIT_EXTENDED semihosting
+    # request will work. This permits the test program's exit status to be
+    # propagated to the exit status of the FVP, so that tests returning 77
+    # for "test skipped" can be automatically detected.
+    with open(
+        path.join(working_directory, ":semihosting-features"), "wb"
+    ) as fh:
+        fh.write(b"SHFB\x01")
+
     result = subprocess.run(
         command,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
This allows picolibc tests to mark themselves as "skipped" by returning the special exit code 77. Previously that didn't work in an FVP test run, so those tests are marked as failed rather than skipped.

In particular, test-sprintf-percent-n was affected, because we build picolibc in a mode that doesn't support printf("%n"), and that test knew it and was trying to return "skipped".

Background: Fast Models does support the SYS_EXIT_EXTENDED semihosting request, which allows specifying an exit status. But it doesn't support the ":semihosting-features" pseudo-file that advertises support for non-default semihosting features including that one. So picolibc wrongly believes that SYS_EXIT_EXTENDED doesn't work, and doesn't try it.

This commit works around that lack of support by simply creating a _real_ file called ":semihosting-features" in the directory where the model will run. Then picolibc does find it, and learns from it that it's allowed to SYS_EXIT_EXTENDED.

This makes test-sprintf-percent-n stop failing. It also means we can remove the semihost-exit-extended test from the list of tests specially disabled on FVP runs, because now it works.