### PR TITLE
Rename the variant name  from strictly_aligned to strictalign.

### DIFF
--- a/arm-multilib/json/multilib.json
+++ b/arm-multilib/json/multilib.json
@@ -71,13 +71,13 @@
             "flags": "--target=armv7-unknown-none-eabi -mfpu=none -fno-exceptions -fno-rtti"
         },
         {
-            "variant": "armv7a_soft_nofp_strictly_aligned_exn_rtti",
-            "json": "armv7a_soft_nofp_strictly_aligned_exn_rtti.json",
+            "variant": "armv7a_soft_nofp_strictalign_exn_rtti",
+            "json": "armv7a_soft_nofp_strictalign_exn_rtti.json",
             "flags": "--target=armv7-unknown-none-eabi -mfpu=none -mno-unaligned-access"
         },
         {
-            "variant": "armv7a_soft_nofp_strictly_aligned",
-            "json": "armv7a_soft_nofp_strictly_aligned.json",
+            "variant": "armv7a_soft_nofp_strictalign",
+            "json": "armv7a_soft_nofp_strictalign.json",
             "flags": "--target=armv7-unknown-none-eabi -mfpu=none -mno-unaligned-access -fno-exceptions -fno-rtti"
         },
         {

--- a/arm-multilib/json/variants/armv7a_soft_nofp_strictalign.json
+++ b/arm-multilib/json/variants/armv7a_soft_nofp_strictalign.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7a",
-            "VARIANT": "armv7a_soft_nofp_strictly_aligned",
+            "VARIANT": "armv7a_soft_nofp_strictalign",
             "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv7a -mfpu=none -mno-unaligned-access",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",

--- a/arm-multilib/json/variants/armv7a_soft_nofp_strictalign_exn_rtti.json
+++ b/arm-multilib/json/variants/armv7a_soft_nofp_strictalign_exn_rtti.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7a",
-            "VARIANT": "armv7a_soft_nofp_strictly_aligned_exn_rtti",
+            "VARIANT": "armv7a_soft_nofp_strictalign_exn_rtti",
             "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv7a -mfpu=none -mno-unaligned-access",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",


### PR DESCRIPTION
This is to match with the corresponding aarch64 variant for -mno-unaligned-access.