### PR TITLE
Fix build failures in aarch64a_[be_]soft_nofp variants.

### DIFF
--- a/arm-multilib/json/variants/aarch64a_be_soft_nofp.json
+++ b/arm-multilib/json/variants/aarch64a_be_soft_nofp.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_be_soft_nofp",
-            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access -fno-exceptions -fno-rtti",
+            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-multilib/json/variants/aarch64a_soft_nofp.json
+++ b/arm-multilib/json/variants/aarch64a_soft_nofp.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_soft_nofp",
-            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access -fno-exceptions -fno-rtti",
+            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",


### PR DESCRIPTION
Those two variants have `-fno-exceptions -fno-rtti` in the configuration file that specifies options for building the library. None of the other library variants is built with this flags, not even the other variants intended for use in _applications_ without exceptions and RTTI.

If you try to build libc++abi with those flags, it fails to build, because `private_typeinfo.cpp` is unconditionally included in the library and unconditionally uses `dynamic_cast`.

(And I assume that it's OK to use `dynamic_cast` in that part of libc++abi if the application will never use RTTI, because then it won't include that object file in the first place.)