### PR TITLE
Undefine the macro _HAVE_INIT_FINI which is defined in newlib.

### DIFF
--- a/arm-runtimes/CMakeLists.txt
+++ b/arm-runtimes/CMakeLists.txt
@@ -468,8 +468,8 @@ if(C_LIBRARY STREQUAL newlib)
         "RANLIB_FOR_TARGET=${LLVM_BINARY_DIR}/bin/llvm-ranlib"
         "READELF_FOR_TARGET=${LLVM_BINARY_DIR}/bin/llvm-readelf"
         "STRIP_FOR_TARGET=${LLVM_BINARY_DIR}/bin/llvm-strip"
-        "CFLAGS_FOR_TARGET=${flags} -Wno-error=implicit-function-declaration -D__USES_INITFINI__ -UHAVE_INIT_FINI__ -U_HAVE_INIT_FINI__ -UHAVE_INIT_FINI --sysroot ${TEMP_LIB_DIR}"
-        "CCASFLAGS=${flags} -Wno-error=implicit-function-declaration -D__USES_INITFINI__ -UHAVE_INIT_FINI__ -U_HAVE_INIT_FINI__ -UHAVE_INIT_FINI --sysroot ${TEMP_LIB_DIR}"
+        "CFLAGS_FOR_TARGET=${flags} -Wno-error=implicit-function-declaration -D__USES_INITFINI__ -U_HAVE_INIT_FINI --sysroot ${TEMP_LIB_DIR}"
+        "CCASFLAGS=${flags} -Wno-error=implicit-function-declaration -D__USES_INITFINI__ -U_HAVE_INIT_FINI --sysroot ${TEMP_LIB_DIR}"
     )
 
     include(ProcessorCount)


### PR DESCRIPTION
Newlib overlay package has calls to init and fini. When building newlib, referencing of _init and _fini has been suppressed by undefining the corresponding macro HAVE_INIT_FINI  and relys on the more modern .init_array and .fini_array. But the name of this macro in newlib has changed from HAVE_INIT_FINI to _HAVE_INIT_FINI, so undefine this macro in the cmake file..