### PR TITLE
Fix multilib flags of AArch64 soft nofp

### DIFF
--- a/arm-multilib/json/multilib.json
+++ b/arm-multilib/json/multilib.json
@@ -33,25 +33,25 @@
         {
             "variant": "aarch64a_soft_nofp_exn_rtti",
             "json": "aarch64a_soft_nofp_exn_rtti.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8-a+nofp+nosimd -mabi=aapcs-soft",
+            "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft",
             "libraries_supported": "picolibc,newlib"
         },
         {
             "variant": "aarch64a_soft_nofp",
             "json": "aarch64a_soft_nofp.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8-a+nofp+nosimd -mabi=aapcs-soft -fno-exceptions -fno-rtti",
+            "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft -fno-exceptions -fno-rtti",
             "libraries_supported": "picolibc,newlib"
         },
         {
             "variant": "aarch64a_be_soft_nofp_exn_rtti",
             "json": "aarch64a_be_soft_nofp_exn_rtti.json",
-            "flags": "--target=aarch64_be-unknown-none-elf -march=armv8-a+nofp+nosimd -mabi=aapcs-soft",
+            "flags": "--target=aarch64_be-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft",
             "libraries_supported": "picolibc,newlib"
         },
         {
             "variant": "aarch64a_be_soft_nofp",
             "json": "aarch64a_be_soft_nofp.json",
-            "flags": "--target=aarch64_be-unknown-none-elf -march=armv8-a+nofp+nosimd -mabi=aapcs-soft -fno-exceptions -fno-rtti",
+            "flags": "--target=aarch64_be-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft -fno-exceptions -fno-rtti",
             "libraries_supported": "picolibc,newlib"
         },
         {


### PR DESCRIPTION
This patch fixes the multilib flags required to select the AArch64 soft nofp variants.

The `+nofp` and `+nosimd` arch extensions are specified in the `-march` or `-mcpu` command line options. Before this patch, the multilib flags specified this part as `-march=armv8-a+nofp+nosimd`, however this does not work for any architecture greater than v8, including point releases, nor does it for any `-mcpu` value whose underlying architecture is greater than v8. In the formed case because any point release would lead to a regular expression mismatch; and in the latter, `-mcpu` option processing introduces extra architecture extensions in the string.

Hence the correct way is to match agains `-march=armvX+nofp` and `-march=armvX+nosimd`. These two multilib flags are inserted by our implementation of `multilib.yaml` when `+nofp` and `+nosimd` are present anywhere in the `-march=` or `-mcpu=` values, respectively.