### PR TITLE
Add aarch64a_soft_nofp variant

### DIFF
--- a/arm-multilib/json/multilib.json
+++ b/arm-multilib/json/multilib.json
@@ -31,6 +31,11 @@
             "flags": "--target=aarch64-unknown-none-elf -mno-unaligned-access -fno-exceptions -fno-rtti"
         },
         {
+            "variant": "aarch64a_soft_nofp",
+            "json": "aarch64a_soft_nofp.json",
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8-a+nofp+nosimd -mabi=aapcs-soft"
+        },
+        {
             "variant": "armv4t_exn_rtti",
             "json": "armv4t_exn_rtti.json",
             "flags": "--target=armv4t-unknown-none-eabi -mfpu=none"

--- a/arm-multilib/json/variants/aarch64a_soft_nofp.json
+++ b/arm-multilib/json/variants/aarch64a_soft_nofp.json
@@ -1,0 +1,40 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "aarch64a",
+            "VARIANT": "aarch64a_soft_nofp",
+            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "cortex-a57",
+            "BOOT_FLASH_ADDRESS": "0x40000000",
+            "BOOT_FLASH_SIZE": "0x1000",
+            "FLASH_ADDRESS": "0x40001000",
+            "FLASH_SIZE": "0xfff000",
+            "RAM_ADDRESS": "0x41000000",
+            "RAM_SIZE": "0x1000000",
+            "STACK_SIZE": "8K"
+        },
+        "picolibc": {
+            "PICOLIBC_BUILD_TYPE": "release",
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "newlib": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "llvmlibc": {
+            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}


### PR DESCRIPTION
Build a soft float multilib variant for aarch64 supporting targets without an FPU.

Authored by Keith Packard and Victor Campos.