### PR TITLE
Add an option to disable QEMU testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,12 +152,12 @@ option(
 )
 option(
     ENABLE_QEMU_TESTING
-    "Tests using QEMU are enabled by default, but can be disabled."
+    "Enable tests that use QEMU. This option is ON by default."
     ON
 )
 option(
     ENABLE_FVP_TESTING
-    "Tests using FVP need to be explictly enabled."
+    "Enable tests that use FVPs. This option is OFF by default."
 )
 set(
     FVP_INSTALL_DIR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,11 @@ option(
     llvm-project to improve performance."
 )
 option(
+    ENABLE_QEMU_TESTING
+    "Tests using QEMU are enabled by default, but can be disabled."
+    ON
+)
+option(
     ENABLE_FVP_TESTING
     "Tests using FVP need to be explictly enabled."
 )
@@ -596,6 +601,7 @@ if(NOT PREBUILT_TARGET_LIBRARIES)
         -DENABLE_VARIANTS=${ENABLE_VARIANTS_PASSTHROUGH}
         -DLIBC_HDRGEN=${LIBC_HDRGEN}
         -DFVP_INSTALL_DIR=${FVP_INSTALL_DIR}
+        -DENABLE_QEMU_TESTING=${ENABLE_QEMU_TESTING}
         -DENABLE_FVP_TESTING=${ENABLE_FVP_TESTING}
         -DFVP_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/fvp/config
         -DFETCHCONTENT_SOURCE_DIR_LLVMPROJECT=${FETCHCONTENT_SOURCE_DIR_LLVMPROJECT}

--- a/arm-multilib/CMakeLists.txt
+++ b/arm-multilib/CMakeLists.txt
@@ -34,6 +34,11 @@ set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc newlib llvmlibc)
 set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM toolchain build or install root.")
 set(LIBC_HDRGEN "" CACHE PATH "Path to prebuilt lbc-hdrgen if not included in LLVM binaries set by LLVM_BINARY_DIR")
 option(
+    ENABLE_QEMU_TESTING
+    "Tests using QEMU are enabled by default, but can be disabled."
+    ON
+)
+option(
     ENABLE_FVP_TESTING
     "Tests using FVP need to be explictly enabled."
 )
@@ -164,7 +169,7 @@ foreach(lib_idx RANGE ${lib_count_dec})
 
             # FVP testing should default to off, so override any 
             # settings from the JSON.
-            if(test_executor STREQUAL "fvp" AND NOT ${ENABLE_FVP_TESTING})
+            if((test_executor STREQUAL "qemu" AND NOT ${ENABLE_QEMU_TESTING}) OR (test_executor STREQUAL "fvp" AND NOT ${ENABLE_FVP_TESTING}))
                 list(APPEND additional_cmake_args "-DENABLE_LIBC_TESTS=OFF" "-DENABLE_COMPILER_RT_TESTS=OFF" "-DENABLE_LIBCXX_TESTS=OFF")
                 set(read_ENABLE_LIBC_TESTS "OFF")
                 set(read_ENABLE_COMPILER_RT_TESTS "OFF")

--- a/arm-multilib/CMakeLists.txt
+++ b/arm-multilib/CMakeLists.txt
@@ -35,12 +35,12 @@ set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM toolchain build or install root.
 set(LIBC_HDRGEN "" CACHE PATH "Path to prebuilt lbc-hdrgen if not included in LLVM binaries set by LLVM_BINARY_DIR")
 option(
     ENABLE_QEMU_TESTING
-    "Tests using QEMU are enabled by default, but can be disabled."
+    "Enable tests that use QEMU. This option is ON by default."
     ON
 )
 option(
     ENABLE_FVP_TESTING
-    "Tests using FVP need to be explictly enabled."
+    "Enable tests that use FVPs. This option is OFF by default."
 )
 set(
     FVP_INSTALL_DIR
@@ -167,8 +167,8 @@ foreach(lib_idx RANGE ${lib_count_dec})
             file(READ ${variant_json_file} variant_json_str)
             string(JSON test_executor GET ${variant_json_str} "args" "common" "TEST_EXECUTOR")
 
-            # FVP testing should default to off, so override any 
-            # settings from the JSON.
+            # The multilib project can be configured to disable QEMU and/or FVP
+            # testing, which will need to override the settings from the json.
             if((test_executor STREQUAL "qemu" AND NOT ${ENABLE_QEMU_TESTING}) OR (test_executor STREQUAL "fvp" AND NOT ${ENABLE_FVP_TESTING}))
                 list(APPEND additional_cmake_args "-DENABLE_LIBC_TESTS=OFF" "-DENABLE_COMPILER_RT_TESTS=OFF" "-DENABLE_LIBCXX_TESTS=OFF")
                 set(read_ENABLE_LIBC_TESTS "OFF")

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -36,6 +36,10 @@ $ brew install llvm python3 git make ninja qemu cmake
 $ pip install meson
 ```
 
+Testing with QEMU is enabled by default, but can be disabled using the 
+`-DENABLE_QEMU_TESTING=OFF` CMake option if testing is not required or QEMU is
+not installed.
+
 Some recent targets are not supported by QEMU, for these the Arm FVP models are
 used instead. These models are available free-of-change but are not
 open-source, and come with their own licenses.


### PR DESCRIPTION
Testing with QEMU is implicitly enabled by default, but configuring the project to run with tests requires QEMU. As testing with QEMU is considered optional, it should be possible to disable tests when QEMU is not available or testing is not needed.

Since there is already an option for controlling FVP testing, this patch adds a similar option for QEMU, ENABLE_QEMU_TESTING, which instead defaults to ON. This can then be turned off when QEMU is not installed, so that configurations where QEMU is expected can suitably detect and show an error when it is missing.