### PR TITLE
Extend OmaxLTO options

### DIFF
--- a/OmaxLTO.cfg
+++ b/OmaxLTO.cfg
@@ -1,5 +1,12 @@
 -flto=full \
+-fuse-linker-plugin \
 -fvirtual-function-elimination \
 -fwhole-program-vtables \
--Wl,-plugin-opt=-extra-LTO-loop-unroll=true
+-Wl,-plugin-opt=-extra-LTO-loop-unroll=true \
+-Wl,-plugin-opt=-inline-threshold=500 \
+-Wl,-plugin-opt=-unroll-threshold=450 \
+-Wl,-plugin-opt=-unroll-partial-threshold=450 \
+-Wl,-plugin-opt=-unroll-max-iteration-count-to-analyze=20 \
+-Wl,-plugin-opt=-lsr-complexity-limit=1073741823 \
+-Wl,-plugin-opt=-force-attribute=main:norecurse \
 


### PR DESCRIPTION
This patch modifies extends OmaxLTO to make use of extra optimisation flags which affect LTO.
