### PR TITLE
Do not build AArch64a soft no_fp variants using llvm-libc

### DIFF
--- a/arm-multilib/CMakeLists.txt
+++ b/arm-multilib/CMakeLists.txt
@@ -143,6 +143,15 @@ foreach(lib_idx RANGE ${lib_count_dec})
     string(JSON variant GET ${lib_def} "variant")
     set(additional_cmake_args "")
 
+    # If a variant doesn't support all possible C library
+    # options, check if it should be skipped.
+    string(JSON variant_support ERROR_VARIABLE json_error GET ${lib_def} "libraries_supported")
+    if(NOT variant_support STREQUAL "libraries_supported-NOTFOUND")
+        if(NOT C_LIBRARY IN_LIST variant_support)
+            continue()
+        endif()
+    endif()
+
     if(variant IN_LIST ENABLE_VARIANTS OR ENABLE_VARIANTS STREQUAL "all")
         string(JSON variant_multilib_flags GET ${lib_def} "flags")
         # Placeholder libraries won't have a json, so store the error in

--- a/arm-multilib/json/multilib.json
+++ b/arm-multilib/json/multilib.json
@@ -33,22 +33,26 @@
         {
             "variant": "aarch64a_soft_nofp",
             "json": "aarch64a_soft_nofp.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8-a+nofp+nosimd -mabi=aapcs-soft -fno-exceptions -fno-rtti"
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8-a+nofp+nosimd -mabi=aapcs-soft -fno-exceptions -fno-rtti",
+            "libraries_supported": "picolibc,newlib"
         },
         {
             "variant": "aarch64a_be_soft_nofp",
             "json": "aarch64a_be_soft_nofp.json",
-            "flags": "--target=aarch64_be-unknown-none-elf -march=armv8-a+nofp+nosimd -mabi=aapcs-soft -fno-exceptions -fno-rtti"
+            "flags": "--target=aarch64_be-unknown-none-elf -march=armv8-a+nofp+nosimd -mabi=aapcs-soft -fno-exceptions -fno-rtti",
+            "libraries_supported": "picolibc,newlib"
         },
         {
             "variant": "aarch64a_soft_nofp_exn_rtti",
             "json": "aarch64a_soft_nofp_exn_rtti.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8-a+nofp+nosimd -mabi=aapcs-soft"
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8-a+nofp+nosimd -mabi=aapcs-soft",
+            "libraries_supported": "picolibc,newlib"
         },
         {
             "variant": "aarch64a_be_soft_nofp_exn_rtti",
             "json": "aarch64a_be_soft_nofp_exn_rtti.json",
-            "flags": "--target=aarch64_be-unknown-none-elf -march=armv8-a+nofp+nosimd -mabi=aapcs-soft"
+            "flags": "--target=aarch64_be-unknown-none-elf -march=armv8-a+nofp+nosimd -mabi=aapcs-soft",
+            "libraries_supported": "picolibc,newlib"
         },
 
         {


### PR DESCRIPTION
LLVM-libc does not currently support no-neon soft float on AArch64 targets. To prevent building these until support is available, this patch adds an option to explicitly set which C libraries a variant can be built with. If the option is absent, the default is to build with all library options.