### PR TITLE
Reinstate armv4t and armv5te compiler_rt and libcxx tests

### DIFF
--- a/arm-multilib/json/variants/armv4t.json
+++ b/arm-multilib/json/variants/armv4t.json
@@ -21,9 +21,9 @@
         "picolibc": {
             "PICOLIBC_BUILD_TYPE": "minsize",
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
+            "ENABLE_LIBCXX_TESTS": "ON"
         },
         "newlib": {
             "ENABLE_CXX_LIBS": "ON",

--- a/arm-multilib/json/variants/armv5te.json
+++ b/arm-multilib/json/variants/armv5te.json
@@ -21,9 +21,9 @@
         "picolibc": {
             "PICOLIBC_BUILD_TYPE": "minsize",
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
+            "ENABLE_LIBCXX_TESTS": "ON"
         },
         "newlib": {
             "ENABLE_CXX_LIBS": "ON",


### PR DESCRIPTION
Pull request #109628 automatically turned on frame pointers for leaf functions in Clang when frame pointers are enabled. This triggered a latent bug in picolibc for armv4t and armv5te, which consequentially broke our tests for them.

There is currently a pull request that fixes this bug (https://github.com/picolibc/picolibc/pull/897), but we don't have to wait for this to merge to reinstate the tests, because we recently changed the behaviour of Clang to by default omit frame pointers altogether (https://github.com/llvm/llvm-project/pull/117140), and that is how picolibc is built now. In general the advice is that you shouldn't build AArch32 targets with frame pointers enabled for various reasons.