### PR TITLE
Fixes to patch application.

### DIFF
--- a/arm-multilib/CMakeLists.txt
+++ b/arm-multilib/CMakeLists.txt
@@ -68,6 +68,8 @@ foreach(arg
     endif()
 endforeach()
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter) # needed by fetch_*.cmake
+
 include(ExternalProject)
 include(${TOOLCHAIN_SOURCE_DIR}/cmake/fetch_llvm.cmake)
 list(APPEND passthrough_dirs "-DFETCHCONTENT_SOURCE_DIR_LLVMPROJECT=${FETCHCONTENT_SOURCE_DIR_LLVMPROJECT}")

--- a/arm-runtimes/CMakeLists.txt
+++ b/arm-runtimes/CMakeLists.txt
@@ -101,10 +101,10 @@ set(LIBC_HDRGEN "" CACHE PATH "Path to prebuilt lbc-hdrgen if not included in LL
 # Temporary location to collect the libraries as they are built.
 set(TEMP_LIB_DIR "${CMAKE_CURRENT_BINARY_DIR}/tmp_install")
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
 include(ExternalProject)
 include(${TOOLCHAIN_SOURCE_DIR}/cmake/fetch_llvm.cmake)
-
-find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 # If a compiler launcher such as ccache has been set, it should be
 # passed down to each subproject build.

--- a/cmake/fetch_picolibc.cmake
+++ b/cmake/fetch_picolibc.cmake
@@ -13,8 +13,8 @@ read_repo_version(picolibc picolibc)
 
 set(
     picolibc_patches
-    ${CMAKE_CURRENT_SOURCE_DIR}/patches/picolibc/0001-Enable-libcxx-builds.patch
-    ${CMAKE_CURRENT_SOURCE_DIR}/patches/picolibc/0002-Add-bootcode-for-AArch64-FVPs.patch
+    ${CMAKE_CURRENT_LIST_DIR}/../patches/picolibc/0001-Enable-libcxx-builds.patch
+    ${CMAKE_CURRENT_LIST_DIR}/../patches/picolibc/0002-Add-bootcode-for-AArch64-FVPs.patch
 )
 
 FetchContent_Declare(picolibc


### PR DESCRIPTION
Every `CMakeLists.txt` that includes `fetch_llvm.cmake` must also call `find_package(Python3)`, because `fetch_llvm.cmake` tries to run `patch_llvm.py` by prefixing it with the Python interpreter name. The CMakeLists in `arm-multilib` wasn't looking for Python at all, and the one in `arm-runtimes` was looking for it _after_ including `fetch_llvm.cmake`.

Also, `fetch_picolibc.cmake` was not reliably looking in the correct directory for its patches: it was using a path relative to `CMAKE_CURRENT_SOURCE_DIR`, which varies depending which CMakeLists it's invoked by. It should be relative to `CMAKE_CURRENT_LIST_DIR`, as the corresponding llvm and newlib paths already are.