### PR TITLE
Add tests for AArch64 A-profile big endian library selection

### DIFF
--- a/test/multilib/aarch64.test
+++ b/test/multilib/aarch64.test
@@ -11,11 +11,50 @@
 
 # AARCH64-EXNRTTI: aarch64-none-elf/aarch64a_exn_rtti{{$}}
 # AARCH64-EXNRTTI-EMPTY:
-#
+
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -fno-exceptions -fno-rtti | FileCheck %s --check-prefix=AARCH64
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5-a+nodotprod -fno-exceptions -fno-rtti | FileCheck %s --check-prefix=AARCH64
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv9.5-a+sve2+sme2 -fno-exceptions -fno-rtti | FileCheck %s --check-prefix=AARCH64
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a57+fp16 -fno-exceptions -fno-rtti | FileCheck %s --check-prefix=AARCH64
-#
+
 # AARCH64: aarch64-none-elf/aarch64a{{$}}
 # AARCH64-EMPTY:
+
+
+# Big endian
+
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -march=armv8-a | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -march=armv8-a+fp16 | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -march=armv8.1-a | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -march=armv8.5-a+nodotprod | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -march=armv8.9-a | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -march=armv9.5-a | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -march=armv9.5-a+sve2+sme2 | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -mcpu=cortex-a57 | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -mcpu=cortex-a57+fp16 | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -mno-unaligned-access | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -march=armv8-a -mno-unaligned-access | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -march=armv8-a+fp16 -mno-unaligned-access | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -march=armv8.1-a -mno-unaligned-access | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -march=armv8.5-a+nodotprod -mno-unaligned-access | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -march=armv8.9-a -mno-unaligned-access | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -march=armv9.5-a -mno-unaligned-access | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -march=armv9.5-a+sve2+sme2 -mno-unaligned-access | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -mcpu=cortex-a57 -mno-unaligned-access | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -mcpu=cortex-a57+fp16 -mno-unaligned-access | FileCheck %s --check-prefix=AARCH64-BE-EXNRTTI
+
+# AARCH64-BE-EXNRTTI: aarch64-none-elf/aarch64a_be_exn_rtti{{$}}
+# AARCH64-BE-EXNRTTI-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -fno-exceptions -fno-rtti | FileCheck %s --check-prefix=AARCH64-BE
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -march=armv8.5-a+nodotprod -fno-exceptions -fno-rtti | FileCheck %s --check-prefix=AARCH64-BE
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -march=armv9.5-a+sve2+sme2 -fno-exceptions -fno-rtti | FileCheck %s --check-prefix=AARCH64-BE
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -mcpu=cortex-a57+fp16 -fno-exceptions -fno-rtti | FileCheck %s --check-prefix=AARCH64-BE
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck %s --check-prefix=AARCH64-BE
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -march=armv8.5-a+nodotprod -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck %s --check-prefix=AARCH64-BE
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -march=armv9.5-a+sve2+sme2 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck %s --check-prefix=AARCH64-BE
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mbig-endian -mcpu=cortex-a57+fp16 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck %s --check-prefix=AARCH64-BE
+
+# AARCH64-BE: aarch64-none-elf/aarch64a_be{{$}}
+# AARCH64-BE-EMPTY:


### PR DESCRIPTION
The tests check if the same variant is chosen with or without `-mno-unaligned-access`. For AArch64 A-profile big endian we provide only strictly aligned libraries.