### PR TITLE
Document option to enable FVP testing

### DIFF
--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -64,8 +64,10 @@ If you have previously downloaded and installed the FVPs outside of the source
 tree, you can set the `-DFVP_INSTALL_DIR=...` cmake option to set the path to
 them.
 
-If the FVPs are not installed, tests which need them will be skipped, but QEMU
-tests will still be run, and all library variants will still be built.
+Testing with FVPs is disabled by default, but QEMU tests will still be run, and
+all library variants will still be built. Testing with FVPs can be enabled by
+setting the `-DENABLE_FVP_TESTING=ON` CMake option if you have installed the
+models as described above.
 
 ## Customizing
 


### PR DESCRIPTION
Previously FVP testing was enabled or disabled implicitly based on whether an FVP install could be found. This has since been changed to a specific CMake option, however the documentation fails to mention this. The build instructions have now been updated with the new CMake option.