### PR TITLE
Add a temporary workaround for 597

### DIFF
--- a/patches/llvm-project/0008-library-order-workaround-for-597.patch
+++ b/patches/llvm-project/0008-library-order-workaround-for-597.patch
@@ -1,0 +1,15 @@
+diff --git a/clang/lib/Driver/ToolChains/BareMetal.cpp b/clang/lib/Driver/ToolChains/BareMetal.cpp
+index eecaaa9a4293..7d07079b5dd4 100644
+--- a/clang/lib/Driver/ToolChains/BareMetal.cpp
++++ b/clang/lib/Driver/ToolChains/BareMetal.cpp
+@@ -491,9 +491,8 @@ void baremetal::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+   }
+ 
+   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs)) {
+-    AddRunTimeLibs(TC, D, CmdArgs, Args);
+-
+     CmdArgs.push_back("-lc");
++    AddRunTimeLibs(TC, D, CmdArgs, Args);
+   }
+ 
+   if (D.isUsingLTO()) {


### PR DESCRIPTION
This adds a patch file that reverts the order of libraries added on the command line to previously working one to avoid error about duplicate __aeabi_mem* symbols.

This patch will be removed, once we implement a proper permanent solution in llvm-project.