### PR TITLE
Pin picolibc to specific known to work commit

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -12,8 +12,8 @@
       "tag": "main"
     },
     "picolibc": {
-      "tagType": "branch",
-      "tag": "main"
+      "tagType": "commithash",
+      "tag": "be1b69f5f5910d216c16f9fca927c1bdb4d38a51"
     },
     "newlib": {
       "tagType": "tag",


### PR DESCRIPTION
As this repo is getting depreciated, pinning picolibc to a specific commit, as we don't want to keep fixing merge conflicts and other unforeseen issues.