### PR TITLE
llvm-libc build: fix build failure with C++ libs disabled

### DIFF
--- a/arm-runtimes/CMakeLists.txt
+++ b/arm-runtimes/CMakeLists.txt
@@ -771,6 +771,14 @@ if(ENABLE_CXX_LIBS)
         endforeach()
     endif()
 
+else() # if not ENABLE_CXX_LIBS
+
+    # The parent arm-multilib cmake script will still want to invoke
+    # build targets like 'cxxlibs-configure', whether we actually have
+    # C++ libraries or not. So we should define them, even if they
+    # don't do anything.
+    add_custom_target(cxxlibs-configure)
+    add_custom_target(cxxlibs-build)
 endif()
 
 install(


### PR DESCRIPTION
Testing the llvm-libc build after the previous commit, I found that the arm-multilib cmake script unconditionally tries to invoke build targets like `cxxlibs-configure` or `cxxlibs-build` in the individual library variant builds. Those targets don't exist in an llvm-libc build, because those set `"ENABLE_CXX_LIBS": "OFF"` in their per-variant JSON files.

This commit applies the simplest possible fix: _make_ targets of those names in `arm-runtimes`, even if nothing is actually in them. Then invoking them from the higher-level build script is a NOP instead of a failure.