### PR TITLE
Set FETCHCONTENT_SOURCE_DIR so that repos are only checked out once

### DIFF
--- a/cmake/fetch_llvm.cmake
+++ b/cmake/fetch_llvm.cmake
@@ -31,3 +31,4 @@ FetchContent_Declare(llvmproject
     SOURCE_SUBDIR do_not_add_llvm_subdir_yet
 )
 FetchContent_MakeAvailable(llvmproject)
+FetchContent_GetProperties(llvmproject SOURCE_DIR FETCHCONTENT_SOURCE_DIR_LLVMPROJECT)

--- a/cmake/fetch_newlib.cmake
+++ b/cmake/fetch_newlib.cmake
@@ -23,3 +23,4 @@ FetchContent_Declare(newlib
     SOURCE_SUBDIR do_not_add_newlib_subdir
 )
 FetchContent_MakeAvailable(newlib)
+FetchContent_GetProperties(newlib SOURCE_DIR FETCHCONTENT_SOURCE_DIR_NEWLIB)

--- a/cmake/fetch_picolibc.cmake
+++ b/cmake/fetch_picolibc.cmake
@@ -29,3 +29,4 @@ FetchContent_Declare(picolibc
     SOURCE_SUBDIR do_not_add_picolibc_subdir
 )
 FetchContent_MakeAvailable(picolibc)
+FetchContent_GetProperties(picolibc SOURCE_DIR FETCHCONTENT_SOURCE_DIR_PICOLIBC)


### PR DESCRIPTION
The cmake scripts to fetch content such as llvm-project and picolibc can be called by both the top-level project as well as the sub-projects. To prevent the content being checked out and patched repeatedly, the `FETCHCONTENT_SOURCE_DIR_<PROJECT>` variables should be defined as these will override the declared source on any subsequent calls.

These variables are already passed down from top-level to sub-project, however the variables themselves are never defined unless configured by a user. This patch addresses this by setting the variables inside the fetch scripts as soon as the fetch content is declared.