### PR TITLE
Turn AArch64 big endian variants into strictly aligned

### DIFF
--- a/arm-multilib/json/variants/aarch64a_be.json
+++ b/arm-multilib/json/variants/aarch64a_be.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_be",
-            "COMPILE_FLAGS": "-march=armv8-a -mbig-endian",
+            "COMPILE_FLAGS": "-march=armv8-a -mbig-endian -mno-unaligned-access",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-multilib/json/variants/aarch64a_be_exn_rtti.json
+++ b/arm-multilib/json/variants/aarch64a_be_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_be_exn_rtti",
-            "COMPILE_FLAGS": "-march=armv8-a -mbig-endian",
+            "COMPILE_FLAGS": "-march=armv8-a -mbig-endian -mno-unaligned-access",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",


### PR DESCRIPTION
We've decided to have just two variants here: one with and one without RTTI and exceptions. We will not have variants across the strict aligment dimension. And since a strictly aligned variant is more compatible than one that's not, this change is made.