### PR TITLE
When QEMU testing is enabled, QEMU should be required

### DIFF
--- a/arm-runtimes/CMakeLists.txt
+++ b/arm-runtimes/CMakeLists.txt
@@ -157,9 +157,9 @@ if(ENABLE_LIBC_TESTS OR ENABLE_COMPILER_RT_TESTS OR ENABLE_LIBCXX_TESTS)
 
     if(TEST_EXECUTOR STREQUAL qemu)
         if(TARGET_ARCH MATCHES "^aarch64")
-            find_program(QEMU_EXECUTABLE qemu-system-aarch64)
+            find_program(QEMU_EXECUTABLE qemu-system-aarch64 REQUIRED)
         else()
-            find_program(QEMU_EXECUTABLE qemu-system-arm)
+            find_program(QEMU_EXECUTABLE qemu-system-arm REQUIRED)
         endif()
 
         # Use colon as a separator because comma and semicolon are used for


### PR DESCRIPTION
Since QEMU is needed to run tests with QEMU, if the program cannot be found the build should stop and an error generated.