### PR TITLE
Fix issues with lit-exec-fvp.py

### DIFF
--- a/arm-runtimes/test-support/lit-exec-fvp.py
+++ b/arm-runtimes/test-support/lit-exec-fvp.py
@@ -26,7 +26,7 @@ def main():
         help="Directory containing FVP config files",
         required=True,
     )
-    main_arg_group.add_argument(
+    parser.add_argument(
         "--fvp-model",
         help="model name for FVP",
         required=True,


### PR DESCRIPTION
This patch gives execution permissions to this Python script and fixes one wrong variable name.

Since this script is used as an executable in our lit tests, it ought to have execution rights.