### PR TITLE
Fix install directory for FVP crypto plugin.

### DIFF
--- a/arm-runtimes/test-support/run_fvp.py
+++ b/arm-runtimes/test-support/run_fvp.py
@@ -12,22 +12,26 @@ import shlex
 class FVP:
     model_exe: str
     tarmac_plugin: str
+    crypto_plugin: str
     cmdline_param: str
 
 MODELS = {
     "corstone-310": FVP(
         "Corstone-310/models/Linux64_GCC-9.3/FVP_Corstone_SSE-310",
         "Corstone-310/plugins/Linux64_GCC-9.3/TarmacTrace.so",
+        "FastModelsPortfolio_11.27/plugins/Linux64_GCC-9.3/Crypto.so",
         "cpu0.semihosting-cmd_line",
     ),
     "aem-a": FVP(
         "Base_RevC_AEMvA_pkg/models/Linux64_GCC-9.3/FVP_Base_RevC-2xAEMvA",
         "Base_RevC_AEMvA_pkg/plugins/Linux64_GCC-9.3/TarmacTrace.so",
+        "FastModelsPortfolio_11.27/plugins/Linux64_GCC-9.3/Crypto.so",
         "cluster0.cpu0.semihosting-cmd_line",
     ),
     "aem-r": FVP(
         "AEMv8R_base_pkg/models/Linux64_GCC-9.3/FVP_BaseR_AEMv8R",
         "AEMv8R_base_pkg/plugins/Linux64_GCC-9.3/TarmacTrace.so",
+        "FastModelsPortfolio_11.27/plugins/Linux64_GCC-9.3/Crypto.so",
         "cluster0.cpu0.semihosting-cmd_line",
     ),
 }
@@ -56,6 +60,7 @@ def run_fvp(
         command.extend(["--config-file", path.join(fvp_config_dir, config + ".cfg")])
     command.extend(["--application", image])
     command.extend(["--parameter", f"{model.cmdline_param}={shlex.join(arguments)}"])
+    command.extend(["--plugin", path.join(fvp_install_dir, model.crypto_plugin)])
     if tarmac_file is not None:
         command.extend([
             "--plugin",

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -47,11 +47,22 @@ which will prompt you to agree to their licenses. Some of the packages do not
 have installers, instead they place their license file into the
 `fvp/license_terms` directory, which you should read before continuing.
 
+The installer for the cryptography plugin requires a graphical display to run:
+it cannot run in a pure terminal session such as you might start via SSH. Also,
+it will prompt for a directory to install the plugin into. You should enter the
+pathname `fvp/install` relative to the root of your checkout. The installer
+will automatically append a subdirectory `FastModelsPortfolio_11.27` to the end
+of that, and respond with a warning such as 'Directory [...] not found (but in
+patch mode). Continue installation?' Say yes to this prompt, and continue
+clicking 'Next' until installation is complete.
+
 For non-interactive use (for example in CI systems), `get_fvps.sh` can be run
-with the `--non-interactive` option, which causes it to implcitly accept all of
-the EULAs. If you have previously downloaded and installed the FVPs outside of
-the source tree, you can set the `-DFVP_INSTALL_DIR=...` cmake option to set
-the path to them.
+with the `--non-interactive` option, which causes it to implicitly accept all
+of the EULAs and set up the correct install directories.
+
+If you have previously downloaded and installed the FVPs outside of the source
+tree, you can set the `-DFVP_INSTALL_DIR=...` cmake option to set the path to
+them.
 
 If the FVPs are not installed, tests which need them will be skipped, but QEMU
 tests will still be run, and all library variants will still be built.


### PR DESCRIPTION
Before this patch, running get_fvps.sh --non-interactive would make a weirdly named directory in the user's home, with a name like "". or "." (depending on circumstances), with the crypto plugins installed in it.

Now --non-interactive installs the plugins under fvp/install in your git checkout of this repository, which is where they should have been.

The problem was because of this construction in get_fvps.sh:

  INSTALLER_FLAGS_CRYPTO="... --basepath \"$(dirname \"$0\")\""

which has multiple shell errors. Firstly, the \" around $0 are taken literally, so dirname is handed a path beginning with a double quote, which propagates into the path it returns. Secondly, the \" around $(dirname) are also literal, but _not_ reprocessed when $INSTALLER_FLAGS_CRYPTO is expanded on to the installer command line (because quote processing happens before variable expansion). The net effect is to give setup.bin a --basepath directory containing lots of confusing double quotes. For extra confusion, setup.bin appears to change directory to $HOME before interpreting that path, so you don't even get a strangely named directory under the FVP install directory – it appears in your home dir instead.

Since this script already commits to bash rather than plain POSIX sh, the sensible fix for the quoting issues is to use a bash array variable to accumulate the extra arguments, and expand it via "${INSTALLER_FLAGS_CRYPTO[@]}".

Also, the --basepath will need to be absolute rather than relative, to avoid confusion when setup.bin changes directory to $HOME. The easiest approach to _that_ is to use the fact that we were already issuing a `cd $(dirname "$0")` command to change into the fvp directory: do that earlier, and then we can use `$PWD` to retrieve the absolute path.

This fixes --non-interactive. But another problem is that if you run setup.bin interactively, you'll have to enter the pathname by hand, and we don't give the user any guidance on what path to enter. So I've also updated the docs to explain the interactive installation more fully.

This is all very error-prone, so I've also extended run_fvp.py so that it actually finds and loads the crypto plugin. That way, if it hasn't been installed in the right place, we find that out early, and can figure out what went wrong.

(Finally, in this commit, I've also fixed a spelling error in one of the script's internal variables: CORSTONE, not CORSONE.)